### PR TITLE
[FEAT] 아이디 비밀번호 찾기 페이지 UI/API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.cursorrules
+.cursor/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@
 # testing
 /coverage
 
+# playwright
+/playwright-report/
+/test-results/
+.cache/
+
 # next.js
 /.next/
 /out/

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "zustand": "^5.0.9"
       },
       "devDependencies": {
+        "@playwright/test": "^1.57.0",
         "@tailwindcss/postcss": "^4",
         "@tanstack/react-query-devtools": "^5.91.1",
         "@types/node": "^20",
@@ -2580,6 +2581,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -5628,6 +5645,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -7422,6 +7454,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev --webpack",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui"
   },
   "dependencies": {
     "@svgr/webpack": "^8.1.0",
@@ -20,6 +23,7 @@
     "zustand": "^5.0.9"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@tailwindcss/postcss": "^4",
     "@tanstack/react-query-devtools": "^5.91.1",
     "@types/node": "^20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,71 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/src/apis/auth/findId.ts
+++ b/src/apis/auth/findId.ts
@@ -1,0 +1,28 @@
+import { axiosInstance } from '@/src/apis/axios';
+import type {
+  ApiResponse,
+  SendFindIdCodeRequest,
+  SendFindIdCodeResponse,
+  VerifyEmailCodeRequest,
+  VerifyEmailCodeResponse,
+  FindIdRequest,
+  FindIdResponse,
+} from '@/src/types';
+
+// 아이디 찾기 - 인증번호 발송
+export const sendFindIdCode = async (data: SendFindIdCodeRequest): Promise<ApiResponse<SendFindIdCodeResponse>> => {
+  const response = await axiosInstance.post<ApiResponse<SendFindIdCodeResponse>>('/auth/find-id/send-code', data);
+  return response.data;
+};
+
+// 이메일 인증번호 검증
+export const verifyEmailCode = async (data: VerifyEmailCodeRequest): Promise<ApiResponse<VerifyEmailCodeResponse>> => {
+  const response = await axiosInstance.post<ApiResponse<VerifyEmailCodeResponse>>('/auth/email/verify', data);
+  return response.data;
+};
+
+// 아이디 찾기 - 사용자 정보 조회
+export const findId = async (data: FindIdRequest): Promise<ApiResponse<FindIdResponse>> => {
+  const response = await axiosInstance.post<ApiResponse<FindIdResponse>>('/auth/find-id', data);
+  return response.data;
+};

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './signup';
 export * from './findId';
+export * from './resetPassword';

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
 export * from './signup';
+export * from './findId';

--- a/src/apis/auth/resetPassword.ts
+++ b/src/apis/auth/resetPassword.ts
@@ -1,0 +1,39 @@
+import { axiosInstance } from '@/src/apis/axios';
+import type {
+  ApiResponse,
+  SendResetPasswordCodeRequest,
+  SendResetPasswordCodeResponse,
+  VerifyResetPasswordRequest,
+  VerifyResetPasswordResponse,
+  ResetPasswordRequest,
+  ResetPasswordResponse,
+} from '@/src/types';
+
+// 비밀번호 재설정 - 인증번호 발송
+export const sendResetPasswordCode = async (
+  data: SendResetPasswordCodeRequest,
+): Promise<ApiResponse<SendResetPasswordCodeResponse>> => {
+  const response = await axiosInstance.post<ApiResponse<SendResetPasswordCodeResponse>>(
+    '/auth/reset-password/send-code',
+    data,
+  );
+  return response.data;
+};
+
+// 비밀번호 재설정 - 사용자 정보 검증
+export const verifyResetPassword = async (
+  data: VerifyResetPasswordRequest,
+): Promise<ApiResponse<VerifyResetPasswordResponse>> => {
+  const response = await axiosInstance.post<ApiResponse<VerifyResetPasswordResponse>>(
+    '/auth/reset-password/verify',
+    data,
+  );
+  return response.data;
+};
+
+// 비밀번호 재설정 - 새로운 비밀번호로 변경
+export const resetPassword = async (data: ResetPasswordRequest): Promise<ApiResponse<ResetPasswordResponse>> => {
+  const response = await axiosInstance.post<ApiResponse<ResetPasswordResponse>>('/auth/reset-password', data);
+  return response.data;
+};
+

--- a/src/app/(auth)/find-id/_funnel/FindIdFunnel.tsx
+++ b/src/app/(auth)/find-id/_funnel/FindIdFunnel.tsx
@@ -12,10 +12,12 @@ export const FindIdFunnel: React.FC = () => {
   // 결과 상태
   const [resultName, setResultName] = useState('');
   const [resultLoginId, setResultLoginId] = useState('');
+  const [resultLoginType, setResultLoginType] = useState('');
 
-  const handleComplete = (name: string, loginId: string) => {
+  const handleComplete = (name: string, loginId: string, loginType: string) => {
     setResultName(name);
     setResultLoginId(loginId);
+    setResultLoginType(loginType);
     setStep('complete');
   };
 
@@ -26,10 +28,9 @@ export const FindIdFunnel: React.FC = () => {
           <StepInput goNext={handleComplete} />
         </Funnel.Step>
         <Funnel.Step name="complete">
-          <StepComplete name={resultName} loginId={resultLoginId} />
+          <StepComplete name={resultName} loginId={resultLoginId} loginType={resultLoginType} />
         </Funnel.Step>
       </Funnel>
     </div>
   );
 };
-

--- a/src/app/(auth)/find-id/_funnel/FindIdFunnel.tsx
+++ b/src/app/(auth)/find-id/_funnel/FindIdFunnel.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+import { useFunnel } from '@/src/hooks/custom/signup/useFunnel';
+import { StepInput, StepComplete } from '.';
+
+export const FindIdFunnel: React.FC = () => {
+  const [Funnel, setStep] = useFunnel(['input', 'complete'] as const, {
+    initialStep: 'input',
+  });
+
+  // 결과 상태
+  const [resultName, setResultName] = useState('');
+  const [resultLoginId, setResultLoginId] = useState('');
+
+  const handleComplete = (name: string, loginId: string) => {
+    setResultName(name);
+    setResultLoginId(loginId);
+    setStep('complete');
+  };
+
+  return (
+    <div className="bg-white min-h-screen relative">
+      <Funnel>
+        <Funnel.Step name="input">
+          <StepInput goNext={handleComplete} />
+        </Funnel.Step>
+        <Funnel.Step name="complete">
+          <StepComplete name={resultName} loginId={resultLoginId} />
+        </Funnel.Step>
+      </Funnel>
+    </div>
+  );
+};
+

--- a/src/app/(auth)/find-id/_funnel/index.ts
+++ b/src/app/(auth)/find-id/_funnel/index.ts
@@ -1,0 +1,4 @@
+export * from './steps/1-Input';
+export * from './steps/2-Complete';
+export * from './FindIdFunnel';
+

--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -7,7 +7,7 @@ import { FixedBottomButton } from '@/src/components/signup';
 import { useSendFindIdCode, useVerifyEmailCode, useFindId } from '@/src/hooks/queries';
 
 interface StepInputProps {
-  goNext: (name: string, loginId: string) => void;
+  goNext: (name: string, loginId: string, loginType: string) => void;
 }
 
 export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
@@ -69,7 +69,6 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
             setError('');
             setAuthCode('');
             setIsVerified(false);
-            alert(response.result.message || '인증번호가 발송되었습니다.');
           } else {
             alert(response.message || '인증번호 발송에 실패했습니다.');
           }
@@ -126,7 +125,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
       {
         onSuccess: (response) => {
           if (response.isSuccess && response.result) {
-            goNext(response.result.name, response.result.loginId);
+            goNext(response.result.name, response.result.loginId, response.result.loginType);
           } else {
             alert(response.message || '아이디 찾기에 실패했습니다.');
           }

--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -189,20 +189,20 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
               )}
             </button>
           </div>
-        </div>
 
-        {/* 인증번호 입력 (인증번호 발송 후에만 표시) */}
-        {codeSent && (
-          <AuthCodeInputWithTimer
-            authCode={authCode}
-            onAuthCodeChange={handleAuthCodeChange}
-            timer={timer}
-            isVerified={isVerified}
-            error={error}
-            isLoading={isVerifyingCode}
-            onVerify={handleVerifyCode}
-          />
-        )}
+          {/* 인증번호 입력 (인증번호 발송 후에만 표시) */}
+          {codeSent && (
+            <AuthCodeInputWithTimer
+              authCode={authCode}
+              onAuthCodeChange={handleAuthCodeChange}
+              timer={timer}
+              isVerified={isVerified}
+              error={error}
+              isLoading={isVerifyingCode}
+              onVerify={handleVerifyCode}
+            />
+          )}
+        </div>
 
         {/* 하단 버튼 */}
         <div className="mt-auto mb-[42px]">

--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -32,14 +32,11 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
   const [codeSent, setCodeSent] = useState(false);
   const [isVerified, setIsVerified] = useState(false);
   const [error, setError] = useState('');
-  const [isSendingCode, setIsSendingCode] = useState(false);
-  const [isVerifyingCode, setIsVerifyingCode] = useState(false);
 
   // 인증번호 발송
   const handleSendCode = useCallback(() => {
     if (!name || !validateEmail(email)) return;
 
-    setIsSendingCode(true);
     sendCodeMutation.mutate(
       { name, email },
       {
@@ -53,7 +50,6 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
           } else {
             alert(response.message || '인증번호 발송에 실패했습니다.');
           }
-          setIsSendingCode(false);
         },
         onError: (error: unknown) => {
           const axiosError = error as {
@@ -61,7 +57,6 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
           };
           const errorMessage = axiosError.response?.data?.message || '인증번호 발송 중 오류가 발생했습니다.';
           alert(errorMessage);
-          setIsSendingCode(false);
         },
       },
     );
@@ -71,7 +66,6 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
   const handleVerifyCode = useCallback(() => {
     if (!authCode) return;
 
-    setIsVerifyingCode(true);
     verifyCodeMutation.mutate(
       { email, authCode, type: 'FIND_ID' },
       {
@@ -83,7 +77,6 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
             setIsVerified(false);
             setError(response.message || '인증번호가 일치하지 않습니다.');
           }
-          setIsVerifyingCode(false);
         },
         onError: (error: unknown) => {
           const axiosError = error as {
@@ -91,7 +84,6 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
           };
           const errorMessage = axiosError.response?.data?.message || '인증번호 검증 중 오류가 발생했습니다.';
           setError(errorMessage);
-          setIsVerifyingCode(false);
         },
       },
     );
@@ -176,9 +168,9 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
                     : 'bg-gray-200 text-gray-600 cursor-not-allowed'
               }`}
               onClick={handleSendCode}
-              disabled={!name || !validateEmail(email) || isSendingCode}
+              disabled={!name || !validateEmail(email) || sendCodeMutation.isPending}
             >
-              {isSendingCode ? (
+              {sendCodeMutation.isPending ? (
                 <div className="flex justify-center">
                   <Spinner />
                 </div>
@@ -198,7 +190,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
               timer={timer}
               isVerified={isVerified}
               error={error}
-              isLoading={isVerifyingCode}
+              isLoading={verifyCodeMutation.isPending}
               onVerify={handleVerifyCode}
             />
           )}

--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
 import { FixedBottomButton } from '@/src/components/signup';
 import { useSendFindIdCode, useVerifyEmailCode, useFindId } from '@/src/hooks/queries';
+import { validateEmail } from '@/src/utils/auth/find-id';
+import { useTimer } from '@/src/hooks/auth/find-id';
+import { AuthHeader, Spinner, AuthCodeInputWithTimer } from '@/src/components/auth';
 
 interface StepInputProps {
   goNext: (name: string, loginId: string, loginType: string) => void;
@@ -18,6 +20,9 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
   const verifyCodeMutation = useVerifyEmailCode();
   const findIdMutation = useFindId();
 
+  // Custom Hooks
+  const { timer, startTimer } = useTimer();
+
   // 입력 상태
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -26,37 +31,13 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
   // 인증 상태
   const [codeSent, setCodeSent] = useState(false);
   const [isVerified, setIsVerified] = useState(false);
-  const [timer, setTimer] = useState(0);
   const [error, setError] = useState('');
   const [isSendingCode, setIsSendingCode] = useState(false);
   const [isVerifyingCode, setIsVerifyingCode] = useState(false);
 
-  // 이메일 유효성 검증
-  const isValidEmail = (email: string) => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
-  };
-
-  // 타이머 포맷팅
-  const formatTime = (seconds: number) => {
-    const min = Math.floor(seconds / 60);
-    const sec = seconds % 60;
-    return `${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;
-  };
-
-  // 타이머 로직
-  useEffect(() => {
-    if (timer > 0) {
-      const interval = setInterval(() => {
-        setTimer((prev) => prev - 1);
-      }, 1000);
-      return () => clearInterval(interval);
-    }
-  }, [timer]);
-
   // 인증번호 발송
   const handleSendCode = useCallback(() => {
-    if (!name || !isValidEmail(email)) return;
+    if (!name || !validateEmail(email)) return;
 
     setIsSendingCode(true);
     sendCodeMutation.mutate(
@@ -65,7 +46,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
         onSuccess: (response) => {
           if (response.isSuccess) {
             setCodeSent(true);
-            setTimer(180); // 3분
+            startTimer(180); // 3분
             setError('');
             setAuthCode('');
             setIsVerified(false);
@@ -84,7 +65,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
         },
       },
     );
-  }, [name, email, sendCodeMutation]);
+  }, [name, email, sendCodeMutation, startTimer]);
 
   // 인증번호 확인
   const handleVerifyCode = useCallback(() => {
@@ -116,6 +97,12 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
     );
   }, [email, authCode, verifyCodeMutation]);
 
+  // 인증번호 입력 변경
+  const handleAuthCodeChange = useCallback((value: string) => {
+    setAuthCode(value);
+    setError('');
+  }, []);
+
   // 아이디 찾기 완료
   const handleFindId = useCallback(() => {
     if (!isVerified) return;
@@ -141,19 +128,10 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
     );
   }, [isVerified, name, email, goNext, findIdMutation]);
 
-  // 뒤로가기
-  const handleBack = () => {
-    router.back();
-  };
-
   return (
     <div className="min-h-screen flex flex-col bg-white">
       {/* 헤더 */}
-      <div className="mt-15 mx-4">
-        <button type="button" onClick={handleBack} className="w-6 h-6 flex items-center justify-center cursor-pointer">
-          <LeftArrowIcon />
-        </button>
-      </div>
+      <AuthHeader onBack={() => router.back()} />
 
       {/* 제목 */}
       <div className="mt-4 mx-4">
@@ -193,16 +171,16 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
               className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight ${
                 codeSent
                   ? 'bg-white text-blue-700 border border-blue-400 cursor-pointer'
-                  : name && isValidEmail(email)
+                  : name && validateEmail(email)
                     ? 'bg-blue-200 text-blue-700 cursor-pointer'
                     : 'bg-gray-200 text-gray-600 cursor-not-allowed'
               }`}
               onClick={handleSendCode}
-              disabled={!name || !isValidEmail(email) || isSendingCode}
+              disabled={!name || !validateEmail(email) || isSendingCode}
             >
               {isSendingCode ? (
                 <div className="flex justify-center">
-                  <div className="w-5 h-5 border-2 border-blue-700 border-t-transparent rounded-full animate-spin" />
+                  <Spinner />
                 </div>
               ) : codeSent ? (
                 '다시받기'
@@ -215,49 +193,15 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
 
         {/* 인증번호 입력 (인증번호 발송 후에만 표시) */}
         {codeSent && (
-          <div className="flex flex-col gap-1">
-            <div className="flex gap-2 items-center">
-              <div className="flex-1 relative">
-                <input
-                  type="text"
-                  className={`w-full border ${
-                    error ? 'border-error' : 'border-gray-400'
-                  } rounded-xl px-4 h-[49px] text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none tracking-tight`}
-                  placeholder="인증번호 입력"
-                  value={authCode}
-                  onChange={(e) => {
-                    setAuthCode(e.target.value.replace(/[^0-9]/g, ''));
-                    setError('');
-                  }}
-                  maxLength={6}
-                  disabled={isVerified}
-                />
-                {timer > 0 && !isVerified && (
-                  <span className="absolute right-4 top-1/2 -translate-y-1/2 text-caption-1-medium text-gray-700">
-                    {formatTime(timer)}
-                  </span>
-                )}
-              </div>
-              <button
-                type="button"
-                className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight ${
-                  isVerified
-                    ? 'bg-gray-200 text-gray-600 cursor-not-allowed'
-                    : authCode.length >= 4
-                      ? 'bg-blue-200 text-blue-700 cursor-pointer'
-                      : 'bg-gray-200 text-gray-600 cursor-not-allowed'
-                }`}
-                onClick={handleVerifyCode}
-                disabled={authCode.length < 4 || isVerified || isVerifyingCode}
-              >
-                {isVerified ? '인증완료' : '인증완료'}
-              </button>
-            </div>
-            {error && <p className="text-caption-1-medium text-error tracking-tight">{error}</p>}
-            {isVerified && (
-              <p className="text-caption-1-medium text-blue-700 tracking-tight">인증번호가 확인되었습니다.</p>
-            )}
-          </div>
+          <AuthCodeInputWithTimer
+            authCode={authCode}
+            onAuthCodeChange={handleAuthCodeChange}
+            timer={timer}
+            isVerified={isVerified}
+            error={error}
+            isLoading={isVerifyingCode}
+            onVerify={handleVerifyCode}
+          />
         )}
 
         {/* 하단 버튼 */}

--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -22,7 +22,8 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
   const [isVerified, setIsVerified] = useState(false);
   const [timer, setTimer] = useState(0);
   const [error, setError] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
+  const [isSendingCode, setIsSendingCode] = useState(false);
+  const [isVerifyingCode, setIsVerifyingCode] = useState(false);
 
   // 이메일 유효성 검증
   const isValidEmail = (email: string) => {
@@ -51,7 +52,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
   const handleSendCode = useCallback(() => {
     if (!name || !isValidEmail(email)) return;
 
-    setIsLoading(true);
+    setIsSendingCode(true);
     // TODO: API 연동 시 실제 요청으로 교체
     setTimeout(() => {
       setCodeSent(true);
@@ -59,7 +60,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
       setError('');
       setAuthCode('');
       setIsVerified(false);
-      setIsLoading(false);
+      setIsSendingCode(false);
     }, 500);
   }, [name, email]);
 
@@ -67,7 +68,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
   const handleVerifyCode = useCallback(() => {
     if (!authCode) return;
 
-    setIsLoading(true);
+    setIsVerifyingCode(true);
     // TODO: API 연동 시 실제 요청으로 교체
     setTimeout(() => {
       // Mock: 인증번호가 "1234"이면 성공
@@ -78,7 +79,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
         setIsVerified(false);
         setError('인증번호가 일치하지 않습니다.');
       }
-      setIsLoading(false);
+      setIsVerifyingCode(false);
     }, 300);
   }, [authCode]);
 
@@ -100,21 +101,15 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
     <div className="min-h-screen flex flex-col bg-white">
       {/* 헤더 */}
       <div className="mt-15 mx-4">
-        <button
-          type="button"
-          onClick={handleBack}
-          className="w-6 h-6 flex items-center justify-center cursor-pointer"
-        >
+        <button type="button" onClick={handleBack} className="w-6 h-6 flex items-center justify-center cursor-pointer">
           <LeftArrowIcon />
         </button>
       </div>
 
       {/* 제목 */}
       <div className="mt-4 mx-4">
-        <h1 className="text-head-1-semibold text-gray-900 tracking-tight">아이디 찾기</h1>
-        <p className="text-body-1-medium text-gray-700 tracking-tight mt-2">
-          이메일 인증을 통해 아이디를 확인합니다.
-        </p>
+        <h1 className="text-head-3-semibold text-gray-900 tracking-tight">아이디 찾기</h1>
+        <p className="text-body-1-medium text-gray-700 tracking-tight mt-2">이메일 인증을 통해 아이디를 확인합니다.</p>
       </div>
 
       {/* 입력 폼 */}
@@ -129,7 +124,6 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
             value={name}
             onChange={(e) => setName(e.target.value)}
             maxLength={20}
-            disabled={codeSent}
           />
         </div>
 
@@ -139,28 +133,33 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
           <div className="flex gap-2 items-center">
             <input
               type="email"
-              className={`flex-1 border border-gray-400 rounded-xl px-4 h-[49px] text-body-2-medium placeholder:text-gray-600 focus:outline-none tracking-tight ${
-                codeSent ? 'bg-gray-100 text-gray-700' : 'bg-white text-gray-900'
-              }`}
+              className="flex-1 border border-gray-400 rounded-xl px-4 h-[49px] text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none tracking-tight bg-white"
               placeholder="이메일을 입력해주세요"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               maxLength={50}
-              disabled={codeSent}
             />
             <button
               type="button"
-              className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight cursor-pointer ${
+              className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight ${
                 codeSent
-                  ? 'bg-white text-blue-700 border border-blue-400'
+                  ? 'bg-white text-blue-700 border border-blue-400 cursor-pointer'
                   : name && isValidEmail(email)
-                    ? 'bg-blue-200 text-blue-700'
-                    : 'bg-gray-200 text-gray-600'
+                    ? 'bg-blue-200 text-blue-700 cursor-pointer'
+                    : 'bg-gray-200 text-gray-600 cursor-not-allowed'
               }`}
               onClick={handleSendCode}
-              disabled={(!name || !isValidEmail(email)) && !codeSent}
+              disabled={!name || !isValidEmail(email) || isSendingCode}
             >
-              {isLoading ? '전송중' : codeSent ? '다시받기' : '인증하기'}
+              {isSendingCode ? (
+                <div className="flex justify-center">
+                  <div className="w-5 h-5 border-2 border-blue-700 border-t-transparent rounded-full animate-spin" />
+                </div>
+              ) : codeSent ? (
+                '다시받기'
+              ) : (
+                '인증하기'
+              )}
             </button>
           </div>
         </div>
@@ -185,31 +184,29 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
                   disabled={isVerified}
                 />
                 {timer > 0 && !isVerified && (
-                  <span className="absolute right-4 top-1/2 -translate-y-1/2 text-caption-1-medium text-blue-700">
+                  <span className="absolute right-4 top-1/2 -translate-y-1/2 text-caption-1-medium text-gray-700">
                     {formatTime(timer)}
                   </span>
                 )}
               </div>
               <button
                 type="button"
-                className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight cursor-pointer ${
+                className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight ${
                   isVerified
-                    ? 'bg-gray-200 text-gray-600'
-                    : authCode
-                      ? 'bg-blue-200 text-blue-700'
-                      : 'bg-gray-200 text-gray-600'
+                    ? 'bg-gray-200 text-gray-600 cursor-not-allowed'
+                    : authCode.length >= 4
+                      ? 'bg-blue-200 text-blue-700 cursor-pointer'
+                      : 'bg-gray-200 text-gray-600 cursor-not-allowed'
                 }`}
                 onClick={handleVerifyCode}
-                disabled={!authCode || isVerified || isLoading}
+                disabled={authCode.length < 4 || isVerified || isVerifyingCode}
               >
                 {isVerified ? '인증완료' : '인증완료'}
               </button>
             </div>
             {error && <p className="text-caption-1-medium text-error tracking-tight">{error}</p>}
             {isVerified && (
-              <p className="text-caption-1-medium text-blue-700 tracking-tight">
-                인증번호가 확인되었습니다.
-              </p>
+              <p className="text-caption-1-medium text-blue-700 tracking-tight">인증번호가 확인되었습니다.</p>
             )}
           </div>
         )}
@@ -224,4 +221,3 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
     </div>
   );
 };
-

--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
 import { FixedBottomButton } from '@/src/components/signup';
+import { useSendFindIdCode, useVerifyEmailCode, useFindId } from '@/src/hooks/queries';
 
 interface StepInputProps {
   goNext: (name: string, loginId: string) => void;
@@ -11,6 +12,11 @@ interface StepInputProps {
 
 export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
   const router = useRouter();
+
+  // React Query Hooks
+  const sendCodeMutation = useSendFindIdCode();
+  const verifyCodeMutation = useVerifyEmailCode();
+  const findIdMutation = useFindId();
 
   // 입력 상태
   const [name, setName] = useState('');
@@ -48,49 +54,93 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
     }
   }, [timer]);
 
-  // 인증번호 발송 (Mock)
+  // 인증번호 발송
   const handleSendCode = useCallback(() => {
     if (!name || !isValidEmail(email)) return;
 
     setIsSendingCode(true);
-    // TODO: API 연동 시 실제 요청으로 교체
-    setTimeout(() => {
-      setCodeSent(true);
-      setTimer(180); // 3분
-      setError('');
-      setAuthCode('');
-      setIsVerified(false);
-      setIsSendingCode(false);
-    }, 500);
-  }, [name, email]);
+    sendCodeMutation.mutate(
+      { name, email },
+      {
+        onSuccess: (response) => {
+          if (response.isSuccess) {
+            setCodeSent(true);
+            setTimer(180); // 3분
+            setError('');
+            setAuthCode('');
+            setIsVerified(false);
+            alert(response.result.message || '인증번호가 발송되었습니다.');
+          } else {
+            alert(response.message || '인증번호 발송에 실패했습니다.');
+          }
+          setIsSendingCode(false);
+        },
+        onError: (error: unknown) => {
+          const axiosError = error as {
+            response?: { data?: { message?: string } };
+          };
+          const errorMessage = axiosError.response?.data?.message || '인증번호 발송 중 오류가 발생했습니다.';
+          alert(errorMessage);
+          setIsSendingCode(false);
+        },
+      },
+    );
+  }, [name, email, sendCodeMutation]);
 
-  // 인증번호 확인 (Mock)
+  // 인증번호 확인
   const handleVerifyCode = useCallback(() => {
     if (!authCode) return;
 
     setIsVerifyingCode(true);
-    // TODO: API 연동 시 실제 요청으로 교체
-    setTimeout(() => {
-      // Mock: 인증번호가 "1234"이면 성공
-      if (authCode === '1234') {
-        setIsVerified(true);
-        setError('');
-      } else {
-        setIsVerified(false);
-        setError('인증번호가 일치하지 않습니다.');
-      }
-      setIsVerifyingCode(false);
-    }, 300);
-  }, [authCode]);
+    verifyCodeMutation.mutate(
+      { email, authCode, type: 'FIND_ID' },
+      {
+        onSuccess: (response) => {
+          if (response.isSuccess) {
+            setIsVerified(true);
+            setError('');
+          } else {
+            setIsVerified(false);
+            setError(response.message || '인증번호가 일치하지 않습니다.');
+          }
+          setIsVerifyingCode(false);
+        },
+        onError: (error: unknown) => {
+          const axiosError = error as {
+            response?: { data?: { message?: string } };
+          };
+          const errorMessage = axiosError.response?.data?.message || '인증번호 검증 중 오류가 발생했습니다.';
+          setError(errorMessage);
+          setIsVerifyingCode(false);
+        },
+      },
+    );
+  }, [email, authCode, verifyCodeMutation]);
 
-  // 아이디 찾기 완료 (Mock)
+  // 아이디 찾기 완료
   const handleFindId = useCallback(() => {
     if (!isVerified) return;
 
-    // TODO: API 연동 시 실제 요청으로 교체
-    // Mock 데이터
-    goNext(name, 'modelly1234');
-  }, [isVerified, name, goNext]);
+    findIdMutation.mutate(
+      { name, email },
+      {
+        onSuccess: (response) => {
+          if (response.isSuccess && response.result) {
+            goNext(response.result.name, response.result.loginId);
+          } else {
+            alert(response.message || '아이디 찾기에 실패했습니다.');
+          }
+        },
+        onError: (error: unknown) => {
+          const axiosError = error as {
+            response?: { data?: { message?: string } };
+          };
+          const errorMessage = axiosError.response?.data?.message || '아이디 찾기 중 오류가 발생했습니다.';
+          alert(errorMessage);
+        },
+      },
+    );
+  }, [isVerified, name, email, goNext, findIdMutation]);
 
   // 뒤로가기
   const handleBack = () => {
@@ -180,7 +230,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
                     setAuthCode(e.target.value.replace(/[^0-9]/g, ''));
                     setError('');
                   }}
-                  maxLength={4}
+                  maxLength={6}
                   disabled={isVerified}
                 />
                 {timer > 0 && !isVerified && (
@@ -213,8 +263,8 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
 
         {/* 하단 버튼 */}
         <div className="mt-auto mb-[42px]">
-          <FixedBottomButton disabled={!isVerified} onClick={handleFindId}>
-            아이디 찾기
+          <FixedBottomButton disabled={!isVerified || findIdMutation.isPending} onClick={handleFindId}>
+            {findIdMutation.isPending ? '조회 중...' : '아이디 찾기'}
           </FixedBottomButton>
         </div>
       </form>

--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
+import { FixedBottomButton } from '@/src/components/signup';
+
+interface StepInputProps {
+  goNext: (name: string, loginId: string) => void;
+}
+
+export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
+  const router = useRouter();
+
+  // 입력 상태
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [authCode, setAuthCode] = useState('');
+
+  // 인증 상태
+  const [codeSent, setCodeSent] = useState(false);
+  const [isVerified, setIsVerified] = useState(false);
+  const [timer, setTimer] = useState(0);
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  // 이메일 유효성 검증
+  const isValidEmail = (email: string) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
+  // 타이머 포맷팅
+  const formatTime = (seconds: number) => {
+    const min = Math.floor(seconds / 60);
+    const sec = seconds % 60;
+    return `${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;
+  };
+
+  // 타이머 로직
+  useEffect(() => {
+    if (timer > 0) {
+      const interval = setInterval(() => {
+        setTimer((prev) => prev - 1);
+      }, 1000);
+      return () => clearInterval(interval);
+    }
+  }, [timer]);
+
+  // 인증번호 발송 (Mock)
+  const handleSendCode = useCallback(() => {
+    if (!name || !isValidEmail(email)) return;
+
+    setIsLoading(true);
+    // TODO: API 연동 시 실제 요청으로 교체
+    setTimeout(() => {
+      setCodeSent(true);
+      setTimer(180); // 3분
+      setError('');
+      setAuthCode('');
+      setIsVerified(false);
+      setIsLoading(false);
+    }, 500);
+  }, [name, email]);
+
+  // 인증번호 확인 (Mock)
+  const handleVerifyCode = useCallback(() => {
+    if (!authCode) return;
+
+    setIsLoading(true);
+    // TODO: API 연동 시 실제 요청으로 교체
+    setTimeout(() => {
+      // Mock: 인증번호가 "1234"이면 성공
+      if (authCode === '1234') {
+        setIsVerified(true);
+        setError('');
+      } else {
+        setIsVerified(false);
+        setError('인증번호가 일치하지 않습니다.');
+      }
+      setIsLoading(false);
+    }, 300);
+  }, [authCode]);
+
+  // 아이디 찾기 완료 (Mock)
+  const handleFindId = useCallback(() => {
+    if (!isVerified) return;
+
+    // TODO: API 연동 시 실제 요청으로 교체
+    // Mock 데이터
+    goNext(name, 'modelly1234');
+  }, [isVerified, name, goNext]);
+
+  // 뒤로가기
+  const handleBack = () => {
+    router.back();
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-white">
+      {/* 헤더 */}
+      <div className="mt-15 mx-4">
+        <button
+          type="button"
+          onClick={handleBack}
+          className="w-6 h-6 flex items-center justify-center cursor-pointer"
+        >
+          <LeftArrowIcon />
+        </button>
+      </div>
+
+      {/* 제목 */}
+      <div className="mt-4 mx-4">
+        <h1 className="text-head-1-semibold text-gray-900 tracking-tight">아이디 찾기</h1>
+        <p className="text-body-1-medium text-gray-700 tracking-tight mt-2">
+          이메일 인증을 통해 아이디를 확인합니다.
+        </p>
+      </div>
+
+      {/* 입력 폼 */}
+      <form className="flex flex-col gap-6 mt-8 mx-4 flex-1" onSubmit={(e) => e.preventDefault()}>
+        {/* 이름 입력 */}
+        <div className="flex flex-col gap-2">
+          <label className="text-gray-900 text-body-1-medium tracking-tight">이름 (실명)</label>
+          <input
+            type="text"
+            className="border border-gray-400 rounded-xl px-4 py-3 text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none tracking-tight"
+            placeholder="이름을 입력해주세요"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={20}
+            disabled={codeSent}
+          />
+        </div>
+
+        {/* 이메일 입력 + 인증하기 버튼 */}
+        <div className="flex flex-col gap-2">
+          <label className="text-gray-900 text-body-1-medium tracking-tight">이메일</label>
+          <div className="flex gap-2 items-center">
+            <input
+              type="email"
+              className={`flex-1 border border-gray-400 rounded-xl px-4 h-[49px] text-body-2-medium placeholder:text-gray-600 focus:outline-none tracking-tight ${
+                codeSent ? 'bg-gray-100 text-gray-700' : 'bg-white text-gray-900'
+              }`}
+              placeholder="이메일을 입력해주세요"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              maxLength={50}
+              disabled={codeSent}
+            />
+            <button
+              type="button"
+              className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight cursor-pointer ${
+                codeSent
+                  ? 'bg-white text-blue-700 border border-blue-400'
+                  : name && isValidEmail(email)
+                    ? 'bg-blue-200 text-blue-700'
+                    : 'bg-gray-200 text-gray-600'
+              }`}
+              onClick={handleSendCode}
+              disabled={(!name || !isValidEmail(email)) && !codeSent}
+            >
+              {isLoading ? '전송중' : codeSent ? '다시받기' : '인증하기'}
+            </button>
+          </div>
+        </div>
+
+        {/* 인증번호 입력 (인증번호 발송 후에만 표시) */}
+        {codeSent && (
+          <div className="flex flex-col gap-1">
+            <div className="flex gap-2 items-center">
+              <div className="flex-1 relative">
+                <input
+                  type="text"
+                  className={`w-full border ${
+                    error ? 'border-error' : 'border-gray-400'
+                  } rounded-xl px-4 h-[49px] text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none tracking-tight`}
+                  placeholder="인증번호 입력"
+                  value={authCode}
+                  onChange={(e) => {
+                    setAuthCode(e.target.value.replace(/[^0-9]/g, ''));
+                    setError('');
+                  }}
+                  maxLength={6}
+                  disabled={isVerified}
+                />
+                {timer > 0 && !isVerified && (
+                  <span className="absolute right-4 top-1/2 -translate-y-1/2 text-caption-1-medium text-blue-700">
+                    {formatTime(timer)}
+                  </span>
+                )}
+              </div>
+              <button
+                type="button"
+                className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight cursor-pointer ${
+                  isVerified
+                    ? 'bg-gray-200 text-gray-600'
+                    : authCode
+                      ? 'bg-blue-200 text-blue-700'
+                      : 'bg-gray-200 text-gray-600'
+                }`}
+                onClick={handleVerifyCode}
+                disabled={!authCode || isVerified || isLoading}
+              >
+                {isVerified ? '인증완료' : '인증완료'}
+              </button>
+            </div>
+            {error && <p className="text-caption-1-medium text-error tracking-tight">{error}</p>}
+            {isVerified && (
+              <p className="text-caption-1-medium text-blue-700 tracking-tight">
+                인증번호가 확인되었습니다.
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* 하단 버튼 */}
+        <div className="mt-auto mb-[42px]">
+          <FixedBottomButton disabled={!isVerified} onClick={handleFindId}>
+            아이디 찾기
+          </FixedBottomButton>
+        </div>
+      </form>
+    </div>
+  );
+};
+

--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -180,7 +180,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
                     setAuthCode(e.target.value.replace(/[^0-9]/g, ''));
                     setError('');
                   }}
-                  maxLength={6}
+                  maxLength={4}
                   disabled={isVerified}
                 />
                 {timer > 0 && !isVerified && (

--- a/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import SignupCompletedIcon from '@/public/icons/signup/signup-completed.svg';
+
+interface StepCompleteProps {
+  name: string;
+  loginId: string;
+}
+
+export const StepComplete: React.FC<StepCompleteProps> = ({ name, loginId }) => {
+  const router = useRouter();
+
+  const handleGoToLogin = () => {
+    router.push('/login');
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-white px-4">
+      <div className="flex flex-col items-center gap-5 mb-[84px]">
+        <div className="relative w-[50px] h-[50px]">
+          <SignupCompletedIcon />
+        </div>
+        <div className="flex flex-col items-center gap-1">
+          <p className="text-gray-900 text-head-3-semibold text-center tracking-tight">
+            {name} 님의 아이디는
+          </p>
+          <div className="flex items-baseline gap-1">
+            <span className="text-gray-900 text-head-2-semibold tracking-tight">{loginId}</span>
+            <span className="text-gray-900 text-head-3-semibold tracking-tight">입니다</span>
+          </div>
+        </div>
+      </div>
+      <button
+        onClick={handleGoToLogin}
+        className="fixed bottom-[42px] left-1/2 -translate-x-1/2 w-[343px] py-4 bg-gray-900 text-white rounded-full text-body-1-semibold cursor-pointer tracking-tight"
+      >
+        로그인 화면으로 이동
+      </button>
+    </div>
+  );
+};
+

--- a/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import SignupCompletedIcon from '@/public/icons/signup/signup-completed.svg';
+import { getSocialServiceName } from '@/src/utils/auth/common';
 
 interface StepCompleteProps {
   name: string;
@@ -14,16 +15,6 @@ export const StepComplete: React.FC<StepCompleteProps> = ({ name, loginId, login
 
   const handleGoToLogin = () => {
     router.push('/login');
-  };
-
-  // loginType을 서비스명으로 변환
-  const getSocialServiceName = (type: string): string => {
-    const serviceMap: Record<string, string> = {
-      KAKAO: '카카오',
-      NAVER: '네이버',
-      GOOGLE: '구글',
-    };
-    return serviceMap[type] || type;
   };
 
   // 소셜 로그인 여부 확인 (loginId가 null이거나 loginType이 JWT가 아닌 경우)

--- a/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
@@ -6,14 +6,28 @@ import SignupCompletedIcon from '@/public/icons/signup/signup-completed.svg';
 interface StepCompleteProps {
   name: string;
   loginId: string;
+  loginType: string;
 }
 
-export const StepComplete: React.FC<StepCompleteProps> = ({ name, loginId }) => {
+export const StepComplete: React.FC<StepCompleteProps> = ({ name, loginId, loginType }) => {
   const router = useRouter();
 
   const handleGoToLogin = () => {
     router.push('/login');
   };
+
+  // loginType을 서비스명으로 변환
+  const getSocialServiceName = (type: string): string => {
+    const serviceMap: Record<string, string> = {
+      KAKAO: '카카오',
+      NAVER: '네이버',
+      GOOGLE: '구글',
+    };
+    return serviceMap[type] || type;
+  };
+
+  // 소셜 로그인 여부 확인 (loginId가 null이거나 loginType이 JWT가 아닌 경우)
+  const isSocialLogin = loginType !== 'JWT' && (loginId === null || loginId === 'null' || !loginId);
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-white px-4">
@@ -22,22 +36,33 @@ export const StepComplete: React.FC<StepCompleteProps> = ({ name, loginId }) => 
           <SignupCompletedIcon />
         </div>
         <div className="flex flex-col items-center gap-1">
-          <p className="text-gray-900 text-head-3-semibold text-center tracking-tight">
-            {name} 님의 아이디는
-          </p>
-          <div className="flex items-baseline gap-1">
-            <span className="text-gray-900 text-head-2-semibold tracking-tight">{loginId}</span>
-            <span className="text-gray-900 text-head-3-semibold tracking-tight">입니다</span>
-          </div>
+          {isSocialLogin ? (
+            <>
+              <p className="text-head-3-medium text-center tracking-tight">{name} 님은</p>
+              <div className="flex items-baseline gap-1">
+                <span className="text-head-2-semibold tracking-tight">
+                  {getSocialServiceName(loginType)} 소셜 로그인 사용자
+                </span>
+                <span className="text-head-3-medium tracking-tight">입니다</span>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="text-head-3-medium text-center tracking-tight">{name} 님의 아이디는</p>
+              <div className="flex items-baseline gap-1">
+                <span className="text-head-2-semibold tracking-tight">{loginId}</span>
+                <span className="text-head-3-medium tracking-tight">입니다</span>
+              </div>
+            </>
+          )}
         </div>
       </div>
       <button
         onClick={handleGoToLogin}
-        className="fixed bottom-[42px] left-1/2 -translate-x-1/2 w-[343px] py-4 bg-gray-900 text-white rounded-full text-body-1-semibold cursor-pointer tracking-tight"
+        className="fixed bottom-[42px] left-1/2 -translate-x-1/2 w-[343px] py-4 bg-gray-900 text-white rounded-full text-body-1-medium cursor-pointer tracking-tight"
       >
         로그인 화면으로 이동
       </button>
     </div>
   );
 };
-

--- a/src/app/(auth)/find-id/page.tsx
+++ b/src/app/(auth)/find-id/page.tsx
@@ -1,0 +1,7 @@
+import { FindIdFunnel } from './_funnel/FindIdFunnel';
+
+const FindIdPage = () => {
+  return <FindIdFunnel />;
+};
+
+export default FindIdPage;

--- a/src/app/(auth)/find-password/_funnel/FindPasswordFunnel.tsx
+++ b/src/app/(auth)/find-password/_funnel/FindPasswordFunnel.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import { useFunnel } from '@/src/hooks/custom/signup/useFunnel';
+import { StepInput, StepNewPassword, StepComplete, StepSocialUser } from '.';
+
+export const FindPasswordFunnel: React.FC = () => {
+  const [Funnel, setStep] = useFunnel(['input', 'new-password', 'complete', 'social-user'] as const, {
+    initialStep: 'input',
+  });
+
+  // 결과 상태
+  const [userName, setUserName] = useState('');
+  const [userLoginId, setUserLoginId] = useState('');
+  const [userEmail, setUserEmail] = useState('');
+  const [socialLoginType, setSocialLoginType] = useState('');
+
+  // Step 1 -> Step 2 (일반 사용자)
+  const handleGoToNewPassword = (name: string, loginId: string, email: string) => {
+    setUserName(name);
+    setUserLoginId(loginId);
+    setUserEmail(email);
+    setStep('new-password');
+  };
+
+  // Step 1 -> social-user (소셜 로그인 사용자)
+  const handleGoToSocialUser = (name: string, loginType: string) => {
+    setUserName(name);
+    setSocialLoginType(loginType);
+    setStep('social-user');
+  };
+
+  // Step 2 -> Step 3 (완료)
+  const handleComplete = () => {
+    setStep('complete');
+  };
+
+  return (
+    <div className="bg-white min-h-screen relative">
+      <Funnel>
+        <Funnel.Step name="input">
+          <StepInput goNext={handleGoToNewPassword} goSocialUser={handleGoToSocialUser} />
+        </Funnel.Step>
+        <Funnel.Step name="new-password">
+          <StepNewPassword email={userEmail} goNext={handleComplete} />
+        </Funnel.Step>
+        <Funnel.Step name="complete">
+          <StepComplete />
+        </Funnel.Step>
+        <Funnel.Step name="social-user">
+          <StepSocialUser name={userName} loginType={socialLoginType} />
+        </Funnel.Step>
+      </Funnel>
+    </div>
+  );
+};

--- a/src/app/(auth)/find-password/_funnel/index.ts
+++ b/src/app/(auth)/find-password/_funnel/index.ts
@@ -1,0 +1,5 @@
+export { StepInput } from './steps/1-Input';
+export { StepNewPassword } from './steps/2-NewPassword';
+export { StepComplete } from './steps/3-Complete';
+export { StepSocialUser } from './steps/4-SocialUser';
+

--- a/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
+import { FixedBottomButton } from '@/src/components/signup';
+
+interface StepInputProps {
+  goNext: (name: string, loginId: string, email: string) => void;
+  goSocialUser: (name: string, loginType: string) => void;
+}
+
+export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) => {
+  const router = useRouter();
+
+  // 입력 상태
+  const [name, setName] = useState('');
+  const [loginId, setLoginId] = useState('');
+  const [email, setEmail] = useState('');
+  const [authCode, setAuthCode] = useState('');
+
+  // 인증 상태
+  const [codeSent, setCodeSent] = useState(false);
+  const [isVerified, setIsVerified] = useState(false);
+  const [timer, setTimer] = useState(0);
+  const [error, setError] = useState('');
+
+  // 이메일 유효성 검증
+  const isValidEmail = (email: string) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
+  // 타이머 포맷팅
+  const formatTime = (seconds: number) => {
+    const min = Math.floor(seconds / 60);
+    const sec = seconds % 60;
+    return `${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;
+  };
+
+  // 타이머 로직
+  useEffect(() => {
+    if (timer > 0) {
+      const interval = setInterval(() => {
+        setTimer((prev) => prev - 1);
+      }, 1000);
+      return () => clearInterval(interval);
+    }
+  }, [timer]);
+
+  // 인증번호 발송 (임시 구현 - API 연동 전)
+  const handleSendCode = () => {
+    if (!name || !loginId || !isValidEmail(email)) return;
+
+    // TODO: API 연동 시 구현
+    setCodeSent(true);
+    setTimer(180); // 3분
+    setError('');
+    setAuthCode('');
+    setIsVerified(false);
+  };
+
+  // 인증번호 확인 (임시 구현 - API 연동 전)
+  const handleVerifyCode = () => {
+    if (!authCode) return;
+
+    // TODO: API 연동 시 구현
+    setIsVerified(true);
+    setError('');
+  };
+
+  // 비밀번호 재설정 진행
+  const handleNextStep = () => {
+    if (!isVerified) return;
+
+    // TODO: API 연동 시 구현
+    goNext(name, loginId, email);
+  };
+
+  // 뒤로가기
+  const handleBack = () => {
+    router.back();
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-white">
+      {/* 헤더 */}
+      <div className="mt-15 mx-4">
+        <button type="button" onClick={handleBack} className="w-6 h-6 flex items-center justify-center cursor-pointer">
+          <LeftArrowIcon />
+        </button>
+      </div>
+
+      {/* 제목 */}
+      <div className="mt-4 mx-4">
+        <h1 className="text-head-3-semibold text-gray-900 tracking-tight">비밀번호 찾기</h1>
+        <p className="text-body-1-medium text-gray-700 tracking-tight mt-2">
+          가입한 아이디를 입력해주세요.
+          <br />
+          이메일 인증을 통해 비밀번호를 변경합니다.
+        </p>
+      </div>
+
+      {/* 입력 폼 */}
+      <form className="flex flex-col gap-6 mt-8 mx-4 flex-1" onSubmit={(e) => e.preventDefault()}>
+        {/* 이름 입력 */}
+        <div className="flex flex-col gap-2">
+          <label className="text-gray-900 text-body-1-medium tracking-tight">이름 (실명)</label>
+          <input
+            type="text"
+            className="border border-gray-400 rounded-xl px-4 py-3 text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none tracking-tight"
+            placeholder="이름을 입력해주세요"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={20}
+            disabled={codeSent}
+          />
+        </div>
+
+        {/* 아이디 입력 */}
+        <div className="flex flex-col gap-2">
+          <label className="text-gray-900 text-body-1-medium tracking-tight">아이디</label>
+          <input
+            type="text"
+            className="border border-gray-400 rounded-xl px-4 py-3 text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none tracking-tight"
+            placeholder="아이디를 입력해주세요"
+            value={loginId}
+            onChange={(e) => setLoginId(e.target.value)}
+            maxLength={20}
+            disabled={codeSent}
+          />
+        </div>
+
+        {/* 이메일 입력 + 인증하기 버튼 */}
+        <div className="flex flex-col gap-2">
+          <label className="text-gray-900 text-body-1-medium tracking-tight">이메일</label>
+          <div className="flex gap-2 items-center">
+            <input
+              type="email"
+              className={`flex-1 border border-gray-400 rounded-xl px-4 h-[49px] text-body-2-medium placeholder:text-gray-600 focus:outline-none tracking-tight ${
+                codeSent ? 'bg-gray-100 text-gray-700' : 'bg-white text-gray-900'
+              }`}
+              placeholder="이메일을 입력해주세요"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              maxLength={50}
+              disabled={codeSent && !isVerified}
+            />
+            <button
+              type="button"
+              className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight ${
+                codeSent
+                  ? 'bg-white text-blue-700 border border-blue-400 cursor-pointer'
+                  : name && loginId && isValidEmail(email)
+                    ? 'bg-blue-200 text-blue-700 cursor-pointer'
+                    : 'bg-gray-200 text-gray-600 cursor-not-allowed'
+              }`}
+              onClick={handleSendCode}
+              disabled={(!name || !loginId || !isValidEmail(email)) && !codeSent}
+            >
+              {codeSent ? '다시받기' : '인증하기'}
+            </button>
+          </div>
+        </div>
+
+        {/* 인증번호 입력 (인증번호 발송 후에만 표시) */}
+        {codeSent && (
+          <div className="flex flex-col gap-1">
+            <div className="flex gap-2 items-center">
+              <div className="flex-1 relative">
+                <input
+                  type="text"
+                  className={`w-full border ${
+                    error ? 'border-error' : 'border-gray-400'
+                  } rounded-xl px-4 h-[49px] text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none tracking-tight`}
+                  placeholder="인증번호 입력"
+                  value={authCode}
+                  onChange={(e) => {
+                    setAuthCode(e.target.value.replace(/[^0-9]/g, ''));
+                    setError('');
+                  }}
+                  maxLength={6}
+                  disabled={isVerified}
+                />
+                {timer > 0 && !isVerified && (
+                  <span className="absolute right-4 top-1/2 -translate-y-1/2 text-caption-1-medium text-gray-700">
+                    {formatTime(timer)}
+                  </span>
+                )}
+              </div>
+              <button
+                type="button"
+                className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight ${
+                  isVerified
+                    ? 'bg-gray-200 text-gray-600 cursor-not-allowed'
+                    : authCode.length >= 4
+                      ? 'bg-blue-200 text-blue-700 cursor-pointer'
+                      : 'bg-gray-200 text-gray-600 cursor-not-allowed'
+                }`}
+                onClick={handleVerifyCode}
+                disabled={authCode.length < 4 || isVerified}
+              >
+                {isVerified ? '인증완료' : '확인하기'}
+              </button>
+            </div>
+            {error && <p className="text-caption-1-medium text-error tracking-tight">{error}</p>}
+            {isVerified && (
+              <p className="text-caption-1-medium text-blue-700 tracking-tight">인증번호가 확인되었습니다.</p>
+            )}
+          </div>
+        )}
+
+        {/* 하단 버튼 */}
+        <div className="mt-auto mb-[42px]">
+          <FixedBottomButton disabled={!isVerified} onClick={handleNextStep}>
+            비밀번호 재설정
+          </FixedBottomButton>
+        </div>
+      </form>
+    </div>
+  );
+};
+

--- a/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
 import { FixedBottomButton } from '@/src/components/signup';
 import { useSendResetPasswordCode, useVerifyEmailCode, useVerifyResetPassword } from '@/src/hooks/queries';
+import { validateEmail } from '@/src/utils/auth/find-password';
+import { useTimer } from '@/src/hooks/auth/find-password';
+import { AuthHeader, Spinner, AuthCodeInputWithTimer } from '@/src/components/auth';
 
 interface StepInputProps {
   goNext: (name: string, loginId: string, email: string) => void;
@@ -19,6 +21,9 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
   const verifyCodeMutation = useVerifyEmailCode();
   const verifyResetMutation = useVerifyResetPassword();
 
+  // Custom Hooks
+  const { timer, startTimer } = useTimer();
+
   // 입력 상태
   const [name, setName] = useState('');
   const [loginId, setLoginId] = useState('');
@@ -28,35 +33,11 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
   // 인증 상태
   const [codeSent, setCodeSent] = useState(false);
   const [isVerified, setIsVerified] = useState(false);
-  const [timer, setTimer] = useState(0);
   const [error, setError] = useState('');
-
-  // 이메일 유효성 검증
-  const isValidEmail = (email: string) => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
-  };
-
-  // 타이머 포맷팅
-  const formatTime = (seconds: number) => {
-    const min = Math.floor(seconds / 60);
-    const sec = seconds % 60;
-    return `${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;
-  };
-
-  // 타이머 로직
-  useEffect(() => {
-    if (timer > 0) {
-      const interval = setInterval(() => {
-        setTimer((prev) => prev - 1);
-      }, 1000);
-      return () => clearInterval(interval);
-    }
-  }, [timer]);
 
   // 인증번호 발송
   const handleSendCode = useCallback(() => {
-    if (!name || !loginId || !isValidEmail(email)) return;
+    if (!name || !loginId || !validateEmail(email)) return;
 
     sendCodeMutation.mutate(
       { name, loginId, email },
@@ -64,7 +45,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
         onSuccess: (response) => {
           if (response.isSuccess) {
             setCodeSent(true);
-            setTimer(180); // 3분
+            startTimer(180); // 3분
             setError('');
             setAuthCode('');
             setIsVerified(false);
@@ -88,7 +69,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
         },
       },
     );
-  }, [name, loginId, email, sendCodeMutation, goSocialUser]);
+  }, [name, loginId, email, sendCodeMutation, goSocialUser, startTimer]);
 
   // 인증번호 확인
   const handleVerifyCode = useCallback(() => {
@@ -117,6 +98,12 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
     );
   }, [email, authCode, verifyCodeMutation]);
 
+  // 인증번호 입력 변경
+  const handleAuthCodeChange = useCallback((value: string) => {
+    setAuthCode(value);
+    setError('');
+  }, []);
+
   // 비밀번호 재설정 진행 (사용자 정보 검증)
   const handleNextStep = useCallback(() => {
     if (!isVerified) return;
@@ -142,19 +129,10 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
     );
   }, [isVerified, name, loginId, email, verifyResetMutation, goNext]);
 
-  // 뒤로가기
-  const handleBack = () => {
-    router.back();
-  };
-
   return (
     <div className="min-h-screen flex flex-col bg-white">
       {/* 헤더 */}
-      <div className="mt-15 mx-4">
-        <button type="button" onClick={handleBack} className="w-6 h-6 flex items-center justify-center cursor-pointer">
-          <LeftArrowIcon />
-        </button>
-      </div>
+      <AuthHeader onBack={() => router.back()} />
 
       {/* 제목 */}
       <div className="mt-4 mx-4">
@@ -213,16 +191,16 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
               className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight ${
                 codeSent
                   ? 'bg-white text-blue-700 border border-blue-400 cursor-pointer'
-                  : name && loginId && isValidEmail(email)
+                  : name && loginId && validateEmail(email)
                     ? 'bg-blue-200 text-blue-700 cursor-pointer'
                     : 'bg-gray-200 text-gray-600 cursor-not-allowed'
               }`}
               onClick={handleSendCode}
-              disabled={((!name || !loginId || !isValidEmail(email)) && !codeSent) || sendCodeMutation.isPending}
+              disabled={((!name || !loginId || !validateEmail(email)) && !codeSent) || sendCodeMutation.isPending}
             >
               {sendCodeMutation.isPending ? (
                 <div className="flex justify-center">
-                  <div className="w-5 h-5 border-2 border-blue-700 border-t-transparent rounded-full animate-spin" />
+                  <Spinner />
                 </div>
               ) : codeSent ? (
                 '다시받기'
@@ -235,57 +213,15 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
 
         {/* 인증번호 입력 (인증번호 발송 후에만 표시) */}
         {codeSent && (
-          <div className="flex flex-col gap-1">
-            <div className="flex gap-2 items-center">
-              <div className="flex-1 relative">
-                <input
-                  type="text"
-                  className={`w-full border ${
-                    error ? 'border-error' : 'border-gray-400'
-                  } rounded-xl px-4 h-[49px] text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none tracking-tight`}
-                  placeholder="인증번호 입력"
-                  value={authCode}
-                  onChange={(e) => {
-                    setAuthCode(e.target.value.replace(/[^0-9]/g, ''));
-                    setError('');
-                  }}
-                  maxLength={6}
-                  disabled={isVerified}
-                />
-                {timer > 0 && !isVerified && (
-                  <span className="absolute right-4 top-1/2 -translate-y-1/2 text-caption-1-medium text-gray-700">
-                    {formatTime(timer)}
-                  </span>
-                )}
-              </div>
-              <button
-                type="button"
-                className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight ${
-                  isVerified
-                    ? 'bg-gray-200 text-gray-600 cursor-not-allowed'
-                    : authCode.length >= 4
-                      ? 'bg-blue-200 text-blue-700 cursor-pointer'
-                      : 'bg-gray-200 text-gray-600 cursor-not-allowed'
-                }`}
-                onClick={handleVerifyCode}
-                disabled={authCode.length < 4 || isVerified || verifyCodeMutation.isPending}
-              >
-                {verifyCodeMutation.isPending ? (
-                  <div className="flex justify-center">
-                    <div className="w-5 h-5 border-2 border-blue-700 border-t-transparent rounded-full animate-spin" />
-                  </div>
-                ) : isVerified ? (
-                  '인증완료'
-                ) : (
-                  '확인하기'
-                )}
-              </button>
-            </div>
-            {error && <p className="text-caption-1-medium text-error tracking-tight">{error}</p>}
-            {isVerified && (
-              <p className="text-caption-1-medium text-blue-700 tracking-tight">인증번호가 확인되었습니다.</p>
-            )}
-          </div>
+          <AuthCodeInputWithTimer
+            authCode={authCode}
+            onAuthCodeChange={handleAuthCodeChange}
+            timer={timer}
+            isVerified={isVerified}
+            error={error}
+            isLoading={verifyCodeMutation.isPending}
+            onVerify={handleVerifyCode}
+          />
         )}
 
         {/* 하단 버튼 */}

--- a/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
 import { FixedBottomButton } from '@/src/components/signup';
+import { useSendResetPasswordCode, useVerifyEmailCode, useVerifyResetPassword } from '@/src/hooks/queries';
 
 interface StepInputProps {
   goNext: (name: string, loginId: string, email: string) => void;
@@ -12,6 +13,11 @@ interface StepInputProps {
 
 export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) => {
   const router = useRouter();
+
+  // React Query Hooks
+  const sendCodeMutation = useSendResetPasswordCode();
+  const verifyCodeMutation = useVerifyEmailCode();
+  const verifyResetMutation = useVerifyResetPassword();
 
   // 입력 상태
   const [name, setName] = useState('');
@@ -24,8 +30,6 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
   const [isVerified, setIsVerified] = useState(false);
   const [timer, setTimer] = useState(0);
   const [error, setError] = useState('');
-  const [isSendingCode, setIsSendingCode] = useState(false);
-  const [isVerifyingCode, setIsVerifyingCode] = useState(false);
 
   // 이메일 유효성 검증
   const isValidEmail = (email: string) => {
@@ -50,42 +54,93 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
     }
   }, [timer]);
 
-  // 인증번호 발송 (임시 구현 - API 연동 전)
-  const handleSendCode = () => {
+  // 인증번호 발송
+  const handleSendCode = useCallback(() => {
     if (!name || !loginId || !isValidEmail(email)) return;
 
-    setIsSendingCode(true);
-    // TODO: API 연동 시 구현
-    setTimeout(() => {
-      setCodeSent(true);
-      setTimer(180); // 3분
-      setError('');
-      setAuthCode('');
-      setIsVerified(false);
-      setIsSendingCode(false);
-    }, 500);
-  };
+    sendCodeMutation.mutate(
+      { name, loginId, email },
+      {
+        onSuccess: (response) => {
+          if (response.isSuccess) {
+            setCodeSent(true);
+            setTimer(180); // 3분
+            setError('');
+            setAuthCode('');
+            setIsVerified(false);
+          } else {
+            alert(response.message || '인증번호 발송에 실패했습니다.');
+          }
+        },
+        onError: (error: unknown) => {
+          const axiosError = error as {
+            response?: { data?: { message?: string; code?: string; result?: { loginType?: string } } };
+          };
+          const errorMessage = axiosError.response?.data?.message || '인증번호 발송 중 오류가 발생했습니다.';
+          const loginType = axiosError.response?.data?.result?.loginType;
 
-  // 인증번호 확인 (임시 구현 - API 연동 전)
-  const handleVerifyCode = () => {
+          // 소셜 로그인 사용자인 경우
+          if (loginType && loginType !== 'JWT') {
+            goSocialUser(name, loginType);
+          } else {
+            alert(errorMessage);
+          }
+        },
+      },
+    );
+  }, [name, loginId, email, sendCodeMutation, goSocialUser]);
+
+  // 인증번호 확인
+  const handleVerifyCode = useCallback(() => {
     if (!authCode) return;
 
-    setIsVerifyingCode(true);
-    // TODO: API 연동 시 구현
-    setTimeout(() => {
-      setIsVerified(true);
-      setError('');
-      setIsVerifyingCode(false);
-    }, 500);
-  };
+    verifyCodeMutation.mutate(
+      { email, authCode, type: 'FIND_PASSWORD' },
+      {
+        onSuccess: (response) => {
+          if (response.isSuccess) {
+            setIsVerified(true);
+            setError('');
+          } else {
+            setIsVerified(false);
+            setError(response.message || '인증번호가 일치하지 않습니다.');
+          }
+        },
+        onError: (error: unknown) => {
+          const axiosError = error as {
+            response?: { data?: { message?: string } };
+          };
+          const errorMessage = axiosError.response?.data?.message || '인증번호 검증 중 오류가 발생했습니다.';
+          setError(errorMessage);
+        },
+      },
+    );
+  }, [email, authCode, verifyCodeMutation]);
 
   // 비밀번호 재설정 진행
-  const handleNextStep = () => {
+  const handleNextStep = useCallback(() => {
     if (!isVerified) return;
 
-    // TODO: API 연동 시 구현
-    goNext(name, loginId, email);
-  };
+    verifyResetMutation.mutate(
+      { name, loginId, email },
+      {
+        onSuccess: (response) => {
+          if (response.isSuccess) {
+            goNext(name, loginId, email);
+          } else {
+            alert(response.message || '사용자 정보 검증에 실패했습니다.');
+          }
+        },
+        onError: (error: unknown) => {
+          const axiosError = error as {
+            response?: { data?: { message?: string } };
+          };
+          const errorMessage = axiosError.response?.data?.message || '사용자 정보 검증 중 오류가 발생했습니다.';
+          alert(errorMessage);
+        },
+      },
+    );
+  }, [isVerified, name, loginId, email, verifyResetMutation, goNext]);
 
   // 뒤로가기
   const handleBack = () => {
@@ -163,9 +218,9 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
                     : 'bg-gray-200 text-gray-600 cursor-not-allowed'
               }`}
               onClick={handleSendCode}
-              disabled={((!name || !loginId || !isValidEmail(email)) && !codeSent) || isSendingCode}
+              disabled={((!name || !loginId || !isValidEmail(email)) && !codeSent) || sendCodeMutation.isPending}
             >
-              {isSendingCode ? (
+              {sendCodeMutation.isPending ? (
                 <div className="flex justify-center">
                   <div className="w-5 h-5 border-2 border-blue-700 border-t-transparent rounded-full animate-spin" />
                 </div>
@@ -213,9 +268,9 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
                       : 'bg-gray-200 text-gray-600 cursor-not-allowed'
                 }`}
                 onClick={handleVerifyCode}
-                disabled={authCode.length < 4 || isVerified || isVerifyingCode}
+                disabled={authCode.length < 4 || isVerified || verifyCodeMutation.isPending}
               >
-                {isVerifyingCode ? (
+                {verifyCodeMutation.isPending ? (
                   <div className="flex justify-center">
                     <div className="w-5 h-5 border-2 border-blue-700 border-t-transparent rounded-full animate-spin" />
                   </div>
@@ -235,8 +290,8 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
 
         {/* 하단 버튼 */}
         <div className="mt-auto mb-[42px]">
-          <FixedBottomButton disabled={!isVerified} onClick={handleNextStep}>
-            비밀번호 재설정
+          <FixedBottomButton disabled={!isVerified || verifyResetMutation.isPending} onClick={handleNextStep}>
+            {verifyResetMutation.isPending ? '검증 중...' : '비밀번호 재설정'}
           </FixedBottomButton>
         </div>
       </form>

--- a/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
@@ -24,6 +24,8 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
   const [isVerified, setIsVerified] = useState(false);
   const [timer, setTimer] = useState(0);
   const [error, setError] = useState('');
+  const [isSendingCode, setIsSendingCode] = useState(false);
+  const [isVerifyingCode, setIsVerifyingCode] = useState(false);
 
   // 이메일 유효성 검증
   const isValidEmail = (email: string) => {
@@ -52,21 +54,29 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
   const handleSendCode = () => {
     if (!name || !loginId || !isValidEmail(email)) return;
 
+    setIsSendingCode(true);
     // TODO: API 연동 시 구현
-    setCodeSent(true);
-    setTimer(180); // 3분
-    setError('');
-    setAuthCode('');
-    setIsVerified(false);
+    setTimeout(() => {
+      setCodeSent(true);
+      setTimer(180); // 3분
+      setError('');
+      setAuthCode('');
+      setIsVerified(false);
+      setIsSendingCode(false);
+    }, 500);
   };
 
   // 인증번호 확인 (임시 구현 - API 연동 전)
   const handleVerifyCode = () => {
     if (!authCode) return;
 
+    setIsVerifyingCode(true);
     // TODO: API 연동 시 구현
-    setIsVerified(true);
-    setError('');
+    setTimeout(() => {
+      setIsVerified(true);
+      setError('');
+      setIsVerifyingCode(false);
+    }, 500);
   };
 
   // 비밀번호 재설정 진행
@@ -137,14 +147,11 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
           <div className="flex gap-2 items-center">
             <input
               type="email"
-              className={`flex-1 border border-gray-400 rounded-xl px-4 h-[49px] text-body-2-medium placeholder:text-gray-600 focus:outline-none tracking-tight ${
-                codeSent ? 'bg-gray-100 text-gray-700' : 'bg-white text-gray-900'
-              }`}
+              className="flex-1 border border-gray-400 rounded-xl px-4 h-[49px] text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none tracking-tight bg-white"
               placeholder="이메일을 입력해주세요"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               maxLength={50}
-              disabled={codeSent && !isVerified}
             />
             <button
               type="button"
@@ -156,9 +163,17 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
                     : 'bg-gray-200 text-gray-600 cursor-not-allowed'
               }`}
               onClick={handleSendCode}
-              disabled={(!name || !loginId || !isValidEmail(email)) && !codeSent}
+              disabled={((!name || !loginId || !isValidEmail(email)) && !codeSent) || isSendingCode}
             >
-              {codeSent ? '다시받기' : '인증하기'}
+              {isSendingCode ? (
+                <div className="flex justify-center">
+                  <div className="w-5 h-5 border-2 border-blue-700 border-t-transparent rounded-full animate-spin" />
+                </div>
+              ) : codeSent ? (
+                '다시받기'
+              ) : (
+                '인증하기'
+              )}
             </button>
           </div>
         </div>
@@ -198,9 +213,17 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
                       : 'bg-gray-200 text-gray-600 cursor-not-allowed'
                 }`}
                 onClick={handleVerifyCode}
-                disabled={authCode.length < 4 || isVerified}
+                disabled={authCode.length < 4 || isVerified || isVerifyingCode}
               >
-                {isVerified ? '인증완료' : '확인하기'}
+                {isVerifyingCode ? (
+                  <div className="flex justify-center">
+                    <div className="w-5 h-5 border-2 border-blue-700 border-t-transparent rounded-full animate-spin" />
+                  </div>
+                ) : isVerified ? (
+                  '인증완료'
+                ) : (
+                  '확인하기'
+                )}
               </button>
             </div>
             {error && <p className="text-caption-1-medium text-error tracking-tight">{error}</p>}
@@ -220,4 +243,3 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
     </div>
   );
 };
-

--- a/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
@@ -209,20 +209,20 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
               )}
             </button>
           </div>
-        </div>
 
-        {/* 인증번호 입력 (인증번호 발송 후에만 표시) */}
-        {codeSent && (
-          <AuthCodeInputWithTimer
-            authCode={authCode}
-            onAuthCodeChange={handleAuthCodeChange}
-            timer={timer}
-            isVerified={isVerified}
-            error={error}
-            isLoading={verifyCodeMutation.isPending}
-            onVerify={handleVerifyCode}
-          />
-        )}
+          {/* 인증번호 입력 (인증번호 발송 후에만 표시) */}
+          {codeSent && (
+            <AuthCodeInputWithTimer
+              authCode={authCode}
+              onAuthCodeChange={handleAuthCodeChange}
+              timer={timer}
+              isVerified={isVerified}
+              error={error}
+              isLoading={verifyCodeMutation.isPending}
+              onVerify={handleVerifyCode}
+            />
+          )}
+        </div>
 
         {/* 하단 버튼 */}
         <div className="mt-auto mb-[42px]">

--- a/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
 import { FixedBottomButton } from '@/src/components/signup';
-import { useSendResetPasswordCode, useVerifyEmailCode, useVerifyResetPassword } from '@/src/hooks/queries';
+import { useSendResetPasswordCode, useVerifyResetPassword } from '@/src/hooks/queries';
 
 interface StepInputProps {
   goNext: (name: string, loginId: string, email: string) => void;
@@ -16,7 +16,6 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
 
   // React Query Hooks
   const sendCodeMutation = useSendResetPasswordCode();
-  const verifyCodeMutation = useVerifyEmailCode();
   const verifyResetMutation = useVerifyResetPassword();
 
   // 입력 상태
@@ -90,12 +89,12 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
     );
   }, [name, loginId, email, sendCodeMutation, goSocialUser]);
 
-  // 인증번호 확인
+  // 인증번호 확인 및 사용자 정보 검증
   const handleVerifyCode = useCallback(() => {
-    if (!authCode) return;
+    if (!authCode || authCode.length < 4) return;
 
-    verifyCodeMutation.mutate(
-      { email, authCode, type: 'FIND_PASSWORD' },
+    verifyResetMutation.mutate(
+      { name, loginId, email },
       {
         onSuccess: (response) => {
           if (response.isSuccess) {
@@ -103,32 +102,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
             setError('');
           } else {
             setIsVerified(false);
-            setError(response.message || '인증번호가 일치하지 않습니다.');
-          }
-        },
-        onError: (error: unknown) => {
-          const axiosError = error as {
-            response?: { data?: { message?: string } };
-          };
-          const errorMessage = axiosError.response?.data?.message || '인증번호 검증 중 오류가 발생했습니다.';
-          setError(errorMessage);
-        },
-      },
-    );
-  }, [email, authCode, verifyCodeMutation]);
-
-  // 비밀번호 재설정 진행
-  const handleNextStep = useCallback(() => {
-    if (!isVerified) return;
-
-    verifyResetMutation.mutate(
-      { name, loginId, email },
-      {
-        onSuccess: (response) => {
-          if (response.isSuccess) {
-            goNext(name, loginId, email);
-          } else {
-            alert(response.message || '사용자 정보 검증에 실패했습니다.');
+            setError(response.message || '사용자 정보 검증에 실패했습니다.');
           }
         },
         onError: (error: unknown) => {
@@ -136,11 +110,17 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
             response?: { data?: { message?: string } };
           };
           const errorMessage = axiosError.response?.data?.message || '사용자 정보 검증 중 오류가 발생했습니다.';
-          alert(errorMessage);
+          setError(errorMessage);
         },
       },
     );
-  }, [isVerified, name, loginId, email, verifyResetMutation, goNext]);
+  }, [name, loginId, email, authCode, verifyResetMutation]);
+
+  // 비밀번호 재설정 진행
+  const handleNextStep = useCallback(() => {
+    if (!isVerified) return;
+    goNext(name, loginId, email);
+  }, [isVerified, name, loginId, email, goNext]);
 
   // 뒤로가기
   const handleBack = () => {
@@ -268,9 +248,9 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
                       : 'bg-gray-200 text-gray-600 cursor-not-allowed'
                 }`}
                 onClick={handleVerifyCode}
-                disabled={authCode.length < 4 || isVerified || verifyCodeMutation.isPending}
+                disabled={authCode.length < 4 || isVerified || verifyResetMutation.isPending}
               >
-                {verifyCodeMutation.isPending ? (
+                {verifyResetMutation.isPending ? (
                   <div className="flex justify-center">
                     <div className="w-5 h-5 border-2 border-blue-700 border-t-transparent rounded-full animate-spin" />
                   </div>
@@ -290,8 +270,8 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
 
         {/* 하단 버튼 */}
         <div className="mt-auto mb-[42px]">
-          <FixedBottomButton disabled={!isVerified || verifyResetMutation.isPending} onClick={handleNextStep}>
-            {verifyResetMutation.isPending ? '검증 중...' : '비밀번호 재설정'}
+          <FixedBottomButton disabled={!isVerified} onClick={handleNextStep}>
+            비밀번호 재설정
           </FixedBottomButton>
         </div>
       </form>

--- a/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
 import { FixedBottomButton } from '@/src/components/signup';
-import { useSendResetPasswordCode, useVerifyResetPassword } from '@/src/hooks/queries';
+import { useSendResetPasswordCode, useVerifyEmailCode, useVerifyResetPassword } from '@/src/hooks/queries';
 
 interface StepInputProps {
   goNext: (name: string, loginId: string, email: string) => void;
@@ -16,6 +16,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
 
   // React Query Hooks
   const sendCodeMutation = useSendResetPasswordCode();
+  const verifyCodeMutation = useVerifyEmailCode();
   const verifyResetMutation = useVerifyResetPassword();
 
   // 입력 상태
@@ -89,12 +90,12 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
     );
   }, [name, loginId, email, sendCodeMutation, goSocialUser]);
 
-  // 인증번호 확인 및 사용자 정보 검증
+  // 인증번호 확인
   const handleVerifyCode = useCallback(() => {
     if (!authCode || authCode.length < 4) return;
 
-    verifyResetMutation.mutate(
-      { name, loginId, email },
+    verifyCodeMutation.mutate(
+      { email, authCode, type: 'RESET_PASSWORD' },
       {
         onSuccess: (response) => {
           if (response.isSuccess) {
@@ -102,7 +103,32 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
             setError('');
           } else {
             setIsVerified(false);
-            setError(response.message || '사용자 정보 검증에 실패했습니다.');
+            setError(response.message || '인증번호가 일치하지 않습니다.');
+          }
+        },
+        onError: (error: unknown) => {
+          const axiosError = error as {
+            response?: { data?: { message?: string } };
+          };
+          const errorMessage = axiosError.response?.data?.message || '인증번호 검증 중 오류가 발생했습니다.';
+          setError(errorMessage);
+        },
+      },
+    );
+  }, [email, authCode, verifyCodeMutation]);
+
+  // 비밀번호 재설정 진행 (사용자 정보 검증)
+  const handleNextStep = useCallback(() => {
+    if (!isVerified) return;
+
+    verifyResetMutation.mutate(
+      { name, loginId, email },
+      {
+        onSuccess: (response) => {
+          if (response.isSuccess) {
+            goNext(name, loginId, email);
+          } else {
+            alert(response.message || '사용자 정보 검증에 실패했습니다.');
           }
         },
         onError: (error: unknown) => {
@@ -110,17 +136,11 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
             response?: { data?: { message?: string } };
           };
           const errorMessage = axiosError.response?.data?.message || '사용자 정보 검증 중 오류가 발생했습니다.';
-          setError(errorMessage);
+          alert(errorMessage);
         },
       },
     );
-  }, [name, loginId, email, authCode, verifyResetMutation]);
-
-  // 비밀번호 재설정 진행
-  const handleNextStep = useCallback(() => {
-    if (!isVerified) return;
-    goNext(name, loginId, email);
-  }, [isVerified, name, loginId, email, goNext]);
+  }, [isVerified, name, loginId, email, verifyResetMutation, goNext]);
 
   // 뒤로가기
   const handleBack = () => {
@@ -248,9 +268,9 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
                       : 'bg-gray-200 text-gray-600 cursor-not-allowed'
                 }`}
                 onClick={handleVerifyCode}
-                disabled={authCode.length < 4 || isVerified || verifyResetMutation.isPending}
+                disabled={authCode.length < 4 || isVerified || verifyCodeMutation.isPending}
               >
-                {verifyResetMutation.isPending ? (
+                {verifyCodeMutation.isPending ? (
                   <div className="flex justify-center">
                     <div className="w-5 h-5 border-2 border-blue-700 border-t-transparent rounded-full animate-spin" />
                   </div>
@@ -270,8 +290,8 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
 
         {/* 하단 버튼 */}
         <div className="mt-auto mb-[42px]">
-          <FixedBottomButton disabled={!isVerified} onClick={handleNextStep}>
-            비밀번호 재설정
+          <FixedBottomButton disabled={!isVerified || verifyResetMutation.isPending} onClick={handleNextStep}>
+            {verifyResetMutation.isPending ? '검증 중...' : '비밀번호 재설정'}
           </FixedBottomButton>
         </div>
       </form>

--- a/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
 import { FixedBottomButton } from '@/src/components/signup';
 import { PasswordInput } from '@/src/components/signup/4-LoginInfo/PasswordInput';
 import { useResetPassword } from '@/src/hooks/queries';
+import { usePasswordValidation } from '@/src/hooks/auth/find-password';
+import { AuthHeader } from '@/src/components/auth';
 
 interface StepNewPasswordProps {
   email: string;
@@ -22,48 +23,12 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
 
-  // 비밀번호 유효성 검증
-  const validatePassword = (password: string) => {
-    // 영문 대소문자, 숫자, 특수문자(~!@#$%) 중 3종 이상 포함
-    const hasLowerCase = /[a-z]/.test(password);
-    const hasUpperCase = /[A-Z]/.test(password);
-    const hasNumber = /[0-9]/.test(password);
-    const hasSpecialChar = /[~!@#$%]/.test(password);
-
-    const typesCount = [hasLowerCase, hasUpperCase, hasNumber, hasSpecialChar].filter(Boolean).length;
-
-    if (password.length < 8 || password.length > 20) {
-      return false;
-    }
-
-    if (typesCount < 3) {
-      return false;
-    }
-
-    return true;
-  };
-
-  // 유효성 상태 - useMemo로 계산
-  const newPasswordError = useMemo(() => {
-    if (newPassword === '') {
-      return null;
-    }
-    return validatePassword(newPassword) ? 'success' : 'error';
-  }, [newPassword]);
-
-  const confirmPasswordError = useMemo(() => {
-    if (confirmPassword === '') {
-      return null;
-    }
-    return newPassword === confirmPassword ? 'success' : 'error';
-  }, [newPassword, confirmPassword]);
-
-  // 완료 버튼 활성화 조건
-  const isFormValid = newPasswordError === 'success' && confirmPasswordError === 'success';
+  // Custom Hook - 비밀번호 검증
+  const { newPasswordError, confirmPasswordError, isValid } = usePasswordValidation(newPassword, confirmPassword);
 
   // 비밀번호 변경 완료
   const handleComplete = useCallback(() => {
-    if (!isFormValid) return;
+    if (!isValid) return;
 
     resetPasswordMutation.mutate(
       { email, newPassword },
@@ -84,21 +49,12 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
         },
       },
     );
-  }, [isFormValid, email, newPassword, resetPasswordMutation, goNext]);
-
-  // 뒤로가기
-  const handleBack = () => {
-    router.back();
-  };
+  }, [isValid, email, newPassword, resetPasswordMutation, goNext]);
 
   return (
     <div className="min-h-screen flex flex-col bg-white">
       {/* 헤더 */}
-      <div className="mt-15 mx-4">
-        <button type="button" onClick={handleBack} className="w-6 h-6 flex items-center justify-center cursor-pointer">
-          <LeftArrowIcon />
-        </button>
-      </div>
+      <AuthHeader onBack={() => router.back()} />
 
       {/* 제목 */}
       <div className="mt-4 mx-4">
@@ -132,7 +88,7 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
 
         {/* 하단 버튼 */}
         <div className="mt-auto mb-[42px]">
-          <FixedBottomButton disabled={!isFormValid || resetPasswordMutation.isPending} onClick={handleComplete}>
+          <FixedBottomButton disabled={!isValid || resetPasswordMutation.isPending} onClick={handleComplete}>
             {resetPasswordMutation.isPending ? '변경 중...' : '완료'}
           </FixedBottomButton>
         </div>

--- a/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
@@ -119,7 +119,7 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
 
       {/* 제목 */}
       <div className="mt-4 mx-4">
-        <h1 className="text-head-3-semibold text-gray-900 tracking-tight">새로운 비밀번호</h1>
+        <h1 className="text-body-1-medium tracking-tight">새로운 비밀번호</h1>
       </div>
 
       {/* 입력 폼 */}
@@ -131,9 +131,9 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
           onChange={setNewPassword}
           placeholder="비밀번호를 입력해주세요"
           error={newPasswordError}
-          errorMessage="영문 대소문자, 숫자, 특수문자(~!@#$%) 중 3종 이상 8자 이상이어야 합니다."
-          hintMessage="영문 대소문자, 숫자, 특수문자(~!@#$%) 중 3종 이상 8자 이상이어야 합니다."
-          successMessage="비밀번호가 일치합니다."
+          errorMessage="영문 대소문자, 숫자, 특수문자(~!@#^*) 조합 8자 이상이어야 합니다."
+          hintMessage="영문 대소문자, 숫자, 특수문자(~!@#^*) 조합 8자 이상이어야 합니다."
+          successMessage="사용 가능한 비밀번호입니다."
         />
 
         {/* 비밀번호 확인 */}
@@ -157,4 +157,3 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
     </div>
   );
 };
-

--- a/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
 import { FixedBottomButton } from '@/src/components/signup';
 import { PasswordInput } from '@/src/components/signup/4-LoginInfo/PasswordInput';
+import { useResetPassword } from '@/src/hooks/queries';
 
 interface StepNewPasswordProps {
   email: string;
@@ -13,6 +14,9 @@ interface StepNewPasswordProps {
 
 export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext }) => {
   const router = useRouter();
+
+  // React Query Hook
+  const resetPasswordMutation = useResetPassword();
 
   // 비밀번호 상태
   const [newPassword, setNewPassword] = useState('');
@@ -75,12 +79,29 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
   const isFormValid = newPasswordError === 'success' && confirmPasswordError === 'success';
 
   // 비밀번호 변경 완료
-  const handleComplete = () => {
+  const handleComplete = useCallback(() => {
     if (!isFormValid) return;
 
-    // TODO: API 연동 시 구현
-    goNext();
-  };
+    resetPasswordMutation.mutate(
+      { email, newPassword },
+      {
+        onSuccess: (response) => {
+          if (response.isSuccess) {
+            goNext();
+          } else {
+            alert(response.message || '비밀번호 변경에 실패했습니다.');
+          }
+        },
+        onError: (error: unknown) => {
+          const axiosError = error as {
+            response?: { data?: { message?: string } };
+          };
+          const errorMessage = axiosError.response?.data?.message || '비밀번호 변경 중 오류가 발생했습니다.';
+          alert(errorMessage);
+        },
+      },
+    );
+  }, [isFormValid, email, newPassword, resetPasswordMutation, goNext]);
 
   // 뒤로가기
   const handleBack = () => {
@@ -128,8 +149,8 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
 
         {/* 하단 버튼 */}
         <div className="mt-auto mb-[42px]">
-          <FixedBottomButton disabled={!isFormValid} onClick={handleComplete}>
-            완료
+          <FixedBottomButton disabled={!isFormValid || resetPasswordMutation.isPending} onClick={handleComplete}>
+            {resetPasswordMutation.isPending ? '변경 중...' : '완료'}
           </FixedBottomButton>
         </div>
       </form>

--- a/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
+import { FixedBottomButton } from '@/src/components/signup';
+import { PasswordInput } from '@/src/components/signup/4-LoginInfo/PasswordInput';
+
+interface StepNewPasswordProps {
+  email: string;
+  goNext: () => void;
+}
+
+export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext }) => {
+  const router = useRouter();
+
+  // 비밀번호 상태
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+
+  // 유효성 상태
+  const [newPasswordError, setNewPasswordError] = useState<string | null>(null);
+  const [confirmPasswordError, setConfirmPasswordError] = useState<string | null>(null);
+
+  // 비밀번호 유효성 검증
+  const validatePassword = (password: string) => {
+    // 영문 대소문자, 숫자, 특수문자(~!@#$%) 중 3종 이상 포함
+    const hasLowerCase = /[a-z]/.test(password);
+    const hasUpperCase = /[A-Z]/.test(password);
+    const hasNumber = /[0-9]/.test(password);
+    const hasSpecialChar = /[~!@#$%]/.test(password);
+
+    const typesCount = [hasLowerCase, hasUpperCase, hasNumber, hasSpecialChar].filter(Boolean).length;
+
+    if (password.length < 8 || password.length > 20) {
+      return false;
+    }
+
+    if (typesCount < 3) {
+      return false;
+    }
+
+    return true;
+  };
+
+  // 새 비밀번호 변경 핸들러
+  useEffect(() => {
+    if (newPassword === '') {
+      setNewPasswordError(null);
+      return;
+    }
+
+    if (validatePassword(newPassword)) {
+      setNewPasswordError('success');
+    } else {
+      setNewPasswordError('error');
+    }
+  }, [newPassword]);
+
+  // 비밀번호 확인 변경 핸들러
+  useEffect(() => {
+    if (confirmPassword === '') {
+      setConfirmPasswordError(null);
+      return;
+    }
+
+    if (newPassword === confirmPassword) {
+      setConfirmPasswordError('success');
+    } else {
+      setConfirmPasswordError('error');
+    }
+  }, [newPassword, confirmPassword]);
+
+  // 완료 버튼 활성화 조건
+  const isFormValid = newPasswordError === 'success' && confirmPasswordError === 'success';
+
+  // 비밀번호 변경 완료
+  const handleComplete = () => {
+    if (!isFormValid) return;
+
+    // TODO: API 연동 시 구현
+    goNext();
+  };
+
+  // 뒤로가기
+  const handleBack = () => {
+    router.back();
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-white">
+      {/* 헤더 */}
+      <div className="mt-15 mx-4">
+        <button type="button" onClick={handleBack} className="w-6 h-6 flex items-center justify-center cursor-pointer">
+          <LeftArrowIcon />
+        </button>
+      </div>
+
+      {/* 제목 */}
+      <div className="mt-4 mx-4">
+        <h1 className="text-head-3-semibold text-gray-900 tracking-tight">새로운 비밀번호</h1>
+      </div>
+
+      {/* 입력 폼 */}
+      <form className="flex flex-col gap-6 mt-8 mx-4 flex-1" onSubmit={(e) => e.preventDefault()}>
+        {/* 새 비밀번호 입력 */}
+        <PasswordInput
+          label="새로운 비밀번호"
+          value={newPassword}
+          onChange={setNewPassword}
+          placeholder="비밀번호를 입력해주세요"
+          error={newPasswordError}
+          errorMessage="영문 대소문자, 숫자, 특수문자(~!@#$%) 중 3종 이상 8자 이상이어야 합니다."
+          hintMessage="영문 대소문자, 숫자, 특수문자(~!@#$%) 중 3종 이상 8자 이상이어야 합니다."
+          successMessage="비밀번호가 일치합니다."
+        />
+
+        {/* 비밀번호 확인 */}
+        <PasswordInput
+          label="비밀번호 확인"
+          value={confirmPassword}
+          onChange={setConfirmPassword}
+          placeholder="비밀번호를 입력해주세요"
+          error={confirmPasswordError}
+          errorMessage="비밀번호가 일치하지 않습니다."
+          successMessage="비밀번호가 일치합니다."
+        />
+
+        {/* 하단 버튼 */}
+        <div className="mt-auto mb-[42px]">
+          <FixedBottomButton disabled={!isFormValid} onClick={handleComplete}>
+            완료
+          </FixedBottomButton>
+        </div>
+      </form>
+    </div>
+  );
+};
+

--- a/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
 import { FixedBottomButton } from '@/src/components/signup';
@@ -21,10 +21,6 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
   // 비밀번호 상태
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-
-  // 유효성 상태
-  const [newPasswordError, setNewPasswordError] = useState<string | null>(null);
-  const [confirmPasswordError, setConfirmPasswordError] = useState<string | null>(null);
 
   // 비밀번호 유효성 검증
   const validatePassword = (password: string) => {
@@ -47,32 +43,19 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
     return true;
   };
 
-  // 새 비밀번호 변경 핸들러
-  useEffect(() => {
+  // 유효성 상태 - useMemo로 계산
+  const newPasswordError = useMemo(() => {
     if (newPassword === '') {
-      setNewPasswordError(null);
-      return;
+      return null;
     }
-
-    if (validatePassword(newPassword)) {
-      setNewPasswordError('success');
-    } else {
-      setNewPasswordError('error');
-    }
+    return validatePassword(newPassword) ? 'success' : 'error';
   }, [newPassword]);
 
-  // 비밀번호 확인 변경 핸들러
-  useEffect(() => {
+  const confirmPasswordError = useMemo(() => {
     if (confirmPassword === '') {
-      setConfirmPasswordError(null);
-      return;
+      return null;
     }
-
-    if (newPassword === confirmPassword) {
-      setConfirmPasswordError('success');
-    } else {
-      setConfirmPasswordError('error');
-    }
+    return newPassword === confirmPassword ? 'success' : 'error';
   }, [newPassword, confirmPassword]);
 
   // 완료 버튼 활성화 조건

--- a/src/app/(auth)/find-password/_funnel/steps/3-Complete.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/3-Complete.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import SignupCompletedIcon from '@/public/icons/signup/signup-completed.svg';
+
+export const StepComplete: React.FC = () => {
+  const router = useRouter();
+
+  const handleGoToLogin = () => {
+    router.push('/login');
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-white px-4">
+      <div className="flex flex-col items-center gap-5 mb-[84px]">
+        <div className="relative w-[50px] h-[50px]">
+          <SignupCompletedIcon />
+        </div>
+        <div className="flex flex-col items-center gap-1">
+          <p className="text-gray-900 text-head-3-semibold text-center tracking-tight">
+            비밀번호 변경이 완료되었어요
+          </p>
+        </div>
+      </div>
+      <button
+        onClick={handleGoToLogin}
+        className="fixed bottom-[42px] left-1/2 -translate-x-1/2 w-[343px] py-4 bg-gray-900 text-white rounded-full text-body-1-medium cursor-pointer tracking-tight"
+      >
+        로그인 화면으로 이동
+      </button>
+    </div>
+  );
+};
+

--- a/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import SignupCompletedIcon from '@/public/icons/signup/signup-completed.svg';
+
+interface StepSocialUserProps {
+  name: string;
+  loginType: string;
+}
+
+export const StepSocialUser: React.FC<StepSocialUserProps> = ({ name, loginType }) => {
+  const router = useRouter();
+
+  const handleGoToLogin = () => {
+    router.push('/login');
+  };
+
+  // loginType을 서비스명으로 변환
+  const getSocialServiceName = (type: string): string => {
+    const serviceMap: Record<string, string> = {
+      KAKAO: '카카오',
+      NAVER: '네이버',
+      GOOGLE: '구글',
+    };
+    return serviceMap[type] || type;
+  };
+
+  const serviceName = getSocialServiceName(loginType);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-white px-4">
+      <div className="flex flex-col items-center gap-5 mb-[84px]">
+        <div className="relative w-[50px] h-[50px]">
+          <SignupCompletedIcon />
+        </div>
+        <div className="flex flex-col items-center gap-1">
+          <p className="text-head-3-medium text-center tracking-tight">{name} 님은</p>
+          <div className="flex items-baseline gap-1">
+            <span className="text-head-2-semibold tracking-tight">{serviceName} 소셜 로그인 사용자</span>
+            <span className="text-head-3-medium tracking-tight">입니다</span>
+          </div>
+          <p className="text-body-1-medium text-gray-700 text-center tracking-tight mt-4">
+            해당 서비스로 로그인해주세요
+          </p>
+        </div>
+      </div>
+      <button
+        onClick={handleGoToLogin}
+        className="fixed bottom-[42px] left-1/2 -translate-x-1/2 w-[343px] py-4 bg-gray-900 text-white rounded-full text-body-1-medium cursor-pointer tracking-tight"
+      >
+        로그인 화면으로 이동
+      </button>
+    </div>
+  );
+};
+

--- a/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import SignupCompletedIcon from '@/public/icons/signup/signup-completed.svg';
+import { getSocialServiceName } from '@/src/utils/auth/common';
 
 interface StepSocialUserProps {
   name: string;
@@ -13,16 +14,6 @@ export const StepSocialUser: React.FC<StepSocialUserProps> = ({ name, loginType 
 
   const handleGoToLogin = () => {
     router.push('/login');
-  };
-
-  // loginType을 서비스명으로 변환
-  const getSocialServiceName = (type: string): string => {
-    const serviceMap: Record<string, string> = {
-      KAKAO: '카카오',
-      NAVER: '네이버',
-      GOOGLE: '구글',
-    };
-    return serviceMap[type] || type;
   };
 
   const serviceName = getSocialServiceName(loginType);
@@ -53,4 +44,3 @@ export const StepSocialUser: React.FC<StepSocialUserProps> = ({ name, loginType 
     </div>
   );
 };
-

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -1,0 +1,8 @@
+import { FindPasswordFunnel } from './_funnel/FindPasswordFunnel';
+
+const FindPasswordPage = () => {
+  return <FindPasswordFunnel />;
+};
+
+export default FindPasswordPage;
+

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -104,9 +104,13 @@ const LoginContent = () => {
 
         {/* 하단 링크 */}
         <div className="flex gap-4 text-gray-800 text-body-2-medium tracking-tight justify-center mb-20">
-          <span>아이디 찾기</span>
+          <Link href="/find-id" className="cursor-pointer hover:underline">
+            아이디 찾기
+          </Link>
           <span>|</span>
-          <span>비밀번호 찾기</span>
+          <Link href="/find-password" className="cursor-pointer hover:underline">
+            비밀번호 찾기
+          </Link>
           <span>|</span>
           <Link href="/signup" className="cursor-pointer hover:underline">
             회원가입

--- a/src/components/auth/common/AuthHeader.tsx
+++ b/src/components/auth/common/AuthHeader.tsx
@@ -1,0 +1,16 @@
+import LeftArrowIcon from '@/public/icons/signup/leftarrow.svg';
+
+interface AuthHeaderProps {
+  onBack: () => void;
+}
+
+/**
+ * 뒤로가기 버튼이 있는 인증 페이지 공통 헤더
+ */
+export const AuthHeader: React.FC<AuthHeaderProps> = ({ onBack }) => (
+  <div className="mt-15 mx-4">
+    <button type="button" onClick={onBack} className="w-6 h-6 flex items-center justify-center cursor-pointer">
+      <LeftArrowIcon />
+    </button>
+  </div>
+);

--- a/src/components/auth/common/Spinner.tsx
+++ b/src/components/auth/common/Spinner.tsx
@@ -1,0 +1,6 @@
+/**
+ * 로딩 스피너 컴포넌트
+ */
+export const Spinner = () => (
+  <div className="w-5 h-5 border-2 border-blue-700 border-t-transparent rounded-full animate-spin" />
+);

--- a/src/components/auth/common/index.ts
+++ b/src/components/auth/common/index.ts
@@ -1,0 +1,3 @@
+export * from './Spinner';
+export * from './AuthHeader';
+

--- a/src/components/auth/find-id/AuthCodeInputWithTimer.tsx
+++ b/src/components/auth/find-id/AuthCodeInputWithTimer.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { formatTime } from '@/src/utils/auth/find-id';
+import { Spinner } from '../common';
+
+interface AuthCodeInputWithTimerProps {
+  authCode: string;
+  onAuthCodeChange: (value: string) => void;
+  timer: number;
+  isVerified: boolean;
+  error: string;
+  isLoading: boolean;
+  onVerify: () => void;
+}
+
+/**
+ * 인증번호 입력 + 타이머 + 확인 버튼 컴포넌트
+ */
+export const AuthCodeInputWithTimer: React.FC<AuthCodeInputWithTimerProps> = ({
+  authCode,
+  onAuthCodeChange,
+  timer,
+  isVerified,
+  error,
+  isLoading,
+  onVerify,
+}) => {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex gap-2 items-center">
+        <div className="flex-1 relative">
+          <input
+            type="text"
+            className={`w-full border ${
+              error ? 'border-error' : 'border-gray-400'
+            } rounded-xl px-4 h-[49px] text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none tracking-tight`}
+            placeholder="인증번호 입력"
+            value={authCode}
+            onChange={(e) => onAuthCodeChange(e.target.value.replace(/[^0-9]/g, ''))}
+            maxLength={6}
+            disabled={isVerified}
+          />
+          {timer > 0 && !isVerified && (
+            <span className="absolute right-4 top-1/2 -translate-y-1/2 text-caption-1-medium text-gray-700">
+              {formatTime(timer)}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          className={`w-20 rounded-xl h-[49px] text-body-2-medium tracking-tight ${
+            isVerified
+              ? 'bg-gray-200 text-gray-600 cursor-not-allowed'
+              : authCode.length >= 4
+                ? 'bg-blue-200 text-blue-700 cursor-pointer'
+                : 'bg-gray-200 text-gray-600 cursor-not-allowed'
+          }`}
+          onClick={onVerify}
+          disabled={authCode.length < 4 || isVerified || isLoading}
+        >
+          {isLoading ? (
+            <div className="flex justify-center">
+              <Spinner />
+            </div>
+          ) : isVerified ? (
+            '인증완료'
+          ) : (
+            '확인하기'
+          )}
+        </button>
+      </div>
+      {error && <p className="text-caption-1-medium text-error tracking-tight">{error}</p>}
+      {isVerified && <p className="text-caption-1-medium text-blue-700 tracking-tight">인증번호가 확인되었습니다.</p>}
+    </div>
+  );
+};

--- a/src/components/auth/find-id/index.ts
+++ b/src/components/auth/find-id/index.ts
@@ -1,0 +1,2 @@
+export * from './AuthCodeInputWithTimer';
+

--- a/src/components/auth/find-password/AuthCodeInputWithTimer.tsx
+++ b/src/components/auth/find-password/AuthCodeInputWithTimer.tsx
@@ -1,0 +1,1 @@
+export * from '../find-id/AuthCodeInputWithTimer';

--- a/src/components/auth/find-password/index.ts
+++ b/src/components/auth/find-password/index.ts
@@ -1,0 +1,2 @@
+export * from './AuthCodeInputWithTimer';
+

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,0 +1,4 @@
+export * from './common';
+export * from './find-id';
+export * from './find-password';
+

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -5,6 +5,8 @@ export const PUBLIC_ROUTES = [
   '/',
   '/login',
   '/signup',
+  '/find-id', // 아이디 찾기
+  '/find-password', // 비밀번호 찾기
   '/auth/callback', // 소셜 로그인 콜백
 ];
 

--- a/src/hooks/auth/find-id/index.ts
+++ b/src/hooks/auth/find-id/index.ts
@@ -1,0 +1,1 @@
+export * from './useTimer';

--- a/src/hooks/auth/find-id/useTimer.ts
+++ b/src/hooks/auth/find-id/useTimer.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+/**
+ * 타이머 카운트다운 상태 관리 훅
+ */
+export const useTimer = () => {
+  const [timer, setTimer] = useState(0);
+
+  useEffect(() => {
+    if (timer > 0) {
+      const interval = setInterval(() => {
+        setTimer((prev) => prev - 1);
+      }, 1000);
+      return () => clearInterval(interval);
+    }
+  }, [timer]);
+
+  return {
+    timer,
+    startTimer: (seconds: number) => setTimer(seconds),
+    resetTimer: () => setTimer(0),
+  };
+};

--- a/src/hooks/auth/find-password/index.ts
+++ b/src/hooks/auth/find-password/index.ts
@@ -1,0 +1,3 @@
+export * from './useTimer';
+export * from './usePasswordValidation';
+

--- a/src/hooks/auth/find-password/usePasswordValidation.ts
+++ b/src/hooks/auth/find-password/usePasswordValidation.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useMemo } from 'react';
+import { validatePassword } from '@/src/utils/auth/find-password';
+
+/**
+ * 비밀번호 검증 상태 관리 훅
+ * useMemo로 계산하여 불필요한 재렌더링 방지
+ */
+export const usePasswordValidation = (newPassword: string, confirmPassword: string) => {
+  const newPasswordError = useMemo(() => {
+    if (!newPassword) return null;
+    return validatePassword(newPassword) ? 'success' : 'error';
+  }, [newPassword]);
+
+  const confirmPasswordError = useMemo(() => {
+    if (!confirmPassword) return null;
+    return newPassword === confirmPassword ? 'success' : 'error';
+  }, [newPassword, confirmPassword]);
+
+  return {
+    newPasswordError,
+    confirmPasswordError,
+    isValid: newPasswordError === 'success' && confirmPasswordError === 'success',
+  };
+};
+

--- a/src/hooks/auth/find-password/useTimer.ts
+++ b/src/hooks/auth/find-password/useTimer.ts
@@ -1,0 +1,2 @@
+export * from '../find-id/useTimer';
+

--- a/src/hooks/queries/auth/index.ts
+++ b/src/hooks/queries/auth/index.ts
@@ -1,2 +1,3 @@
 export * from './useAuth';
 export * from './useFindId';
+export * from './useResetPassword';

--- a/src/hooks/queries/auth/index.ts
+++ b/src/hooks/queries/auth/index.ts
@@ -1,1 +1,2 @@
 export * from './useAuth';
+export * from './useFindId';

--- a/src/hooks/queries/auth/useFindId.ts
+++ b/src/hooks/queries/auth/useFindId.ts
@@ -1,0 +1,39 @@
+import { useMutation } from '@tanstack/react-query';
+import { sendFindIdCode, verifyEmailCode, findId } from '@/src/apis';
+import type {
+  SendFindIdCodeRequest,
+  SendFindIdCodeResponse,
+  VerifyEmailCodeRequest,
+  VerifyEmailCodeResponse,
+  FindIdRequest,
+  FindIdResponse,
+  ApiResponse,
+} from '@/src/types';
+
+/**
+ * 아이디 찾기 - 인증번호 발송 mutation hook
+ */
+export function useSendFindIdCode() {
+  return useMutation<ApiResponse<SendFindIdCodeResponse>, Error, SendFindIdCodeRequest>({
+    mutationFn: sendFindIdCode,
+  });
+}
+
+/**
+ * 이메일 인증번호 검증 mutation hook
+ */
+export function useVerifyEmailCode() {
+  return useMutation<ApiResponse<VerifyEmailCodeResponse>, Error, VerifyEmailCodeRequest>({
+    mutationFn: verifyEmailCode,
+  });
+}
+
+/**
+ * 아이디 찾기 - 사용자 정보 조회 mutation hook
+ */
+export function useFindId() {
+  return useMutation<ApiResponse<FindIdResponse>, Error, FindIdRequest>({
+    mutationFn: findId,
+  });
+}
+

--- a/src/hooks/queries/auth/useResetPassword.ts
+++ b/src/hooks/queries/auth/useResetPassword.ts
@@ -1,0 +1,38 @@
+import { useMutation } from '@tanstack/react-query';
+import { sendResetPasswordCode, verifyResetPassword, resetPassword } from '@/src/apis';
+import type {
+  SendResetPasswordCodeRequest,
+  SendResetPasswordCodeResponse,
+  VerifyResetPasswordRequest,
+  VerifyResetPasswordResponse,
+  ResetPasswordRequest,
+  ResetPasswordResponse,
+  ApiResponse,
+} from '@/src/types';
+
+/**
+ * 비밀번호 재설정 - 인증번호 발송 mutation hook
+ */
+export function useSendResetPasswordCode() {
+  return useMutation<ApiResponse<SendResetPasswordCodeResponse>, Error, SendResetPasswordCodeRequest>({
+    mutationFn: sendResetPasswordCode,
+  });
+}
+
+/**
+ * 비밀번호 재설정 - 사용자 정보 검증 mutation hook
+ */
+export function useVerifyResetPassword() {
+  return useMutation<ApiResponse<VerifyResetPasswordResponse>, Error, VerifyResetPasswordRequest>({
+    mutationFn: verifyResetPassword,
+  });
+}
+
+/**
+ * 비밀번호 재설정 - 새로운 비밀번호로 변경 mutation hook
+ */
+export function useResetPassword() {
+  return useMutation<ApiResponse<ResetPasswordResponse>, Error, ResetPasswordRequest>({
+    mutationFn: resetPassword,
+  });
+}

--- a/src/types/auth/findId.ts
+++ b/src/types/auth/findId.ts
@@ -1,0 +1,35 @@
+// 아이디 찾기 API 관련 타입
+
+// 1) 아이디 찾기 - 인증번호 발송
+export interface SendFindIdCodeRequest {
+  name: string;
+  email: string;
+}
+
+export interface SendFindIdCodeResponse {
+  message: string;
+}
+
+// 2) 이메일 인증번호 검증
+export interface VerifyEmailCodeRequest {
+  email: string;
+  authCode: string;
+  type: 'FIND_ID' | 'FIND_PASSWORD' | 'SIGNUP';
+}
+
+export interface VerifyEmailCodeResponse {
+  message: string;
+}
+
+// 3) 아이디 찾기 - 사용자 정보 조회
+export interface FindIdRequest {
+  name: string;
+  email: string;
+}
+
+export interface FindIdResponse {
+  loginType: string; // 'JWT', 'KAKAO', 'NAVER', 'GOOGLE' 등
+  name: string;
+  loginId: string;
+  email: string;
+}

--- a/src/types/auth/findId.ts
+++ b/src/types/auth/findId.ts
@@ -14,7 +14,7 @@ export interface SendFindIdCodeResponse {
 export interface VerifyEmailCodeRequest {
   email: string;
   authCode: string;
-  type: 'FIND_ID' | 'FIND_PASSWORD' | 'SIGNUP';
+  type: 'FIND_ID' | 'RESET_PASSWORD' | 'SIGNUP';
 }
 
 export interface VerifyEmailCodeResponse {

--- a/src/types/auth/index.ts
+++ b/src/types/auth/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './signup';
 export * from './findId';
+export * from './resetPassword';

--- a/src/types/auth/index.ts
+++ b/src/types/auth/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
 export * from './signup';
+export * from './findId';

--- a/src/types/auth/resetPassword.ts
+++ b/src/types/auth/resetPassword.ts
@@ -1,0 +1,33 @@
+// 비밀번호 재설정 API 관련 타입
+
+// 1) 비밀번호 재설정 - 인증번호 발송
+export interface SendResetPasswordCodeRequest {
+  name: string;
+  loginId: string;
+  email: string;
+}
+
+export interface SendResetPasswordCodeResponse {
+  message: string;
+}
+
+// 2) 비밀번호 재설정 - 사용자 정보 검증
+export interface VerifyResetPasswordRequest {
+  name: string;
+  loginId: string;
+  email: string;
+}
+
+export interface VerifyResetPasswordResponse {
+  message: string;
+}
+
+// 3) 비밀번호 재설정 - 새로운 비밀번호로 변경
+export interface ResetPasswordRequest {
+  email: string;
+  newPassword: string;
+}
+
+export interface ResetPasswordResponse {
+  message: string;
+}

--- a/src/utils/auth/common.ts
+++ b/src/utils/auth/common.ts
@@ -1,0 +1,12 @@
+/**
+ * 소셜 로그인 타입을 한글 서비스명으로 변환
+ */
+export const getSocialServiceName = (loginType: string): string => {
+  const serviceMap: Record<string, string> = {
+    KAKAO: '카카오',
+    NAVER: '네이버',
+    GOOGLE: '구글',
+  };
+  return serviceMap[loginType] || loginType;
+};
+

--- a/src/utils/auth/find-id/format.ts
+++ b/src/utils/auth/find-id/format.ts
@@ -1,0 +1,8 @@
+/**
+ * 타이머 시간 포맷팅 (MM:SS)
+ */
+export const formatTime = (seconds: number): string => {
+  const min = Math.floor(seconds / 60);
+  const sec = seconds % 60;
+  return `${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;
+};

--- a/src/utils/auth/find-id/index.ts
+++ b/src/utils/auth/find-id/index.ts
@@ -1,0 +1,3 @@
+export * from './validation';
+export * from './format';
+

--- a/src/utils/auth/find-id/validation.ts
+++ b/src/utils/auth/find-id/validation.ts
@@ -1,0 +1,8 @@
+/**
+ * 이메일 형식 검증
+ */
+export const validateEmail = (email: string): boolean => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+};
+

--- a/src/utils/auth/find-password/format.ts
+++ b/src/utils/auth/find-password/format.ts
@@ -1,0 +1,2 @@
+export * from '../find-id/format';
+

--- a/src/utils/auth/find-password/index.ts
+++ b/src/utils/auth/find-password/index.ts
@@ -1,0 +1,3 @@
+export * from './validation';
+export * from './format';
+

--- a/src/utils/auth/find-password/validation.ts
+++ b/src/utils/auth/find-password/validation.ts
@@ -1,0 +1,18 @@
+export * from '../find-id/validation';
+
+/**
+ * 비밀번호 유효성 검증
+ * 영문 대소문자, 숫자, 특수문자(~!@#$%) 중 3종 이상 포함
+ * 8자 이상 20자 이하
+ */
+export const validatePassword = (password: string): boolean => {
+  const hasLowerCase = /[a-z]/.test(password);
+  const hasUpperCase = /[A-Z]/.test(password);
+  const hasNumber = /[0-9]/.test(password);
+  const hasSpecialChar = /[~!@#$%]/.test(password);
+
+  const typesCount = [hasLowerCase, hasUpperCase, hasNumber, hasSpecialChar].filter(Boolean).length;
+
+  return password.length >= 8 && password.length <= 20 && typesCount >= 3;
+};
+

--- a/src/utils/auth/index.ts
+++ b/src/utils/auth/index.ts
@@ -1,1 +1,2 @@
 export * from './socialLogin';
+export * from './common';

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Authentication', () => {
+  test('should load login page', async ({ page }) => {
+    await page.goto('http://localhost:3000/auth/login');
+    await expect(page).toHaveTitle(/Modelly/);
+  });
+
+  test('should load signup page', async ({ page }) => {
+    await page.goto('http://localhost:3000/auth/signup');
+    await expect(page).toHaveTitle(/Modelly/);
+  });
+
+  test('should load find-id page', async ({ page }) => {
+    await page.goto('http://localhost:3000/auth/find-id');
+    await expect(page).toHaveTitle(/Modelly/);
+  });
+
+  test('should load find-password page', async ({ page }) => {
+    await page.goto('http://localhost:3000/auth/find-password');
+    await expect(page).toHaveTitle(/Modelly/);
+  });
+});

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -2,22 +2,22 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Authentication', () => {
   test('should load login page', async ({ page }) => {
-    await page.goto('http://localhost:3000/auth/login');
+    await page.goto('http://localhost:3000/login');
     await expect(page).toHaveTitle(/Modelly/);
   });
 
   test('should load signup page', async ({ page }) => {
-    await page.goto('http://localhost:3000/auth/signup');
+    await page.goto('http://localhost:3000/signup');
     await expect(page).toHaveTitle(/Modelly/);
   });
 
   test('should load find-id page', async ({ page }) => {
-    await page.goto('http://localhost:3000/auth/find-id');
+    await page.goto('http://localhost:3000/find-id');
     await expect(page).toHaveTitle(/Modelly/);
   });
 
   test('should load find-password page', async ({ page }) => {
-    await page.goto('http://localhost:3000/auth/find-password');
+    await page.goto('http://localhost:3000/find-password');
     await expect(page).toHaveTitle(/Modelly/);
   });
 });

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/);
+});
+
+test('get started link', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Click the get started link.
+  await page.getByRole('link', { name: 'Get started' }).click();
+
+  // Expects page to have a heading with the name of Installation.
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+});


### PR DESCRIPTION
### 💡 To Reviewers
- 새로 추가된 devDependency: `@playwright/test` (`package.json`), 실행 스크립트는 `npm run test|test:headed|test:ui`이며 브라우저 설치가 필요하면 `npx playwright install` 후 사용해 주세요. (이번주~다음주 혼자 작업할때 사용할 예정입니다. 사용 안해도 무관)
- find-id / find-password 퍼널은 백엔드 엔드포인트(`/auth/find-id/send-code`, `/auth/email/verify`, `/auth/reset-password` 등) 응답에 의존하니 동작 확인 시 API 연결 상태를 같이 점검해 주세요.
- 이메일 인증 입력/타이머는 `src/components/auth/find-id/AuthCodeInputWithTimer.tsx`로 공통화했고, 상단 백버튼(`src/components/auth/common/AuthHeader.tsx`)과 로더(`src/components/auth/common/Spinner.tsx`)를 공통 사용합니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- 아이디 찾기 퍼널 구현: 이름/이메일 입력 및 인증번호 발송·검증 후 결과 노출(`src/app/(auth)/find-id/_funnel/*`), React Query mutation(`useSendFindIdCode`, `useVerifyEmailCode`, `useFindId`)과 `src/apis/auth/findId.ts` 연동.
- 비밀번호 찾기 퍼널 구현: 이름·아이디·이메일 수집 후 인증번호 검증과 계정 확인(`useVerifyResetPassword`), 새 비밀번호 설정(`usePasswordValidation`, `useResetPassword`) 및 소셜 로그인 계정 안내 분기 추가(`src/app/(auth)/find-password/_funnel/*`, `src/apis/auth/resetPassword.ts`).
- 인증 공통 요소 추가: 상단 헤더/스피너, 인증 코드 입력+타이머 컴포넌트, 시간 포맷/타이머/이메일·비밀번호 유효성 유틸(`src/hooks/auth/find-id/useTimer.ts`, `src/utils/auth/find-id|find-password/*`).
- 라우팅/접근성 보완: 로그인 페이지 하단에 아이디·비밀번호 찾기 링크 연결(`src/app/(auth)/login/page.tsx`), 퍼블릭 라우트 정의에 find-id/find-password 추가(`src/constants/routes.ts`).
- E2E 준비: Playwright 설정(`playwright.config.ts`)과 기본 페이지 로드 스펙(`tests/auth.spec.ts`, `tests/example.spec.ts`) 추가, `.gitignore`에 Playwright 산출물/`.cursor/` 등록.

### 🤔 추후 작업 예정
- 인증번호 발송·검증 및 비밀번호 변경 흐름에 대한 Playwright E2E 시나리오를 확장하고, 실제/스테이징 백엔드와 연동된 테스트를 마련.
- 오류 메시지·UX 카피 정리 및 인코딩 깨짐/문구 통일성 점검 후 텍스트 리소스 관리화.
- 서버 응답 코드별 예외 처리(재시도, 타임아웃, rate limit)와 입력 검증(이메일 형식, 비밀번호 정책) 보강.


### 📸 작업 결과 (스크린샷)

<img width="1475" height="1032" alt="image" src="https://github.com/user-attachments/assets/6391dd73-9c6c-4a88-9b21-1e6de0ca7c38" />

<img width="1475" height="1032" alt="image" src="https://github.com/user-attachments/assets/1ca955ec-568a-42f1-ae00-e50c907e3780" />

<img width="1475" height="1032" alt="image" src="https://github.com/user-attachments/assets/972de723-bb93-44db-a040-c97e29652636" />

<img width="1475" height="1032" alt="image" src="https://github.com/user-attachments/assets/9efbb324-307c-48fc-b0fa-f505bd8e583b" />


### 🔗 관련 이슈

- #15 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 아이디 찾기 페이지 추가: 이름·이메일로 인증 코드 발송, 인증 및 아이디 확인 가능
  * 비밀번호 찾기 페이지 추가: 아이디·이메일로 인증 코드 발송, 인증 후 새 비밀번호 설정 가능
  * 로그인 화면에 아이디/비밀번호 찾기 링크 추가

* **UI/UX**
  * 인증 코드 입력 UI(타이머, 검증 버튼, 로딩) 및 공통 헤더/스피너 추가
  * 소셜 로그인 사용자 안내 화면 추가

* **Tests**
  * 인증 관련 Playwright e2e 테스트 추가

* **Chores**
  * 테스트 구성 및 실행 스크립트 추가, VCS 무시 항목 정리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->