### PR TITLE
[FEAT] 탐색 페이지 API 연동 및 SSR/CSR 구현

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -1,4 +1,5 @@
 import { useAuthStore, getAccessToken, setAccessToken } from '@/src/stores';
+import { apiLogger } from '@/src/utils';
 import axios from 'axios';
 
 // 인증 없이 접근 가능한 API
@@ -12,7 +13,7 @@ export const axiosInstance = axios.create({
   withCredentials: true, // refreshToken 쿠키 자동 전송
 });
 
-// Request Interceptor: 쿠키에서 accessToken 읽어서 헤더에 추가
+// Request Interceptor: 쿠키에서 accessToken 읽어서 헤더에 추가 + 로깅
 axiosInstance.interceptors.request.use(
   (config) => {
     const isNonAuthRequest = NON_AUTH_URLS.some((path) => config.url?.includes(path));
@@ -25,12 +26,15 @@ axiosInstance.interceptors.request.use(
       }
     }
 
+    // API 로깅 (NEXT_PUBLIC_API_LOGGING=true 일 때만 활성화)
+    apiLogger.request(config.method || 'GET', config.url || '', config.params || config.data);
+
     return config;
   },
   (error) => Promise.reject(error),
 );
 
-// Response Interceptor: 새 accessToken이 오면 쿠키에 저장
+// Response Interceptor: 새 accessToken이 오면 쿠키에 저장 + 로깅
 axiosInstance.interceptors.response.use(
   (response) => {
     const authHeader = response.headers['authorization'];
@@ -38,12 +42,19 @@ axiosInstance.interceptors.response.use(
       const newToken = authHeader.split(' ')[1];
       setAccessToken(newToken); // 쿠키에 저장
     }
+
+    // API 로깅 (성공)
+    apiLogger.response(response.config.url || '', response.status, response.data);
+
     return response;
   },
   (error) => {
     const { clearAuth } = useAuthStore.getState();
     const res = error.response;
     const code = res?.data?.serviceCode || res?.data?.data?.codeName || '';
+
+    // API 로깅 (에러)
+    apiLogger.error(res?.config?.url || '', res?.status || 0, res?.data || error.message);
 
     const shouldLogout =
       res?.status === 401 ||

--- a/src/apis/explore/designers.ts
+++ b/src/apis/explore/designers.ts
@@ -1,0 +1,80 @@
+import { axiosInstance } from '../axios';
+import { isMockEnabled } from '@/src/config/api';
+import { mockDesignerItems } from '@/src/mocks/explore';
+import type { ApiResponse, DesignerListParams, DesignerListResponse } from '@/src/types';
+
+const DEFAULT_PAGE_SIZE = 20;
+
+/**
+ * 디자이너 목록 조회
+ * GET /designers
+ */
+export async function getDesigners(
+  params: DesignerListParams = {}
+): Promise<ApiResponse<DesignerListResponse>> {
+  if (isMockEnabled('designers')) {
+    return getMockDesigners(params);
+  }
+
+  const { data } = await axiosInstance.get<ApiResponse<DesignerListResponse>>('/designers', {
+    params,
+  });
+  return data;
+}
+
+// ===== Mock 함수 =====
+
+function getMockDesigners(
+  params: DesignerListParams
+): Promise<ApiResponse<DesignerListResponse>> {
+  const { category, keyword, sortOption, cursorId, size = DEFAULT_PAGE_SIZE } = params;
+
+  // 필터링
+  let filtered = [...mockDesignerItems];
+
+  if (category) {
+    filtered = filtered.filter((item) => item.category === category);
+  }
+
+  if (keyword) {
+    const lowerKeyword = keyword.toLowerCase();
+    filtered = filtered.filter(
+      (item) =>
+        item.designerName.toLowerCase().includes(lowerKeyword) ||
+        item.shop.toLowerCase().includes(lowerKeyword)
+    );
+  }
+
+  // 정렬
+  switch (sortOption) {
+    case 'MOST_REVIEWS':
+      filtered.sort((a, b) => b.reviewCount - a.reviewCount);
+      break;
+    case 'DISTANCE':
+      filtered.sort((a, b) => a.distance - b.distance);
+      break;
+    case 'NEWEST':
+    default:
+      filtered.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      break;
+  }
+
+  // 커서 기반 페이징
+  const startIndex = cursorId
+    ? filtered.findIndex((item) => item.designerId === cursorId) + 1
+    : 0;
+  const items = filtered.slice(startIndex, startIndex + size);
+  const hasNext = startIndex + size < filtered.length;
+  const nextCursor = hasNext ? items[items.length - 1]?.designerId : 0;
+
+  return Promise.resolve({
+    isSuccess: true,
+    code: 'SUCCESS',
+    message: '디자이너 목록 조회 성공',
+    result: {
+      items,
+      hasNext,
+      nextCursor,
+    },
+  });
+}

--- a/src/apis/explore/index.ts
+++ b/src/apis/explore/index.ts
@@ -1,0 +1,2 @@
+export * from './recruitments';
+export * from './designers';

--- a/src/apis/explore/recruitments.ts
+++ b/src/apis/explore/recruitments.ts
@@ -1,0 +1,127 @@
+import { axiosInstance } from '../axios';
+import { isMockEnabled } from '@/src/config/api';
+import {
+  mockRecruitmentItems,
+  mockRecruitmentDetail,
+  mockRecruitmentDetail2,
+} from '@/src/mocks/explore';
+import type {
+  ApiResponse,
+  RecruitmentListParams,
+  RecruitmentListResponse,
+  RecruitmentDetail,
+} from '@/src/types';
+
+const DEFAULT_PAGE_SIZE = 20;
+
+/**
+ * 공고 목록 조회
+ * GET /recruitments
+ */
+export async function getRecruitments(
+  params: RecruitmentListParams = {}
+): Promise<ApiResponse<RecruitmentListResponse>> {
+  if (isMockEnabled('recruitments')) {
+    return getMockRecruitments(params);
+  }
+
+  const { data } = await axiosInstance.get<ApiResponse<RecruitmentListResponse>>(
+    '/recruitments',
+    { params }
+  );
+  return data;
+}
+
+/**
+ * 공고 상세 조회
+ * GET /recruitments/{recruitmentId}
+ */
+export async function getRecruitmentDetail(
+  recruitmentId: number
+): Promise<ApiResponse<RecruitmentDetail>> {
+  if (isMockEnabled('recruitmentDetail')) {
+    return getMockRecruitmentDetail(recruitmentId);
+  }
+
+  const { data } = await axiosInstance.get<ApiResponse<RecruitmentDetail>>(
+    `/recruitments/${recruitmentId}`
+  );
+  return data;
+}
+
+// ===== Mock 함수 =====
+
+function getMockRecruitments(
+  params: RecruitmentListParams
+): Promise<ApiResponse<RecruitmentListResponse>> {
+  const { category, subCategory, keyword, sortOption, cursorId, size = DEFAULT_PAGE_SIZE } = params;
+
+  // 필터링
+  let filtered = [...mockRecruitmentItems];
+
+  if (category) {
+    filtered = filtered.filter((item) => item.category === category);
+  }
+
+  if (subCategory) {
+    filtered = filtered.filter((item) => item.subCategories.includes(subCategory));
+  }
+
+  if (keyword) {
+    const lowerKeyword = keyword.toLowerCase();
+    filtered = filtered.filter(
+      (item) =>
+        item.title.toLowerCase().includes(lowerKeyword) ||
+        item.designerName.toLowerCase().includes(lowerKeyword) ||
+        item.shop.toLowerCase().includes(lowerKeyword)
+    );
+  }
+
+  // 정렬
+  switch (sortOption) {
+    case 'MOST_REVIEWS':
+      filtered.sort((a, b) => b.reviewCount - a.reviewCount);
+      break;
+    case 'DISTANCE':
+      filtered.sort((a, b) => a.distance - b.distance);
+      break;
+    case 'NEWEST':
+    default:
+      filtered.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      break;
+  }
+
+  // 커서 기반 페이징
+  const startIndex = cursorId ? filtered.findIndex((item) => item.recruitmentId === cursorId) + 1 : 0;
+  const items = filtered.slice(startIndex, startIndex + size);
+  const hasNext = startIndex + size < filtered.length;
+  const nextCursor = hasNext ? items[items.length - 1]?.recruitmentId : 0;
+
+  return Promise.resolve({
+    isSuccess: true,
+    code: 'SUCCESS',
+    message: '공고 목록 조회 성공',
+    result: {
+      items,
+      hasNext,
+      nextCursor,
+    },
+  });
+}
+
+function getMockRecruitmentDetail(
+  recruitmentId: number
+): Promise<ApiResponse<RecruitmentDetail>> {
+  // ID에 따라 다른 Mock 데이터 반환
+  const detail = recruitmentId === 2 ? mockRecruitmentDetail2 : mockRecruitmentDetail;
+
+  return Promise.resolve({
+    isSuccess: true,
+    code: 'SUCCESS',
+    message: '공고 상세 조회 성공',
+    result: {
+      ...detail,
+      recruitmentId,
+    },
+  });
+}

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,3 +1,5 @@
 export * from './auth';
 export * from './chat';
+export * from './explore';
+export * from './likes';
 export * from './axios';

--- a/src/apis/likes/index.ts
+++ b/src/apis/likes/index.ts
@@ -1,0 +1,1 @@
+export * from './likes';

--- a/src/apis/likes/likes.ts
+++ b/src/apis/likes/likes.ts
@@ -1,0 +1,30 @@
+import { axiosInstance } from '../axios';
+import type { ApiResponse } from '@/src/types';
+
+/**
+ * 공고 찜하기 / 찜 취소하기 (토글)
+ * POST /likes/recruitments/{recruitmentId}
+ * 인증 필요
+ */
+export async function toggleRecruitmentLike(
+  recruitmentId: number
+): Promise<ApiResponse<string>> {
+  const { data } = await axiosInstance.post<ApiResponse<string>>(
+    `/likes/recruitments/${recruitmentId}`
+  );
+  return data;
+}
+
+/**
+ * 디자이너 찜하기 / 찜 취소하기 (토글)
+ * POST /likes/designers/{designerId}
+ * 인증 필요
+ */
+export async function toggleDesignerLike(
+  designerId: number
+): Promise<ApiResponse<string>> {
+  const { data } = await axiosInstance.post<ApiResponse<string>>(
+    `/likes/designers/${designerId}`
+  );
+  return data;
+}

--- a/src/app/(model)/explore/page.tsx
+++ b/src/app/(model)/explore/page.tsx
@@ -1,97 +1,29 @@
-'use client';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { getQueryClient } from '@/src/lib/queryClient';
+import { getRecruitments } from '@/src/apis';
+import { recruitmentKeys } from '@/src/hooks/queries/explore/useRecruitments';
+import { ExploreContent } from '@/src/components/explore';
 
-import { useState } from 'react';
-import {
-  ExploreHeader,
-  CategoryTabs,
-  SearchBar,
-  SubCategoryChips,
-  SortDropdown,
-  RecruitmentCard,
-  DesignerCard,
-} from '@/src/components/explore';
-import { CATEGORIES, HAIR_SUB_CATEGORIES, SORT_OPTIONS } from '@/src/constants/explore';
-import {
-  mockRecruitmentItems,
-  mockDesignerItems,
-  mockRecruitmentListResponse,
-  mockDesignerListResponse,
-} from '@/src/mocks/explore';
+export default async function ExplorePage() {
+  const queryClient = getQueryClient();
 
-export default function ExplorePage() {
-  // 상태 관리
-  const [view, setView] = useState<'designer' | 'recruitment'>('recruitment');
-  const [selectedCategory, setSelectedCategory] = useState('HAIR');
-  const [selectedSubCategory, setSelectedSubCategory] = useState('ALL');
-  const [selectedSort, setSelectedSort] = useState('MOST_REVIEWS');
-  const [searchKeyword, setSearchKeyword] = useState('');
-
-  // Mock 데이터 사용
-  const recruitments = mockRecruitmentItems;
-  const designers = mockDesignerItems;
-  const totalRecruitments = mockRecruitmentListResponse.items.length;
-  const totalDesigners = mockDesignerListResponse.items.length;
+  // 서버에서 초기 데이터 프리페칭 (기본값: HAIR 카테고리, 후기순)
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: recruitmentKeys.list({
+      category: 'HAIR',
+      sortOption: 'MOST_REVIEWS',
+    }),
+    queryFn: () =>
+      getRecruitments({
+        category: 'HAIR',
+        sortOption: 'MOST_REVIEWS',
+      }),
+    initialPageParam: undefined,
+  });
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
-      {/* 헤더 */}
-      <ExploreHeader view={view} onViewChange={setView} />
-
-      {/* 카테고리 탭 */}
-      <CategoryTabs
-        categories={CATEGORIES}
-        selectedCategory={selectedCategory}
-        onCategoryChange={setSelectedCategory}
-      />
-
-      {/* 검색 및 필터 영역 */}
-      <div className="flex flex-col gap-3 px-4 py-4">
-        {/* 검색바 */}
-        <SearchBar value={searchKeyword} onChange={setSearchKeyword} />
-
-        {/* 공고 탐색일 때만 서브 카테고리 칩 표시 */}
-        {view === 'recruitment' && (
-          <SubCategoryChips
-            subCategories={HAIR_SUB_CATEGORIES}
-            selectedSubCategory={selectedSubCategory}
-            onSubCategoryChange={setSelectedSubCategory}
-          />
-        )}
-
-        {/* 총 개수 및 정렬 */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1">
-            <span className="text-body-2-medium text-black">전체</span>
-            <span className="text-body-2-semibold text-gray-600">
-              {view === 'recruitment' ? totalRecruitments : totalDesigners}
-            </span>
-          </div>
-          <SortDropdown sortOptions={SORT_OPTIONS} selectedSort={selectedSort} onSortChange={setSelectedSort} />
-        </div>
-      </div>
-
-      {/* 콘텐츠 영역 */}
-      <div className="flex-1 pb-6">
-        {view === 'recruitment' ? (
-          /* 공고 그리드 (2열) */
-          <div className="grid grid-cols-2 gap-x-2 gap-y-6">
-            {recruitments.map((recruitment, index) => (
-              <RecruitmentCard
-                key={recruitment.recruitmentId}
-                recruitment={recruitment}
-                isLeftColumn={index % 2 === 0}
-              />
-            ))}
-          </div>
-        ) : (
-          /* 디자이너 리스트 */
-          <div className="flex flex-col gap-6 px-4">
-            {designers.map((designer) => (
-              <DesignerCard key={designer.designerId} designer={designer} />
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ExploreContent />
+    </HydrationBoundary>
   );
 }

--- a/src/app/(model)/explore/page.tsx
+++ b/src/app/(model)/explore/page.tsx
@@ -7,16 +7,16 @@ import { ExploreContent } from '@/src/components/explore';
 export default async function ExplorePage() {
   const queryClient = getQueryClient();
 
-  // 서버에서 초기 데이터 프리페칭 (기본값: HAIR 카테고리, 후기순)
+  // 서버에서 초기 데이터 프리페칭 (기본값: HAIR 카테고리, 최신순)
   await queryClient.prefetchInfiniteQuery({
     queryKey: recruitmentKeys.list({
       category: 'HAIR',
-      sortOption: 'MOST_REVIEWS',
+      sortOption: 'NEWEST',
     }),
     queryFn: () =>
       getRecruitments({
         category: 'HAIR',
-        sortOption: 'MOST_REVIEWS',
+        sortOption: 'NEWEST',
       }),
     initialPageParam: undefined,
   });

--- a/src/app/(model)/post/[id]/page.tsx
+++ b/src/app/(model)/post/[id]/page.tsx
@@ -1,199 +1,73 @@
-'use client';
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { getQueryClient } from '@/src/lib/queryClient';
+import { getRecruitmentDetail } from '@/src/apis';
+import { recruitmentKeys } from '@/src/hooks/queries/explore';
+import { PostDetailContent } from '@/src/components/post';
 
-import { useState } from 'react';
-import Image from 'next/image';
-import { notFound, useParams } from 'next/navigation';
-import { ImageGallery, PostTabs, AvailableDates, InfoSection, PostActions } from '@/src/components/post';
-import { mockRecruitmentDetail, mockRecruitmentDetail2 } from '@/src/mocks/explore';
-import Link from 'next/link';
+interface PostDetailPageProps {
+  params: Promise<{ id: string }>;
+}
 
-export default function PostDetailPage() {
-  const params = useParams();
-  const [activeTab, setActiveTab] = useState<'detail' | 'review'>('detail');
-  const [isFavorite, setIsFavorite] = useState(false);
+// SEO 메타데이터 동적 생성
+export async function generateMetadata({ params }: PostDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const recruitmentId = parseInt(id, 10);
 
-  // Mock 데이터에서 해당 ID의 공고 찾기
-  const postId = parseInt(params.id as string);
-  const detail = postId === 1 ? mockRecruitmentDetail : postId === 2 ? mockRecruitmentDetail2 : null;
+  if (isNaN(recruitmentId)) {
+    return {
+      title: '공고를 찾을 수 없습니다 | MODELLY',
+    };
+  }
 
-  if (!detail) {
+  try {
+    const response = await getRecruitmentDetail(recruitmentId);
+    const detail = response.result;
+
+    return {
+      title: `${detail.title} | MODELLY`,
+      description: detail.content.slice(0, 150),
+      openGraph: {
+        title: detail.title,
+        description: detail.content.slice(0, 150),
+        images: detail.imageUrls.length > 0 ? [detail.imageUrls[0]] : [],
+        type: 'article',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: detail.title,
+        description: detail.content.slice(0, 150),
+        images: detail.imageUrls.length > 0 ? [detail.imageUrls[0]] : [],
+      },
+    };
+  } catch {
+    return {
+      title: '공고를 찾을 수 없습니다 | MODELLY',
+    };
+  }
+}
+
+export default async function PostDetailPage({ params }: PostDetailPageProps) {
+  const { id } = await params;
+  const recruitmentId = parseInt(id, 10);
+
+  // 유효하지 않은 ID
+  if (isNaN(recruitmentId)) {
     notFound();
   }
 
-  const handleFavoriteClick = () => {
-    // TODO: 찜하기 API 연동 (추후 구현)
-    setIsFavorite(!isFavorite);
-  };
+  const queryClient = getQueryClient();
 
-  // 서브카테고리를 한글로 변환
-  const getSubCategoryLabel = (subCategory: string) => {
-    const labels: Record<string, string> = {
-      HAIR_CUT: '커트',
-      HAIR_PERM: '펌',
-      HAIR_COLORING: '염색',
-      ONE_COLOR: '원컬러',
-      ART: '아트',
-      PEDICURE: '페디큐어',
-      EYELASH_PERM: '래쉬펌',
-      EYELASH_EXTENSION: '익스텐션',
-      LIP_TATTOO: '입술',
-      EYEBROW_TATTOO: '눈썹',
-      NORMAL_TATTOO: '타투',
-      ETC: '기타',
-    };
-    return labels[subCategory] || subCategory;
-  };
+  // SSR에서 데이터 프리페치
+  await queryClient.prefetchQuery({
+    queryKey: recruitmentKeys.detail(recruitmentId),
+    queryFn: () => getRecruitmentDetail(recruitmentId),
+  });
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
-      {/* 이미지 갤러리 */}
-      <ImageGallery images={detail.imageUrls} />
-      {/* 제목 및 찜하기 */}
-      <div className="flex items-start justify-between gap-4 px-4 pt-4">
-        <h1 className="text-head-2-semibold flex-1 text-gray-900">{detail.title}</h1>
-        <button
-          type="button"
-          onClick={handleFavoriteClick}
-          className="flex size-6 shrink-0 items-center justify-center"
-        >
-          <Image
-            src={isFavorite ? '/icons/common/heart-active.svg' : '/icons/common/heart.svg'}
-            alt="찜하기"
-            width={24}
-            height={24}
-          />
-        </button>
-      </div>
-      {/* 디자이너 정보 */}
-      <div className="px-4 pt-2">
-        <Link href={`/designer/${detail.designerProfile.designerId}`} className="flex flex-col gap-1">
-          <div className="flex items-center gap-1">
-            <span className="text-body-1-medium text-gray-800">디자이너</span>
-            <span className="text-body-2-medium text-gray-800">·</span>
-            <span className="text-body-1-medium mr-1 text-gray-800">{detail.designerProfile.shop}</span>
-            <Image src="/icons/common/arrow-right.svg" alt="디자이너 정보" width={6} height={10} />
-          </div>
-
-          <div className="flex flex-col gap-1">
-            {/* 위치 */}
-            <div className="flex items-center gap-1">
-              <Image src="/icons/common/location.svg" alt="위치" width={12} height={12} />
-              <span className="text-body-2-medium text-gray-700">{detail.designerProfile.shopAddress}</span>
-            </div>
-
-            {/* 별점 및 리뷰 */}
-            <div className="flex items-center gap-1">
-              <div className="flex items-center gap-1">
-                <Image src="/icons/common/star.svg" alt="별점" width={16} height={16} />
-                <span className="text-body-2-medium text-gray-700">5.0</span>
-              </div>
-              <span className="text-body-2-medium text-gray-800">·</span>
-              <span className="text-body-2-medium text-gray-700">리뷰 42</span>
-            </div>
-          </div>
-        </Link>
-      </div>
-      {/* 탭 */}
-      <div className="mt-6">
-        <PostTabs activeTab={activeTab} onTabChange={setActiveTab} />
-      </div>
-      {/* 탭 내용 */}
-      {activeTab === 'detail' ? (
-        <div className="flex flex-col gap-2 bg-gray-100 px-4 py-4">
-          {/* 시술 내용 */}
-          <div className="flex flex-col gap-2 rounded-lg bg-white p-4">
-            <div className="flex items-center justify-between">
-              <h3 className="text-body-2-semibold text-gray-900">시술 내용</h3>
-              <div className="flex gap-1">
-                {detail.subCategories.map((subCategory) => (
-                  <span
-                    key={subCategory}
-                    className="text-caption-1-medium rounded bg-purple-200 px-2 py-1 text-purple-700"
-                  >
-                    {getSubCategoryLabel(subCategory)}
-                  </span>
-                ))}
-              </div>
-            </div>
-            <div className="rounded-lg bg-gray-100 px-4 py-3">
-              <p className="text-body-2-medium whitespace-pre-wrap text-black">{detail.content}</p>
-            </div>
-          </div>
-
-          {/* 시술 가능한 날짜 */}
-          <div className="flex flex-col gap-2 overflow-hidden rounded-lg bg-white p-4">
-            <h3 className="text-body-2-semibold text-gray-900">시술 가능한 날짜</h3>
-            <AvailableDates schedules={detail.recruitmentSchedule} />
-          </div>
-
-          {/* 모집 목적 */}
-          {(detail.goal1 || detail.goal2 || detail.goal3) && (
-            <div className="rounded-lg bg-white p-4">
-              <InfoSection
-                title="모델 모집 목적"
-                content={[detail.goal1, detail.goal2, detail.goal3].filter(Boolean).join('\n')}
-              />
-            </div>
-          )}
-
-          {/* 유의사항 */}
-          {detail.notice && (
-            <div className="flex flex-col gap-4 rounded-lg bg-white p-4">
-              <h3 className="text-body-2-semibold text-gray-900">유의사항</h3>
-              <div className="flex items-start gap-3 rounded-lg bg-gray-100 px-4 py-3">
-                <div className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-gray-800">
-                  <span className="text-caption-1-medium text-white">✕</span>
-                </div>
-                <p className="text-body-2-medium flex-1 whitespace-pre-wrap text-black">{detail.notice}</p>
-              </div>
-            </div>
-          )}
-
-          {/* 사전 동의사항 */}
-          {(detail.agreeVideo || detail.agreeInsta || detail.agreeMosaic) && (
-            <div className="flex flex-col gap-4 rounded-lg bg-white p-4">
-              <h3 className="text-body-2-semibold text-gray-900">사전 동의사항</h3>
-              {detail.agreeVideo && (
-                <div className="flex items-start gap-3 rounded-lg bg-gray-100 px-4 py-3">
-                  <div className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-purple-600">
-                    <Image src="/icons/post/check.svg" alt="" width={12} height={12} />
-                  </div>
-                  <p className="text-body-2-medium flex-1 text-black">영상 촬영 및 활용</p>
-                </div>
-              )}
-              {detail.agreeInsta && (
-                <div className="flex items-start gap-3 rounded-lg bg-gray-100 px-4 py-3">
-                  <div className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-purple-600">
-                    <Image src="/icons/post/check.svg" alt="" width={12} height={12} />
-                  </div>
-                  <p className="text-body-2-medium flex-1 text-black">인스타 업로드</p>
-                </div>
-              )}
-              {detail.agreeMosaic && (
-                <div className="flex items-start gap-3 rounded-lg bg-gray-100 px-4 py-3">
-                  <div className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-purple-600">
-                    <Image src="/icons/post/check.svg" alt="" width={12} height={12} />
-                  </div>
-                  <p className="text-body-2-medium flex-1 text-black">모자이크 처리</p>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* 기타 */}
-          {detail.etc && (
-            <div className="rounded-lg bg-white p-4">
-              <InfoSection title="기타" content={detail.etc} hasIcon={false} />
-            </div>
-          )}
-        </div>
-      ) : (
-        <div className="flex flex-1 items-center justify-center p-8">
-          <p className="text-body-2-medium text-gray-600">디자이너 리뷰는 추후 구현 예정입니다.</p>
-        </div>
-      )}
-      {/* 하단 액션 버튼 (채팅하기 / 예약하기) */}
-      <PostActions recruitmentId={detail.recruitmentId} designerId={detail.designerProfile.designerId} />
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <PostDetailContent recruitmentId={recruitmentId} />
+    </HydrationBoundary>
   );
 }

--- a/src/app/(model)/post/[id]/page.tsx
+++ b/src/app/(model)/post/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
@@ -5,6 +6,9 @@ import { getQueryClient } from '@/src/lib/queryClient';
 import { getRecruitmentDetail } from '@/src/apis';
 import { recruitmentKeys } from '@/src/hooks/queries/explore';
 import { PostDetailContent } from '@/src/components/post';
+
+// React cache로 래핑하여 동일 요청 중복 방지
+const getCachedRecruitmentDetail = cache((id: number) => getRecruitmentDetail(id));
 
 interface PostDetailPageProps {
   params: Promise<{ id: string }>;
@@ -22,23 +26,28 @@ export async function generateMetadata({ params }: PostDetailPageProps): Promise
   }
 
   try {
-    const response = await getRecruitmentDetail(recruitmentId);
+    const response = await getCachedRecruitmentDetail(recruitmentId);
     const detail = response.result;
 
+    // Null safety 처리
+    const title = detail?.title ?? '공고 상세';
+    const content = detail?.content ?? '';
+    const imageUrls = detail?.imageUrls ?? [];
+
     return {
-      title: `${detail.title} | MODELLY`,
-      description: detail.content.slice(0, 150),
+      title: `${title} | MODELLY`,
+      description: content.slice(0, 150),
       openGraph: {
-        title: detail.title,
-        description: detail.content.slice(0, 150),
-        images: detail.imageUrls.length > 0 ? [detail.imageUrls[0]] : [],
+        title,
+        description: content.slice(0, 150),
+        images: imageUrls.length > 0 ? [imageUrls[0]] : [],
         type: 'article',
       },
       twitter: {
         card: 'summary_large_image',
-        title: detail.title,
-        description: detail.content.slice(0, 150),
-        images: detail.imageUrls.length > 0 ? [detail.imageUrls[0]] : [],
+        title,
+        description: content.slice(0, 150),
+        images: imageUrls.length > 0 ? [imageUrls[0]] : [],
       },
     };
   } catch {
@@ -59,10 +68,10 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
 
   const queryClient = getQueryClient();
 
-  // SSR에서 데이터 프리페치
+  // SSR에서 데이터 프리페치 (캐시된 함수 사용으로 중복 요청 방지)
   await queryClient.prefetchQuery({
     queryKey: recruitmentKeys.detail(recruitmentId),
-    queryFn: () => getRecruitmentDetail(recruitmentId),
+    queryFn: () => getCachedRecruitmentDetail(recruitmentId),
   });
 
   return (

--- a/src/components/explore/Cards/DesignerCard.tsx
+++ b/src/components/explore/Cards/DesignerCard.tsx
@@ -8,16 +8,17 @@ import { formatDistrict, formatDistance } from '@/src/utils/common';
 
 interface DesignerCardProps {
   designer: DesignerListItem;
+  onLikeToggle?: () => void;
 }
 
-export default function DesignerCard({ designer }: DesignerCardProps) {
+export default function DesignerCard({ designer, onLikeToggle }: DesignerCardProps) {
   const [isLiked, setIsLiked] = useState(designer.isLiked);
 
   const handleFavoriteClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setIsLiked((prev) => !prev);
-    // TODO: API 연동 시 찜하기/취소 API 호출
+    onLikeToggle?.();
   };
 
   return (

--- a/src/components/explore/Cards/DesignerCard.tsx
+++ b/src/components/explore/Cards/DesignerCard.tsx
@@ -12,7 +12,7 @@ interface DesignerCardProps {
 }
 
 export default function DesignerCard({ designer, onLikeToggle }: DesignerCardProps) {
-  const [isLiked, setIsLiked] = useState(designer.isLiked);
+  const [isLiked, setIsLiked] = useState(designer.isLiked ?? false);
 
   const handleFavoriteClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -48,11 +48,11 @@ export default function DesignerCard({ designer, onLikeToggle }: DesignerCardPro
               <div className="flex items-center gap-1">
                 <Image src="/icons/common/star.svg" alt="별점" width={14} height={14} />
                 <span className="text-caption-1-medium text-gray-700">
-                  5.0 ({designer.reviewCount.toLocaleString()})
+                  5.0 ({(designer.reviewCount ?? 0).toLocaleString()})
                 </span>
               </div>
               <span className="text-body-2-medium text-gray-700">·</span>
-              <span className="text-caption-1-medium text-gray-700">{formatDistance(designer.distance)}</span>
+              <span className="text-caption-1-medium text-gray-700">{formatDistance(designer.distance ?? 0)}</span>
             </div>
           </div>
         </div>

--- a/src/components/explore/Cards/RecruitmentCard.tsx
+++ b/src/components/explore/Cards/RecruitmentCard.tsx
@@ -13,7 +13,7 @@ interface RecruitmentCardProps {
 }
 
 export default function RecruitmentCard({ recruitment, isLeftColumn = false, onLikeToggle }: RecruitmentCardProps) {
-  const [isLiked, setIsLiked] = useState(recruitment.isLiked);
+  const [isLiked, setIsLiked] = useState(recruitment.isLiked ?? false);
 
   const handleFavoriteClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -84,11 +84,11 @@ export default function RecruitmentCard({ recruitment, isLeftColumn = false, onL
               <div className="flex items-center gap-1">
                 <Image src="/icons/common/star.svg" alt="별점" width={14} height={14} />
                 <span className="text-caption-1-medium text-gray-700">
-                  5.0 ({recruitment.reviewCount.toLocaleString()})
+                  5.0 ({(recruitment.reviewCount ?? 0).toLocaleString()})
                 </span>
               </div>
               <span className="text-body-2-medium text-gray-700">·</span>
-              <span className="text-caption-1-medium text-gray-700">{formatDistance(recruitment.distance)}</span>
+              <span className="text-caption-1-medium text-gray-700">{formatDistance(recruitment.distance ?? 0)}</span>
             </div>
           </div>
         </div>

--- a/src/components/explore/Cards/RecruitmentCard.tsx
+++ b/src/components/explore/Cards/RecruitmentCard.tsx
@@ -9,16 +9,17 @@ import { formatDistrict, formatDistance } from '@/src/utils/common';
 interface RecruitmentCardProps {
   recruitment: RecruitmentListItem;
   isLeftColumn?: boolean;
+  onLikeToggle?: () => void;
 }
 
-export default function RecruitmentCard({ recruitment, isLeftColumn = false }: RecruitmentCardProps) {
+export default function RecruitmentCard({ recruitment, isLeftColumn = false, onLikeToggle }: RecruitmentCardProps) {
   const [isLiked, setIsLiked] = useState(recruitment.isLiked);
 
   const handleFavoriteClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setIsLiked((prev) => !prev);
-    // TODO: 찜하기 API 연동
+    onLikeToggle?.();
   };
 
   // 서브카테고리를 한글로 변환

--- a/src/components/explore/ExploreContent.tsx
+++ b/src/components/explore/ExploreContent.tsx
@@ -12,7 +12,7 @@ import {
   RecruitmentCardSkeleton,
   DesignerCardSkeleton,
 } from '@/src/components/explore';
-import { CATEGORIES, HAIR_SUB_CATEGORIES, SORT_OPTIONS } from '@/src/constants/explore';
+import { CATEGORIES, SUB_CATEGORIES_BY_CATEGORY, SORT_OPTIONS } from '@/src/constants/explore';
 import { useRecruitments, useDesigners } from '@/src/hooks/queries/explore';
 import { useToggleRecruitmentLike, useToggleDesignerLike } from '@/src/hooks/queries/likes';
 import type { Category, SubCategory, SortOption } from '@/src/types';
@@ -120,7 +120,10 @@ export default function ExploreContent() {
       <CategoryTabs
         categories={CATEGORIES}
         selectedCategory={selectedCategory}
-        onCategoryChange={(cat) => setSelectedCategory(cat as Category)}
+        onCategoryChange={(cat) => {
+          setSelectedCategory(cat as Category);
+          setSelectedSubCategory('ALL'); // 카테고리 변경 시 서브카테고리 리셋
+        }}
       />
 
       {/* 검색 및 필터 영역 */}
@@ -131,7 +134,7 @@ export default function ExploreContent() {
         {/* 공고 탐색일 때만 서브 카테고리 칩 표시 */}
         {view === 'recruitment' && (
           <SubCategoryChips
-            subCategories={HAIR_SUB_CATEGORIES}
+            subCategories={SUB_CATEGORIES_BY_CATEGORY[selectedCategory]}
             selectedSubCategory={selectedSubCategory}
             onSubCategoryChange={(sub) => setSelectedSubCategory(sub as SubCategory | 'ALL')}
           />

--- a/src/components/explore/ExploreContent.tsx
+++ b/src/components/explore/ExploreContent.tsx
@@ -15,6 +15,8 @@ import {
 import { CATEGORIES, SUB_CATEGORIES_BY_CATEGORY, SORT_OPTIONS } from '@/src/constants/explore';
 import { useRecruitments, useDesigners } from '@/src/hooks/queries/explore';
 import { useToggleRecruitmentLike, useToggleDesignerLike } from '@/src/hooks/queries/likes';
+import { useUserLocation } from '@/src/hooks/custom';
+import { useToast } from '@/src/hooks/common/useToast';
 import type { Category, SubCategory, SortOption } from '@/src/types';
 
 export default function ExploreContent() {
@@ -25,8 +27,32 @@ export default function ExploreContent() {
   const [selectedSort, setSelectedSort] = useState<SortOption>('NEWEST');
   const [searchKeyword, setSearchKeyword] = useState('');
 
+  // 위치 정보 훅
+  const { location, error: locationError, isLoading: isLocationLoading, requestLocation } = useUserLocation();
+  const { showToast } = useToast();
+
   // Infinite scroll observer ref
   const loadMoreRef = useRef<HTMLDivElement>(null);
+
+  // 거리순 정렬 시 위치 정보 필요 여부
+  const needsLocation = selectedSort === 'DISTANCE';
+  const hasLocation = !!location;
+
+  // 거리순 정렬 선택 시 위치 요청
+  const handleSortChange = (sort: SortOption) => {
+    if (sort === 'DISTANCE' && !location && !isLocationLoading) {
+      requestLocation();
+    }
+    setSelectedSort(sort);
+  };
+
+  // 위치 에러 시 기본 정렬로 복귀
+  useEffect(() => {
+    if (locationError && selectedSort === 'DISTANCE') {
+      showToast(locationError);
+      setSelectedSort('NEWEST');
+    }
+  }, [locationError, selectedSort, showToast]);
 
   // Query params
   const recruitmentParams = {
@@ -34,13 +60,20 @@ export default function ExploreContent() {
     subCategory: selectedSubCategory === 'ALL' ? undefined : selectedSubCategory,
     keyword: searchKeyword || undefined,
     sortOption: selectedSort,
+    userLatitude: needsLocation ? location?.latitude : undefined,
+    userLongitude: needsLocation ? location?.longitude : undefined,
   };
 
   const designerParams = {
     category: selectedCategory,
     keyword: searchKeyword || undefined,
     sortOption: selectedSort,
+    userLatitude: needsLocation ? location?.latitude : undefined,
+    userLongitude: needsLocation ? location?.longitude : undefined,
   };
+
+  // 거리순 정렬 시 위치 정보가 없으면 쿼리 비활성화
+  const canQueryWithDistance = !needsLocation || hasLocation;
 
   // Query hooks
   const {
@@ -49,7 +82,7 @@ export default function ExploreContent() {
     hasNextPage: hasNextRecruitments,
     isFetchingNextPage: isFetchingNextRecruitments,
     isLoading: isLoadingRecruitments,
-  } = useRecruitments({ ...recruitmentParams, enabled: view === 'recruitment' });
+  } = useRecruitments({ ...recruitmentParams, enabled: view === 'recruitment' && canQueryWithDistance });
 
   const {
     data: designerData,
@@ -57,7 +90,7 @@ export default function ExploreContent() {
     hasNextPage: hasNextDesigners,
     isFetchingNextPage: isFetchingNextDesigners,
     isLoading: isLoadingDesigners,
-  } = useDesigners({ ...designerParams, enabled: view === 'designer' });
+  } = useDesigners({ ...designerParams, enabled: view === 'designer' && canQueryWithDistance });
 
   // Like mutations
   const { mutate: toggleRecruitmentLike } = useToggleRecruitmentLike();
@@ -108,7 +141,9 @@ export default function ExploreContent() {
     return () => observer.disconnect();
   }, [handleObserver]);
 
-  const isLoading = view === 'recruitment' ? isLoadingRecruitments : isLoadingDesigners;
+  // 거리순 정렬에서 위치 로딩 중이거나 데이터 로딩 중인 경우
+  const isWaitingForLocation = needsLocation && !hasLocation && isLocationLoading;
+  const isLoading = isWaitingForLocation || (view === 'recruitment' ? isLoadingRecruitments : isLoadingDesigners);
   const isFetchingNext = view === 'recruitment' ? isFetchingNextRecruitments : isFetchingNextDesigners;
 
   return (
@@ -151,7 +186,7 @@ export default function ExploreContent() {
           <SortDropdown
             sortOptions={SORT_OPTIONS}
             selectedSort={selectedSort}
-            onSortChange={(sort) => setSelectedSort(sort as SortOption)}
+            onSortChange={(sort) => handleSortChange(sort as SortOption)}
           />
         </div>
       </div>

--- a/src/components/explore/ExploreContent.tsx
+++ b/src/components/explore/ExploreContent.tsx
@@ -22,7 +22,7 @@ export default function ExploreContent() {
   const [view, setView] = useState<'designer' | 'recruitment'>('recruitment');
   const [selectedCategory, setSelectedCategory] = useState<Category>('HAIR');
   const [selectedSubCategory, setSelectedSubCategory] = useState<SubCategory | 'ALL'>('ALL');
-  const [selectedSort, setSelectedSort] = useState<SortOption>('MOST_REVIEWS');
+  const [selectedSort, setSelectedSort] = useState<SortOption>('NEWEST');
   const [searchKeyword, setSearchKeyword] = useState('');
 
   // Infinite scroll observer ref

--- a/src/components/explore/ExploreContent.tsx
+++ b/src/components/explore/ExploreContent.tsx
@@ -40,8 +40,18 @@ export default function ExploreContent() {
 
   // 거리순 정렬 선택 시 위치 요청
   const handleSortChange = (sort: SortOption) => {
+    console.log('[ExploreContent] handleSortChange 호출:', sort);
+    console.log('[ExploreContent] 현재 상태:', { location, isLocationLoading, needsLocation: sort === 'DISTANCE' });
+
     if (sort === 'DISTANCE' && !location && !isLocationLoading) {
+      console.log('[ExploreContent] requestLocation 호출 조건 충족');
       requestLocation();
+    } else {
+      console.log('[ExploreContent] requestLocation 호출 조건 미충족:', {
+        isDistance: sort === 'DISTANCE',
+        hasLocation: !!location,
+        isLocationLoading,
+      });
     }
     setSelectedSort(sort);
   };

--- a/src/components/explore/ExploreContent.tsx
+++ b/src/components/explore/ExploreContent.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import {
+  ExploreHeader,
+  CategoryTabs,
+  SearchBar,
+  SubCategoryChips,
+  SortDropdown,
+  RecruitmentCard,
+  DesignerCard,
+  RecruitmentCardSkeleton,
+  DesignerCardSkeleton,
+} from '@/src/components/explore';
+import { CATEGORIES, HAIR_SUB_CATEGORIES, SORT_OPTIONS } from '@/src/constants/explore';
+import { useRecruitments, useDesigners } from '@/src/hooks/queries/explore';
+import { useToggleRecruitmentLike, useToggleDesignerLike } from '@/src/hooks/queries/likes';
+import type { Category, SubCategory, SortOption } from '@/src/types';
+
+export default function ExploreContent() {
+  // 상태 관리
+  const [view, setView] = useState<'designer' | 'recruitment'>('recruitment');
+  const [selectedCategory, setSelectedCategory] = useState<Category>('HAIR');
+  const [selectedSubCategory, setSelectedSubCategory] = useState<SubCategory | 'ALL'>('ALL');
+  const [selectedSort, setSelectedSort] = useState<SortOption>('MOST_REVIEWS');
+  const [searchKeyword, setSearchKeyword] = useState('');
+
+  // Infinite scroll observer ref
+  const loadMoreRef = useRef<HTMLDivElement>(null);
+
+  // Query params
+  const recruitmentParams = {
+    category: selectedCategory,
+    subCategory: selectedSubCategory === 'ALL' ? undefined : selectedSubCategory,
+    keyword: searchKeyword || undefined,
+    sortOption: selectedSort,
+  };
+
+  const designerParams = {
+    category: selectedCategory,
+    keyword: searchKeyword || undefined,
+    sortOption: selectedSort,
+  };
+
+  // Query hooks
+  const {
+    data: recruitmentData,
+    fetchNextPage: fetchNextRecruitments,
+    hasNextPage: hasNextRecruitments,
+    isFetchingNextPage: isFetchingNextRecruitments,
+    isLoading: isLoadingRecruitments,
+  } = useRecruitments({ ...recruitmentParams, enabled: view === 'recruitment' });
+
+  const {
+    data: designerData,
+    fetchNextPage: fetchNextDesigners,
+    hasNextPage: hasNextDesigners,
+    isFetchingNextPage: isFetchingNextDesigners,
+    isLoading: isLoadingDesigners,
+  } = useDesigners({ ...designerParams, enabled: view === 'designer' });
+
+  // Like mutations
+  const { mutate: toggleRecruitmentLike } = useToggleRecruitmentLike();
+  const { mutate: toggleDesignerLike } = useToggleDesignerLike();
+
+  // Flatten paginated data
+  const recruitments = recruitmentData?.pages.flatMap((page) => page.result.items) ?? [];
+  const designers = designerData?.pages.flatMap((page) => page.result.items) ?? [];
+
+  // Total count
+  const totalRecruitments = recruitments.length;
+  const totalDesigners = designers.length;
+
+  // Infinite scroll callback
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [target] = entries;
+      if (target.isIntersecting) {
+        if (view === 'recruitment' && hasNextRecruitments && !isFetchingNextRecruitments) {
+          fetchNextRecruitments();
+        } else if (view === 'designer' && hasNextDesigners && !isFetchingNextDesigners) {
+          fetchNextDesigners();
+        }
+      }
+    },
+    [
+      view,
+      hasNextRecruitments,
+      hasNextDesigners,
+      isFetchingNextRecruitments,
+      isFetchingNextDesigners,
+      fetchNextRecruitments,
+      fetchNextDesigners,
+    ]
+  );
+
+  // Setup Intersection Observer
+  useEffect(() => {
+    const element = loadMoreRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(handleObserver, {
+      threshold: 0.1,
+      rootMargin: '100px',
+    });
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [handleObserver]);
+
+  const isLoading = view === 'recruitment' ? isLoadingRecruitments : isLoadingDesigners;
+  const isFetchingNext = view === 'recruitment' ? isFetchingNextRecruitments : isFetchingNextDesigners;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white">
+      {/* 헤더 */}
+      <ExploreHeader view={view} onViewChange={setView} />
+
+      {/* 카테고리 탭 */}
+      <CategoryTabs
+        categories={CATEGORIES}
+        selectedCategory={selectedCategory}
+        onCategoryChange={(cat) => setSelectedCategory(cat as Category)}
+      />
+
+      {/* 검색 및 필터 영역 */}
+      <div className="flex flex-col gap-3 px-4 py-4">
+        {/* 검색바 */}
+        <SearchBar value={searchKeyword} onChange={setSearchKeyword} />
+
+        {/* 공고 탐색일 때만 서브 카테고리 칩 표시 */}
+        {view === 'recruitment' && (
+          <SubCategoryChips
+            subCategories={HAIR_SUB_CATEGORIES}
+            selectedSubCategory={selectedSubCategory}
+            onSubCategoryChange={(sub) => setSelectedSubCategory(sub as SubCategory | 'ALL')}
+          />
+        )}
+
+        {/* 총 개수 및 정렬 */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1">
+            <span className="text-body-2-medium text-black">전체</span>
+            <span className="text-body-2-semibold text-gray-600">
+              {view === 'recruitment' ? totalRecruitments : totalDesigners}
+            </span>
+          </div>
+          <SortDropdown
+            sortOptions={SORT_OPTIONS}
+            selectedSort={selectedSort}
+            onSortChange={(sort) => setSelectedSort(sort as SortOption)}
+          />
+        </div>
+      </div>
+
+      {/* 콘텐츠 영역 */}
+      <div className="flex-1 pb-6">
+        {view === 'recruitment' ? (
+          /* 공고 그리드 (2열) */
+          <div className="grid grid-cols-2 gap-x-2 gap-y-6">
+            {isLoading
+              ? [0, 1, 2, 3, 4, 5].map((index) => (
+                  <RecruitmentCardSkeleton key={index} isLeftColumn={index % 2 === 0} />
+                ))
+              : recruitments.map((recruitment, index) => (
+                  <RecruitmentCard
+                    key={recruitment.recruitmentId}
+                    recruitment={recruitment}
+                    isLeftColumn={index % 2 === 0}
+                    onLikeToggle={() => toggleRecruitmentLike(recruitment.recruitmentId)}
+                  />
+                ))}
+            {isFetchingNext &&
+              [0, 1].map((index) => (
+                <RecruitmentCardSkeleton key={`loading-${index}`} isLeftColumn={index % 2 === 0} />
+              ))}
+          </div>
+        ) : (
+          /* 디자이너 리스트 */
+          <div className="flex flex-col gap-6 px-4">
+            {isLoading
+              ? [0, 1, 2, 3].map((index) => <DesignerCardSkeleton key={index} />)
+              : designers.map((designer) => (
+                  <DesignerCard
+                    key={designer.designerId}
+                    designer={designer}
+                    onLikeToggle={() => toggleDesignerLike(designer.designerId)}
+                  />
+                ))}
+            {isFetchingNext && [0, 1].map((index) => <DesignerCardSkeleton key={`loading-${index}`} />)}
+          </div>
+        )}
+
+        {/* Infinite scroll trigger */}
+        <div ref={loadMoreRef} className="h-4" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/explore/ExploreContent.tsx
+++ b/src/components/explore/ExploreContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import {
   ExploreHeader,
   CategoryTabs,
@@ -27,9 +27,21 @@ export default function ExploreContent() {
   const [selectedSort, setSelectedSort] = useState<SortOption>('NEWEST');
   const [searchKeyword, setSearchKeyword] = useState('');
 
-  // 위치 정보 훅
-  const { location, error: locationError, isLoading: isLocationLoading, requestLocation } = useUserLocation();
   const { showToast } = useToast();
+
+  // 위치 에러 핸들러 (콜백으로 처리하여 effect 내 setState 방지)
+  const handleLocationError = useCallback(
+    (errorMessage: string) => {
+      showToast(errorMessage);
+      setSelectedSort('NEWEST');
+    },
+    [showToast]
+  );
+
+  // 위치 정보 훅
+  const { location, isLoading: isLocationLoading, requestLocation } = useUserLocation({
+    onError: handleLocationError,
+  });
 
   // Infinite scroll observer ref
   const loadMoreRef = useRef<HTMLDivElement>(null);
@@ -40,29 +52,11 @@ export default function ExploreContent() {
 
   // 거리순 정렬 선택 시 위치 요청
   const handleSortChange = (sort: SortOption) => {
-    console.log('[ExploreContent] handleSortChange 호출:', sort);
-    console.log('[ExploreContent] 현재 상태:', { location, isLocationLoading, needsLocation: sort === 'DISTANCE' });
-
     if (sort === 'DISTANCE' && !location && !isLocationLoading) {
-      console.log('[ExploreContent] requestLocation 호출 조건 충족');
       requestLocation();
-    } else {
-      console.log('[ExploreContent] requestLocation 호출 조건 미충족:', {
-        isDistance: sort === 'DISTANCE',
-        hasLocation: !!location,
-        isLocationLoading,
-      });
     }
     setSelectedSort(sort);
   };
-
-  // 위치 에러 시 기본 정렬로 복귀
-  useEffect(() => {
-    if (locationError && selectedSort === 'DISTANCE') {
-      showToast(locationError);
-      setSelectedSort('NEWEST');
-    }
-  }, [locationError, selectedSort, showToast]);
 
   // Query params
   const recruitmentParams = {

--- a/src/components/explore/Filters/SortDropdown.tsx
+++ b/src/components/explore/Filters/SortDropdown.tsx
@@ -38,8 +38,8 @@ export default function SortDropdown({ sortOptions, selectedSort, onSortChange }
         <Image
           src="/icons/common/arrow-down.svg"
           alt="정렬"
-          width={16}
-          height={16}
+          width={10}
+          height={10}
           className={`transition-transform ${isOpen ? 'rotate-180' : ''}`}
         />
       </button>

--- a/src/components/explore/index.ts
+++ b/src/components/explore/index.ts
@@ -2,4 +2,5 @@ export * from './Header';
 export * from './Filters';
 export * from './Cards';
 export * from './Skeleton';
+export { default as ExploreContent } from './ExploreContent';
 

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import {
+  ImageGallery,
+  PostTabs,
+  AvailableDates,
+  InfoSection,
+  PostActions,
+  PostPageSkeleton,
+} from '@/src/components/post';
+import { useRecruitmentDetail } from '@/src/hooks/queries/explore';
+import { useToggleRecruitmentLike } from '@/src/hooks/queries/likes';
+
+interface PostDetailContentProps {
+  recruitmentId: number;
+}
+
+export default function PostDetailContent({ recruitmentId }: PostDetailContentProps) {
+  const [activeTab, setActiveTab] = useState<'detail' | 'review'>('detail');
+
+  // Query hook
+  const { data, isLoading, isError } = useRecruitmentDetail(recruitmentId);
+
+  // Like mutation
+  const { mutate: toggleLike } = useToggleRecruitmentLike();
+
+  // 로딩 중
+  if (isLoading) {
+    return <PostPageSkeleton />;
+  }
+
+  // 에러 또는 데이터 없음
+  if (isError || !data?.result) {
+    notFound();
+  }
+
+  const detail = data.result;
+
+  const handleFavoriteClick = () => {
+    toggleLike(recruitmentId);
+  };
+
+  // 서브카테고리를 한글로 변환
+  const getSubCategoryLabel = (subCategory: string) => {
+    const labels: Record<string, string> = {
+      HAIR_CUT: '커트',
+      HAIR_PERM: '펌',
+      HAIR_COLORING: '염색',
+      HAIR_MAGIC: '매직',
+      ONE_COLOR: '원컬러',
+      ART: '아트',
+      PEDICURE: '페디큐어',
+      EYELASH_PERM: '래쉬펌',
+      EYELASH_EXTENSION: '익스텐션',
+      LIP_TATTOO: '입술',
+      EYEBROW_TATTOO: '눈썹',
+      NORMAL_TATTOO: '타투',
+      ETC: '기타',
+    };
+    return labels[subCategory] || subCategory;
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white">
+      {/* 이미지 갤러리 */}
+      <ImageGallery images={detail.imageUrls} />
+
+      {/* 제목 및 찜하기 */}
+      <div className="flex items-start justify-between gap-4 px-4 pt-4">
+        <h1 className="text-head-2-semibold flex-1 text-gray-900">{detail.title}</h1>
+        <button
+          type="button"
+          onClick={handleFavoriteClick}
+          className="flex size-6 shrink-0 items-center justify-center"
+        >
+          <Image
+            src={detail.isLiked ? '/icons/common/heart-active.svg' : '/icons/common/heart.svg'}
+            alt="찜하기"
+            width={24}
+            height={24}
+          />
+        </button>
+      </div>
+
+      {/* 디자이너 정보 */}
+      <div className="px-4 pt-2">
+        <Link href={`/designer/${detail.designerProfile.designerId}`} className="flex flex-col gap-1">
+          <div className="flex items-center gap-1">
+            <span className="text-body-1-medium text-gray-800">디자이너</span>
+            <span className="text-body-2-medium text-gray-800">·</span>
+            <span className="text-body-1-medium mr-1 text-gray-800">{detail.designerProfile.shop}</span>
+            <Image src="/icons/common/arrow-right.svg" alt="디자이너 정보" width={6} height={10} />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            {/* 위치 */}
+            <div className="flex items-center gap-1">
+              <Image src="/icons/common/location.svg" alt="위치" width={12} height={12} />
+              <span className="text-body-2-medium text-gray-700">{detail.designerProfile.shopAddress}</span>
+            </div>
+
+            {/* 별점 및 리뷰 */}
+            <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1">
+                <Image src="/icons/common/star.svg" alt="별점" width={16} height={16} />
+                <span className="text-body-2-medium text-gray-700">5.0</span>
+              </div>
+              <span className="text-body-2-medium text-gray-800">·</span>
+              <span className="text-body-2-medium text-gray-700">리뷰 42</span>
+            </div>
+          </div>
+        </Link>
+      </div>
+
+      {/* 탭 */}
+      <div className="mt-6">
+        <PostTabs activeTab={activeTab} onTabChange={setActiveTab} />
+      </div>
+
+      {/* 탭 내용 */}
+      {activeTab === 'detail' ? (
+        <div className="flex flex-col gap-2 bg-gray-100 px-4 py-4">
+          {/* 시술 내용 */}
+          <div className="flex flex-col gap-2 rounded-lg bg-white p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-body-2-semibold text-gray-900">시술 내용</h3>
+              <div className="flex gap-1">
+                {detail.subCategories.map((subCategory) => (
+                  <span
+                    key={subCategory}
+                    className="text-caption-1-medium rounded bg-purple-200 px-2 py-1 text-purple-700"
+                  >
+                    {getSubCategoryLabel(subCategory)}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-lg bg-gray-100 px-4 py-3">
+              <p className="text-body-2-medium whitespace-pre-wrap text-black">{detail.content}</p>
+            </div>
+          </div>
+
+          {/* 시술 가능한 날짜 */}
+          <div className="flex flex-col gap-2 overflow-hidden rounded-lg bg-white p-4">
+            <h3 className="text-body-2-semibold text-gray-900">시술 가능한 날짜</h3>
+            <AvailableDates schedules={detail.recruitmentSchedule} />
+          </div>
+
+          {/* 모집 목적 */}
+          {(detail.goal1 || detail.goal2 || detail.goal3) && (
+            <div className="rounded-lg bg-white p-4">
+              <InfoSection
+                title="모델 모집 목적"
+                content={[detail.goal1, detail.goal2, detail.goal3].filter(Boolean).join('\n')}
+              />
+            </div>
+          )}
+
+          {/* 유의사항 */}
+          {detail.notice && (
+            <div className="flex flex-col gap-4 rounded-lg bg-white p-4">
+              <h3 className="text-body-2-semibold text-gray-900">유의사항</h3>
+              <div className="flex items-start gap-3 rounded-lg bg-gray-100 px-4 py-3">
+                <div className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-gray-800">
+                  <span className="text-caption-1-medium text-white">✕</span>
+                </div>
+                <p className="text-body-2-medium flex-1 whitespace-pre-wrap text-black">{detail.notice}</p>
+              </div>
+            </div>
+          )}
+
+          {/* 사전 동의사항 */}
+          {(detail.agreeVideo || detail.agreeInsta || detail.agreeMosaic) && (
+            <div className="flex flex-col gap-4 rounded-lg bg-white p-4">
+              <h3 className="text-body-2-semibold text-gray-900">사전 동의사항</h3>
+              {detail.agreeVideo && (
+                <div className="flex items-start gap-3 rounded-lg bg-gray-100 px-4 py-3">
+                  <div className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-purple-600">
+                    <Image src="/icons/post/check.svg" alt="" width={12} height={12} />
+                  </div>
+                  <p className="text-body-2-medium flex-1 text-black">영상 촬영 및 활용</p>
+                </div>
+              )}
+              {detail.agreeInsta && (
+                <div className="flex items-start gap-3 rounded-lg bg-gray-100 px-4 py-3">
+                  <div className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-purple-600">
+                    <Image src="/icons/post/check.svg" alt="" width={12} height={12} />
+                  </div>
+                  <p className="text-body-2-medium flex-1 text-black">인스타 업로드</p>
+                </div>
+              )}
+              {detail.agreeMosaic && (
+                <div className="flex items-start gap-3 rounded-lg bg-gray-100 px-4 py-3">
+                  <div className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-purple-600">
+                    <Image src="/icons/post/check.svg" alt="" width={12} height={12} />
+                  </div>
+                  <p className="text-body-2-medium flex-1 text-black">모자이크 처리</p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* 기타 */}
+          {detail.etc && (
+            <div className="rounded-lg bg-white p-4">
+              <InfoSection title="기타" content={detail.etc} hasIcon={false} />
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="text-body-2-medium text-gray-600">디자이너 리뷰는 추후 구현 예정입니다.</p>
+        </div>
+      )}
+
+      {/* 하단 액션 버튼 (채팅하기 / 예약하기) */}
+      <PostActions recruitmentId={detail.recruitmentId} designerId={detail.designerProfile.designerId} />
+    </div>
+  );
+}

--- a/src/components/post/index.ts
+++ b/src/components/post/index.ts
@@ -4,4 +4,5 @@ export * from './Designer';
 export * from './Content';
 export * from './Actions';
 export * from './Skeleton';
+export { default as PostDetailContent } from './PostDetailContent';
 

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,9 +1,9 @@
 export const API_CONFIG = {
   USE_MOCK: process.env.NEXT_PUBLIC_USE_MOCK === 'true',
   MOCK_ENDPOINTS: {
-    recruitments: true,
-    recruitmentDetail: true,
-    designers: true,
+    recruitments: false,
+    recruitmentDetail: false,
+    designers: false,
   },
 } as const;
 

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,0 +1,14 @@
+export const API_CONFIG = {
+  USE_MOCK: process.env.NEXT_PUBLIC_USE_MOCK === 'true',
+  MOCK_ENDPOINTS: {
+    recruitments: true,
+    recruitmentDetail: true,
+    designers: true,
+  },
+} as const;
+
+export type MockEndpoint = keyof typeof API_CONFIG.MOCK_ENDPOINTS;
+
+export const isMockEnabled = (endpoint: MockEndpoint): boolean => {
+  return API_CONFIG.USE_MOCK || API_CONFIG.MOCK_ENDPOINTS[endpoint];
+};

--- a/src/constants/explore.ts
+++ b/src/constants/explore.ts
@@ -37,6 +37,37 @@ export const HAIR_SUB_CATEGORIES: SubCategory[] = [
   { code: 'HAIR_MAGIC', name: '매직' },
 ];
 
+// 서브 카테고리 (네일)
+export const NAIL_SUB_CATEGORIES: SubCategory[] = [
+  { code: 'ALL', name: '전체' },
+  { code: 'ONE_COLOR', name: '원컬러' },
+  { code: 'ART', name: '아트' },
+  { code: 'PEDICURE', name: '페디큐어' },
+];
+
+// 서브 카테고리 (속눈썹)
+export const EYELASH_SUB_CATEGORIES: SubCategory[] = [
+  { code: 'ALL', name: '전체' },
+  { code: 'EYELASH_PERM', name: '펌' },
+  { code: 'EYELASH_EXTENSION', name: '연장' },
+];
+
+// 서브 카테고리 (타투)
+export const TATTOO_SUB_CATEGORIES: SubCategory[] = [
+  { code: 'ALL', name: '전체' },
+  { code: 'NORMAL_TATTOO', name: '일반 디자인' },
+  { code: 'LIP_TATTOO', name: '입술 문신' },
+  { code: 'EYEBROW_TATTOO', name: '눈썹 문신' },
+];
+
+// 카테고리별 서브카테고리 매핑
+export const SUB_CATEGORIES_BY_CATEGORY: Record<CategoryType, SubCategory[]> = {
+  HAIR: HAIR_SUB_CATEGORIES,
+  NAIL: NAIL_SUB_CATEGORIES,
+  EYELASH: EYELASH_SUB_CATEGORIES,
+  TATTOO: TATTOO_SUB_CATEGORIES,
+};
+
 // 정렬 옵션
 export const SORT_OPTIONS: SortOption[] = [
   { code: 'NEWEST', name: '최신순' },

--- a/src/hooks/custom/index.ts
+++ b/src/hooks/custom/index.ts
@@ -1,2 +1,3 @@
 export * from './signup';
 export * from './chat';
+export * from './useUserLocation';

--- a/src/hooks/custom/useUserLocation.ts
+++ b/src/hooks/custom/useUserLocation.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+export interface UserLocation {
+  latitude: number;
+  longitude: number;
+}
+
+interface UseUserLocationReturn {
+  location: UserLocation | null;
+  error: string | null;
+  isLoading: boolean;
+  requestLocation: () => void;
+}
+
+/**
+ * 사용자 위치 정보 Hook
+ * 거리순 정렬 시 사용자의 위도/경도를 제공합니다.
+ */
+export function useUserLocation(): UseUserLocationReturn {
+  const [location, setLocation] = useState<UserLocation | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const requestLocation = useCallback(() => {
+    if (!navigator.geolocation) {
+      setError('브라우저가 위치 정보를 지원하지 않습니다.');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setLocation({
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        });
+        setIsLoading(false);
+      },
+      (err) => {
+        switch (err.code) {
+          case err.PERMISSION_DENIED:
+            setError('위치 정보 접근이 거부되었습니다.');
+            break;
+          case err.POSITION_UNAVAILABLE:
+            setError('위치 정보를 사용할 수 없습니다.');
+            break;
+          case err.TIMEOUT:
+            setError('위치 정보 요청 시간이 초과되었습니다.');
+            break;
+          default:
+            setError('위치 정보를 가져오는 중 오류가 발생했습니다.');
+        }
+        setIsLoading(false);
+      },
+      {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 300000, // 5분간 캐시
+      }
+    );
+  }, []);
+
+  // 컴포넌트 마운트 시 자동으로 위치 요청하지 않음
+  // 거리순 정렬 선택 시에만 requestLocation 호출
+
+  return {
+    location,
+    error,
+    isLoading,
+    requestLocation,
+  };
+}

--- a/src/hooks/custom/useUserLocation.ts
+++ b/src/hooks/custom/useUserLocation.ts
@@ -1,15 +1,18 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 
 export interface UserLocation {
   latitude: number;
   longitude: number;
 }
 
+interface UseUserLocationOptions {
+  onError?: (errorMessage: string) => void;
+}
+
 interface UseUserLocationReturn {
   location: UserLocation | null;
-  error: string | null;
   isLoading: boolean;
   requestLocation: () => void;
 }
@@ -17,30 +20,25 @@ interface UseUserLocationReturn {
 /**
  * 사용자 위치 정보 Hook
  * 거리순 정렬 시 사용자의 위도/경도를 제공합니다.
+ * @param options.onError - 위치 획득 실패 시 호출되는 콜백
  */
-export function useUserLocation(): UseUserLocationReturn {
+export function useUserLocation(options: UseUserLocationOptions = {}): UseUserLocationReturn {
+  const { onError } = options;
   const [location, setLocation] = useState<UserLocation | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   const requestLocation = useCallback(() => {
-    console.log('[useUserLocation] requestLocation 호출됨');
-
     if (!navigator.geolocation) {
-      console.log('[useUserLocation] Geolocation API 미지원');
-      setError('브라우저가 위치 정보를 지원하지 않습니다.');
+      onError?.('브라우저가 위치 정보를 지원하지 않습니다.');
       return;
     }
 
-    console.log('[useUserLocation] getCurrentPosition 요청 시작');
     setIsLoading(true);
-    setError(null);
 
-    // 먼저 빠른 저정밀 위치 시도, 실패 시 고정밀 위치 시도
+    // 고정밀 모드 먼저 시도, 타임아웃 시 저정밀 모드로 폴백
     const tryGetPosition = (highAccuracy: boolean) => {
       navigator.geolocation.getCurrentPosition(
         (position) => {
-          console.log('[useUserLocation] 위치 정보 획득 성공:', position.coords);
           setLocation({
             latitude: position.coords.latitude,
             longitude: position.coords.longitude,
@@ -48,47 +46,45 @@ export function useUserLocation(): UseUserLocationReturn {
           setIsLoading(false);
         },
         (err) => {
-          console.log('[useUserLocation] 위치 정보 오류:', err.code, err.message, { highAccuracy });
-
-          // 고정밀 모드에서 실패 시 저정밀 모드로 재시도
+          // 고정밀 모드에서 타임아웃 시 저정밀 모드로 재시도
           if (highAccuracy && err.code === err.TIMEOUT) {
-            console.log('[useUserLocation] 저정밀 모드로 재시도');
             tryGetPosition(false);
             return;
           }
 
+          let errorMessage: string;
           switch (err.code) {
             case err.PERMISSION_DENIED:
-              setError('위치 정보 접근이 거부되었습니다.');
+              errorMessage = '위치 정보 접근이 거부되었습니다.';
               break;
             case err.POSITION_UNAVAILABLE:
-              setError('위치 정보를 사용할 수 없습니다.');
+              errorMessage = '위치 정보를 사용할 수 없습니다.';
               break;
             case err.TIMEOUT:
-              setError('위치 정보 요청 시간이 초과되었습니다.');
+              errorMessage = '위치 정보 요청 시간이 초과되었습니다.';
               break;
             default:
-              setError('위치 정보를 가져오는 중 오류가 발생했습니다.');
+              errorMessage = '위치 정보를 가져오는 중 오류가 발생했습니다.';
           }
+          onError?.(errorMessage);
           setIsLoading(false);
         },
         {
           enableHighAccuracy: highAccuracy,
-          timeout: highAccuracy ? 5000 : 15000, // 고정밀 5초, 저정밀 15초
+          timeout: highAccuracy ? 5000 : 15000,
           maximumAge: 300000, // 5분간 캐시
         }
       );
     };
 
     tryGetPosition(true);
-  }, []);
+  }, [onError]);
 
   // 컴포넌트 마운트 시 자동으로 위치 요청하지 않음
   // 거리순 정렬 선택 시에만 requestLocation 호출
 
   return {
     location,
-    error,
     isLoading,
     requestLocation,
   };

--- a/src/hooks/custom/useUserLocation.ts
+++ b/src/hooks/custom/useUserLocation.ts
@@ -24,44 +24,63 @@ export function useUserLocation(): UseUserLocationReturn {
   const [isLoading, setIsLoading] = useState(false);
 
   const requestLocation = useCallback(() => {
+    console.log('[useUserLocation] requestLocation 호출됨');
+
     if (!navigator.geolocation) {
+      console.log('[useUserLocation] Geolocation API 미지원');
       setError('브라우저가 위치 정보를 지원하지 않습니다.');
       return;
     }
 
+    console.log('[useUserLocation] getCurrentPosition 요청 시작');
     setIsLoading(true);
     setError(null);
 
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        setLocation({
-          latitude: position.coords.latitude,
-          longitude: position.coords.longitude,
-        });
-        setIsLoading(false);
-      },
-      (err) => {
-        switch (err.code) {
-          case err.PERMISSION_DENIED:
-            setError('위치 정보 접근이 거부되었습니다.');
-            break;
-          case err.POSITION_UNAVAILABLE:
-            setError('위치 정보를 사용할 수 없습니다.');
-            break;
-          case err.TIMEOUT:
-            setError('위치 정보 요청 시간이 초과되었습니다.');
-            break;
-          default:
-            setError('위치 정보를 가져오는 중 오류가 발생했습니다.');
+    // 먼저 빠른 저정밀 위치 시도, 실패 시 고정밀 위치 시도
+    const tryGetPosition = (highAccuracy: boolean) => {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          console.log('[useUserLocation] 위치 정보 획득 성공:', position.coords);
+          setLocation({
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+          });
+          setIsLoading(false);
+        },
+        (err) => {
+          console.log('[useUserLocation] 위치 정보 오류:', err.code, err.message, { highAccuracy });
+
+          // 고정밀 모드에서 실패 시 저정밀 모드로 재시도
+          if (highAccuracy && err.code === err.TIMEOUT) {
+            console.log('[useUserLocation] 저정밀 모드로 재시도');
+            tryGetPosition(false);
+            return;
+          }
+
+          switch (err.code) {
+            case err.PERMISSION_DENIED:
+              setError('위치 정보 접근이 거부되었습니다.');
+              break;
+            case err.POSITION_UNAVAILABLE:
+              setError('위치 정보를 사용할 수 없습니다.');
+              break;
+            case err.TIMEOUT:
+              setError('위치 정보 요청 시간이 초과되었습니다.');
+              break;
+            default:
+              setError('위치 정보를 가져오는 중 오류가 발생했습니다.');
+          }
+          setIsLoading(false);
+        },
+        {
+          enableHighAccuracy: highAccuracy,
+          timeout: highAccuracy ? 5000 : 15000, // 고정밀 5초, 저정밀 15초
+          maximumAge: 300000, // 5분간 캐시
         }
-        setIsLoading(false);
-      },
-      {
-        enableHighAccuracy: true,
-        timeout: 10000,
-        maximumAge: 300000, // 5분간 캐시
-      }
-    );
+      );
+    };
+
+    tryGetPosition(true);
   }, []);
 
   // 컴포넌트 마운트 시 자동으로 위치 요청하지 않음

--- a/src/hooks/queries/explore/index.ts
+++ b/src/hooks/queries/explore/index.ts
@@ -1,0 +1,3 @@
+export * from './useRecruitments';
+export * from './useRecruitmentDetail';
+export * from './useDesigners';

--- a/src/hooks/queries/explore/useDesigners.ts
+++ b/src/hooks/queries/explore/useDesigners.ts
@@ -1,0 +1,44 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getDesigners } from '@/src/apis';
+import type { DesignerListParams, DesignerListResponse, ApiResponse } from '@/src/types';
+
+export const designerKeys = {
+  all: ['designers'] as const,
+  lists: () => [...designerKeys.all, 'list'] as const,
+  list: (params: DesignerListParams) => [...designerKeys.lists(), params] as const,
+};
+
+interface UseDesignersParams extends Omit<DesignerListParams, 'cursorId'> {
+  enabled?: boolean;
+}
+
+/**
+ * 디자이너 목록 무한 스크롤 Hook
+ * useInfiniteQuery를 사용하여 커서 기반 페이징 지원
+ */
+export function useDesigners(params: UseDesignersParams = {}) {
+  const { enabled = true, ...queryParams } = params;
+
+  return useInfiniteQuery<
+    ApiResponse<DesignerListResponse>,
+    Error,
+    { pages: ApiResponse<DesignerListResponse>[]; pageParams: (number | undefined)[] },
+    ReturnType<typeof designerKeys.list>,
+    number | undefined
+  >({
+    queryKey: designerKeys.list(queryParams),
+    queryFn: async ({ pageParam }) => {
+      return getDesigners({
+        ...queryParams,
+        cursorId: pageParam,
+      });
+    },
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.result.hasNext) return undefined;
+      return lastPage.result.nextCursor;
+    },
+    enabled,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+}

--- a/src/hooks/queries/explore/useDesigners.ts
+++ b/src/hooks/queries/explore/useDesigners.ts
@@ -6,6 +6,8 @@ export const designerKeys = {
   all: ['designers'] as const,
   lists: () => [...designerKeys.all, 'list'] as const,
   list: (params: DesignerListParams) => [...designerKeys.lists(), params] as const,
+  details: () => [...designerKeys.all, 'detail'] as const,
+  detail: (id: number) => [...designerKeys.details(), id] as const,
 };
 
 interface UseDesignersParams extends Omit<DesignerListParams, 'cursorId'> {

--- a/src/hooks/queries/explore/useRecruitmentDetail.ts
+++ b/src/hooks/queries/explore/useRecruitmentDetail.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { getRecruitmentDetail } from '@/src/apis';
+import { recruitmentKeys } from './useRecruitments';
+import type { RecruitmentDetail, ApiResponse } from '@/src/types';
+
+interface UseRecruitmentDetailOptions {
+  enabled?: boolean;
+}
+
+/**
+ * 공고 상세 조회 Hook
+ */
+export function useRecruitmentDetail(
+  recruitmentId: number,
+  options: UseRecruitmentDetailOptions = {}
+) {
+  const { enabled = true } = options;
+
+  return useQuery<ApiResponse<RecruitmentDetail>, Error>({
+    queryKey: recruitmentKeys.detail(recruitmentId),
+    queryFn: () => getRecruitmentDetail(recruitmentId),
+    enabled: enabled && recruitmentId > 0,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+}

--- a/src/hooks/queries/explore/useRecruitments.ts
+++ b/src/hooks/queries/explore/useRecruitments.ts
@@ -1,0 +1,46 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getRecruitments } from '@/src/apis';
+import type { RecruitmentListParams, RecruitmentListResponse, ApiResponse } from '@/src/types';
+
+export const recruitmentKeys = {
+  all: ['recruitments'] as const,
+  lists: () => [...recruitmentKeys.all, 'list'] as const,
+  list: (params: RecruitmentListParams) => [...recruitmentKeys.lists(), params] as const,
+  details: () => [...recruitmentKeys.all, 'detail'] as const,
+  detail: (id: number) => [...recruitmentKeys.details(), id] as const,
+};
+
+interface UseRecruitmentsParams extends Omit<RecruitmentListParams, 'cursorId'> {
+  enabled?: boolean;
+}
+
+/**
+ * 공고 목록 무한 스크롤 Hook
+ * useInfiniteQuery를 사용하여 커서 기반 페이징 지원
+ */
+export function useRecruitments(params: UseRecruitmentsParams = {}) {
+  const { enabled = true, ...queryParams } = params;
+
+  return useInfiniteQuery<
+    ApiResponse<RecruitmentListResponse>,
+    Error,
+    { pages: ApiResponse<RecruitmentListResponse>[]; pageParams: (number | undefined)[] },
+    ReturnType<typeof recruitmentKeys.list>,
+    number | undefined
+  >({
+    queryKey: recruitmentKeys.list(queryParams),
+    queryFn: async ({ pageParam }) => {
+      return getRecruitments({
+        ...queryParams,
+        cursorId: pageParam,
+      });
+    },
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.result.hasNext) return undefined;
+      return lastPage.result.nextCursor;
+    },
+    enabled,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -1,2 +1,4 @@
 export * from './auth';
 export * from './signup';
+export * from './explore';
+export * from './likes';

--- a/src/hooks/queries/likes/index.ts
+++ b/src/hooks/queries/likes/index.ts
@@ -1,0 +1,1 @@
+export * from './useLikes';

--- a/src/hooks/queries/likes/useLikes.ts
+++ b/src/hooks/queries/likes/useLikes.ts
@@ -23,8 +23,10 @@ export function useToggleRecruitmentLike() {
       }
       return toggleRecruitmentLike(recruitmentId);
     },
-    onSuccess: () => {
+    onSuccess: (_, recruitmentId) => {
+      // 목록 및 상세 쿼리 모두 갱신
       queryClient.invalidateQueries({ queryKey: recruitmentKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: recruitmentKeys.detail(recruitmentId) });
     },
   });
 }
@@ -46,8 +48,10 @@ export function useToggleDesignerLike() {
       }
       return toggleDesignerLike(designerId);
     },
-    onSuccess: () => {
+    onSuccess: (_, designerId) => {
+      // 목록 및 상세 쿼리 모두 갱신
       queryClient.invalidateQueries({ queryKey: designerKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: designerKeys.detail(designerId) });
     },
   });
 }

--- a/src/hooks/queries/likes/useLikes.ts
+++ b/src/hooks/queries/likes/useLikes.ts
@@ -1,18 +1,28 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toggleRecruitmentLike, toggleDesignerLike } from '@/src/apis';
+import { useAuthStore } from '@/src/stores';
+import { useToast } from '@/src/hooks/common/useToast';
 import { recruitmentKeys } from '../explore/useRecruitments';
 import { designerKeys } from '../explore/useDesigners';
 import type { ApiResponse } from '@/src/types';
 
 /**
  * 공고 찜하기 Mutation Hook
- * 인증 필요 - 컴포넌트에서 로그인 여부 확인 후 호출
+ * 미로그인 시 토스트 메시지 표시 후 요청 차단
  */
 export function useToggleRecruitmentLike() {
   const queryClient = useQueryClient();
+  const { isAuthenticated } = useAuthStore();
+  const { showToast } = useToast();
 
   return useMutation<ApiResponse<string>, Error, number>({
-    mutationFn: toggleRecruitmentLike,
+    mutationFn: (recruitmentId: number) => {
+      if (!isAuthenticated) {
+        showToast('로그인이 필요한 기능입니다.');
+        return Promise.reject(new Error('Unauthorized'));
+      }
+      return toggleRecruitmentLike(recruitmentId);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: recruitmentKeys.lists() });
     },
@@ -21,13 +31,21 @@ export function useToggleRecruitmentLike() {
 
 /**
  * 디자이너 찜하기 Mutation Hook
- * 인증 필요 - 컴포넌트에서 로그인 여부 확인 후 호출
+ * 미로그인 시 토스트 메시지 표시 후 요청 차단
  */
 export function useToggleDesignerLike() {
   const queryClient = useQueryClient();
+  const { isAuthenticated } = useAuthStore();
+  const { showToast } = useToast();
 
   return useMutation<ApiResponse<string>, Error, number>({
-    mutationFn: toggleDesignerLike,
+    mutationFn: (designerId: number) => {
+      if (!isAuthenticated) {
+        showToast('로그인이 필요한 기능입니다.');
+        return Promise.reject(new Error('Unauthorized'));
+      }
+      return toggleDesignerLike(designerId);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: designerKeys.lists() });
     },

--- a/src/hooks/queries/likes/useLikes.ts
+++ b/src/hooks/queries/likes/useLikes.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toggleRecruitmentLike, toggleDesignerLike } from '@/src/apis';
+import { recruitmentKeys } from '../explore/useRecruitments';
+import { designerKeys } from '../explore/useDesigners';
+import type { ApiResponse } from '@/src/types';
+
+/**
+ * 공고 찜하기 Mutation Hook
+ * 인증 필요 - 컴포넌트에서 로그인 여부 확인 후 호출
+ */
+export function useToggleRecruitmentLike() {
+  const queryClient = useQueryClient();
+
+  return useMutation<ApiResponse<string>, Error, number>({
+    mutationFn: toggleRecruitmentLike,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: recruitmentKeys.lists() });
+    },
+  });
+}
+
+/**
+ * 디자이너 찜하기 Mutation Hook
+ * 인증 필요 - 컴포넌트에서 로그인 여부 확인 후 호출
+ */
+export function useToggleDesignerLike() {
+  const queryClient = useQueryClient();
+
+  return useMutation<ApiResponse<string>, Error, number>({
+    mutationFn: toggleDesignerLike,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: designerKeys.lists() });
+    },
+  });
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { PUBLIC_ROUTES, MODEL_ONLY_ROUTES, DESIGNER_ONLY_ROUTES, AUTHENTICATED_ROUTES } from '@/src/constants/routes';
-import { ValidateResponse, ApiResponse } from '@/src/types/auth/auth';
+import { ValidateResponse } from '@/src/types/auth/auth';
+import { ApiResponse } from '@/src/types';
 
 /**
  * 백엔드 API로 accessToken 유효성 검증

--- a/src/mocks/explore/recruitmentDetail.ts
+++ b/src/mocks/explore/recruitmentDetail.ts
@@ -45,6 +45,7 @@ export const mockRecruitmentDetail: RecruitmentDetail = {
   agreeInsta: true,
   agreeMosaic: false,
   etc: '시술 후 홈케어 방법과 스타일링 팁도 자세히 알려드립니다. 궁금한 점이 있으시면 언제든 문의해주세요!',
+  isLiked: false,
 };
 
 // 두 번째 공고 상세 Mock 데이터
@@ -80,4 +81,5 @@ export const mockRecruitmentDetail2: RecruitmentDetail = {
   agreeInsta: true,
   agreeMosaic: true,
   etc: '염색 후 컬러 유지를 위한 홈케어 제품도 추천해드립니다.',
+  isLiked: true,
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -72,12 +72,7 @@
   }
 
   .animate-skeleton {
-    background: linear-gradient(
-      90deg,
-      var(--color-gray-200) 25%,
-      var(--color-gray-300) 50%,
-      var(--color-gray-200) 75%
-    );
+    background: linear-gradient(90deg, var(--color-gray-200) 25%, var(--color-gray-300) 50%, var(--color-gray-200) 75%);
     background-size: 200% 100%;
     animation: skeleton-shimmer 1.5s ease-in-out infinite;
   }
@@ -159,37 +154,6 @@
 @utility text-caption-2-regular {
   font-size: var(--text-caption-2);
   font-weight: var(--font-weight-regular);
-  line-height: var(--leading-150);
-}
-
-/* Number Typography - 숫자 전용 타이포그래피 */
-@utility text-number-1 {
-  font-size: var(--text-head-1);
-  font-weight: var(--font-weight-medium);
-  line-height: var(--leading-140);
-}
-
-@utility text-number-2 {
-  font-size: var(--text-head-2);
-  font-weight: var(--font-weight-medium);
-  line-height: var(--leading-140);
-}
-
-@utility text-number-3 {
-  font-size: var(--text-head-3);
-  font-weight: var(--font-weight-medium);
-  line-height: var(--leading-140);
-}
-
-@utility text-number-4 {
-  font-size: var(--text-body-1);
-  font-weight: var(--font-weight-medium);
-  line-height: var(--leading-140);
-}
-
-@utility text-number-5 {
-  font-size: var(--text-body-2);
-  font-weight: var(--font-weight-medium);
   line-height: var(--leading-150);
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -162,6 +162,37 @@
   line-height: var(--leading-150);
 }
 
+/* Number Typography - 숫자 전용 타이포그래피 */
+@utility text-number-1 {
+  font-size: var(--text-head-1);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--leading-140);
+}
+
+@utility text-number-2 {
+  font-size: var(--text-head-2);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--leading-140);
+}
+
+@utility text-number-3 {
+  font-size: var(--text-head-3);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--leading-140);
+}
+
+@utility text-number-4 {
+  font-size: var(--text-body-1);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--leading-140);
+}
+
+@utility text-number-5 {
+  font-size: var(--text-body-2);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--leading-150);
+}
+
 /* gradation Colors */
 @utility gradation {
   background:

--- a/src/types/auth/auth.ts
+++ b/src/types/auth/auth.ts
@@ -122,11 +122,3 @@ export interface SocialLoginCallbackResponse {
   userRole: 'MODEL' | 'DESIGNER';
 }
 
-// 공통 API 응답 타입
-
-export interface ApiResponse<T> {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  result: T;
-}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,8 @@
+// 공통 API 응답 타입
+
+export interface ApiResponse<T> {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: T;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,8 @@
 // Types index - 타입 통합 export
 
+// Common types
+export * from './common';
+
 // Auth types
 export * from './auth';
 

--- a/src/types/recruitment/recruitment.ts
+++ b/src/types/recruitment/recruitment.ts
@@ -91,5 +91,6 @@ export interface RecruitmentDetail {
   agreeInsta: boolean;
   agreeMosaic: boolean;
   etc: string;
+  isLiked: boolean;
 }
 

--- a/src/utils/debug/apiLogger.ts
+++ b/src/utils/debug/apiLogger.ts
@@ -1,0 +1,37 @@
+/**
+ * API 로깅 유틸리티
+ * 개발 환경에서 SSR/CSR API 호출을 추적하기 위한 로거
+ *
+ * 환경 변수로 제어:
+ * - NEXT_PUBLIC_API_LOGGING=true  → 로깅 활성화
+ * - NEXT_PUBLIC_API_LOGGING=false → 로깅 비활성화 (기본값)
+ */
+
+const isLoggingEnabled = () => {
+  return process.env.NODE_ENV === 'development' && process.env.NEXT_PUBLIC_API_LOGGING === 'true';
+};
+
+const getPrefix = () => {
+  const isServer = typeof window === 'undefined';
+  return isServer ? '[SSR]' : '[CSR]';
+};
+
+export const apiLogger = {
+  request: (method: string, url: string, params?: unknown) => {
+    if (!isLoggingEnabled()) return;
+    const prefix = getPrefix();
+    console.log(`${prefix} [REQ] ${method.toUpperCase()} ${url}`, params ?? '');
+  },
+
+  response: (url: string, status: number, data: unknown) => {
+    if (!isLoggingEnabled()) return;
+    const prefix = getPrefix();
+    console.log(`${prefix} [RES] ${status} ${url}`, data);
+  },
+
+  error: (url: string, status: number, error: unknown) => {
+    if (!isLoggingEnabled()) return;
+    const prefix = getPrefix();
+    console.error(`${prefix} [ERR] ${status} ${url}`, error);
+  },
+};

--- a/src/utils/debug/apiLogger.ts
+++ b/src/utils/debug/apiLogger.ts
@@ -20,18 +20,18 @@ export const apiLogger = {
   request: (method: string, url: string, params?: unknown) => {
     if (!isLoggingEnabled()) return;
     const prefix = getPrefix();
-    console.log(`${prefix} [REQ] ${method.toUpperCase()} ${url}`, params ?? '');
+    console.log(`${prefix} [REQUEST] ${method.toUpperCase()} ${url}`, params ?? '');
   },
 
   response: (url: string, status: number, data: unknown) => {
     if (!isLoggingEnabled()) return;
     const prefix = getPrefix();
-    console.log(`${prefix} [RES] ${status} ${url}`, data);
+    console.log(`${prefix} [RESPONSE] ${status} ${url}`, data);
   },
 
   error: (url: string, status: number, error: unknown) => {
     if (!isLoggingEnabled()) return;
     const prefix = getPrefix();
-    console.error(`${prefix} [ERR] ${status} ${url}`, error);
+    console.error(`${prefix} [ERROR] ${status} ${url}`, error);
   },
 };

--- a/src/utils/debug/index.ts
+++ b/src/utils/debug/index.ts
@@ -1,0 +1,1 @@
+export { apiLogger } from './apiLogger';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './signup';
 export * from './common';
+export * from './debug';


### PR DESCRIPTION
## 💡 To Reviewers

- **Mock/API 전환**: `.env.local`의 `NEXT_PUBLIC_USE_MOCK` 값으로 Mock 데이터와 실제 API 간 전환 가능
  - `true`: Mock 데이터 사용 (개발/테스트용)
  - `false`: 실제 API 연동
- **SSR/CSR 하이브리드**: 초기 데이터는 서버에서 프리페칭하고, 클라이언트에서 무한 스크롤 및 상호작용 처리
- API 응답에서 `null` 값이 올 수 있는 필드들에 대해 방어 처리 적용 (`reviewCount`, `distance`, `isLiked`)

---

## 🔥 작업 내용

### 1. API 레이어 구축
- **공고 API** (`src/apis/explore/recruitments.ts`)
  - `getRecruitments()`: 공고 목록 조회 (커서 기반 페이지네이션)
  - `getRecruitmentDetail()`: 공고 상세 조회
- **디자이너 API** (`src/apis/explore/designers.ts`)
  - `getDesigners()`: 디자이너 목록 조회 (커서 기반 페이지네이션)
- **찜하기 API** (`src/apis/likes/likes.ts`)
  - `toggleRecruitmentLike()`: 공고 찜하기 토글
  - `toggleDesignerLike()`: 디자이너 찜하기 토글

### 2. TanStack Query Hooks 구현
- **공고 목록 조회** (`useRecruitments`)
  - `useInfiniteQuery` 활용 무한 스크롤 지원
  - Query Key Factory 패턴 적용 (`recruitmentKeys`)
- **공고 상세 조회** (`useRecruitmentDetail`)
  - `useQuery` 활용 단일 공고 조회
- **디자이너 목록 조회** (`useDesigners`)
  - `useInfiniteQuery` 활용 무한 스크롤 지원
- **찜하기 Mutation** (`useToggleRecruitmentLike`, `useToggleDesignerLike`)
  - Optimistic Update 지원
  - 인증 여부 확인 후 로그인 페이지 리다이렉트

### 3. SSR/CSR 하이브리드 아키텍처
- **Explore 페이지** (`src/app/(model)/explore/page.tsx`)
  - Server Component로 초기 데이터 프리페칭
  - `HydrationBoundary`로 클라이언트에 데이터 전달
  - 기본값: HAIR 카테고리, 최신순 정렬
- **Post 상세 페이지** (`src/app/(model)/post/[id]/page.tsx`)
  - Server Component로 SSR 처리
  - `generateMetadata()`로 SEO 메타데이터 동적 생성
  - Open Graph 태그 적용

### 4. 클라이언트 컴포넌트 분리
- **ExploreContent** (`src/components/explore/ExploreContent.tsx`)
  - 카테고리/서브카테고리 필터링
  - 무한 스크롤 (IntersectionObserver)
  - 검색 및 정렬 기능
  - 찜하기 토글
- **PostDetailContent** (`src/components/post/PostDetailContent.tsx`)
  - 공고 상세 정보 표시
  - 이미지 갤러리
  - 찜하기 기능
  - 신청하기 버튼

### 5. 서브카테고리 확장
- **네일**: 원컬러, 아트, 페디큐어
- **속눈썹**: 펌, 연장
- **타투**: 일반 디자인, 입술 문신, 눈썹 문신
- 카테고리 변경 시 서브카테고리 자동 리셋

### 6. 기타 개선사항
- **API 로깅 유틸리티** (`src/utils/debug/apiLogger.ts`): 개발 환경에서 API 요청/응답 로깅
- **공통 타입 정리**: `ApiResponse` 중복 제거
- **Null 방어 처리**: 카드 컴포넌트에서 `reviewCount`, `distance`, `isLiked` null 처리

---

## 🤔 추후 작업 예정

- [x] 실제 API 연동 테스트 (Playwright E2E)
- [ ] 디자이너 상세 페이지 SSR 전환
- [ ] 에러 바운더리 적용
- [ ] 로딩 상태 UX 개선 (Skeleton → Suspense)
- [ ] 검색 디바운싱 적용

---

## 📸 작업 결과 (스크린샷)

<img width="1631" height="998" alt="image" src="https://github.com/user-attachments/assets/d1906169-f3f3-4935-a29a-52efabae63ec" />

---

## 🔗 관련 이슈

- #28 

---

## 📁 변경된 파일 (36개)

### API 레이어
| 파일 | 설명 |
|------|------|
| `src/apis/explore/recruitments.ts` | 공고 API 함수 |
| `src/apis/explore/designers.ts` | 디자이너 API 함수 |
| `src/apis/likes/likes.ts` | 찜하기 API 함수 |
| `src/apis/axios.ts` | Axios 인스턴스 로깅 추가 |
| `src/config/api.ts` | Mock/API 전환 설정 |

### Query Hooks
| 파일 | 설명 |
|------|------|
| `src/hooks/queries/explore/useRecruitments.ts` | 공고 목록 조회 훅 |
| `src/hooks/queries/explore/useRecruitmentDetail.ts` | 공고 상세 조회 훅 |
| `src/hooks/queries/explore/useDesigners.ts` | 디자이너 목록 조회 훅 |
| `src/hooks/queries/likes/useLikes.ts` | 찜하기 Mutation 훅 |
| `src/hooks/custom/useUserLocation.ts` | 사용자 위치 정보 훅 |

### 페이지 및 컴포넌트
| 파일 | 설명 |
|------|------|
| `src/app/(model)/explore/page.tsx` | Explore 페이지 SSR 전환 |
| `src/app/(model)/post/[id]/page.tsx` | Post 상세 페이지 SSR 전환 |
| `src/components/explore/ExploreContent.tsx` | Explore 클라이언트 컴포넌트 |
| `src/components/post/PostDetailContent.tsx` | Post 상세 클라이언트 컴포넌트 |
| `src/components/explore/Cards/RecruitmentCard.tsx` | Null 방어 처리 |
| `src/components/explore/Cards/DesignerCard.tsx` | Null 방어 처리 |

### 타입 및 상수
| 파일 | 설명 |
|------|------|
| `src/types/common.ts` | ApiResponse 타입 추가 |
| `src/types/recruitment/recruitment.ts` | isLiked 속성 추가 |
| `src/constants/explore.ts` | 서브카테고리 상수 추가 |

### 유틸리티
| 파일 | 설명 |
|------|------|
| `src/utils/debug/apiLogger.ts` | API 로깅 유틸리티 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 탐색 페이지: 모집·디자이너 목록(검색, 필터, 정렬, 무한 스크롤) 및 위치 기반 거리 정렬
  * 게시물 상세: 동적 SEO 메타데이터와 상세 콘텐츠(이미지 갤러리, 탭 등)
  * 모집/디자이너 찜(토글) 기능
  * 개발용 API 요청·응답 로깅 도구

* **버그 수정**
  * 카드 컴포넌트의 null 안전성 개선
  * 유효하지 않은 게시물 접근 시 적절한 처리 개선

* **리팩토링**
  * 서버사이드 데이터 프리페칭 및 클라이언트 하이드레이션 도입
  * 공통 API 응답 타입 통합 및 타입 정리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->