### PR TITLE
Feature/#39 ios pwa

### DIFF
--- a/src/app/(common)/chat/page.tsx
+++ b/src/app/(common)/chat/page.tsx
@@ -47,7 +47,7 @@ export default function ChatPage() {
   }, [error, showToast]);
 
   return (
-    <div className="min-h-screen bg-white pb-20">
+    <div className="min-h-screen bg-white pb-20 pt-[env(safe-area-inset-top)]">
       <h1 className="text-head-2-semibold px-5 py-3">채팅</h1>
       <SearchInput
         onSearch={setSearchKeyword}

--- a/src/app/(designer)/layout.tsx
+++ b/src/app/(designer)/layout.tsx
@@ -6,16 +6,18 @@ import { BottomNav } from '@/src/components/common';
 export default function DesignerLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
 
-  // 공고 상세/생성/수정 페이지에서는 하단 네비게이션 높이 padding 제외
+  // 공고 상세/생성/수정 페이지에서는 safe-area 및 하단 padding 제외
   const isDetailOrFormPage =
     pathname.match(/^\/myRecruitment\/\d+/) || pathname === '/myRecruitment/create';
 
+  // 메인 컨텐츠 클래스 결정
+  const mainClassName = isDetailOrFormPage
+    ? '' // 상세/폼: safe-area를 컴포넌트에서 개별 처리
+    : 'pt-[env(safe-area-inset-top)] pb-[calc(60px+env(safe-area-inset-bottom))]';
+
   return (
     <>
-      {/* 메인 컨텐츠 */}
-      <main className={isDetailOrFormPage ? '' : 'pb-[calc(60px+env(safe-area-inset-bottom))]'}>{children}</main>
-
-      {/* 하단 네비게이션 */}
+      <main className={mainClassName}>{children}</main>
       <BottomNav />
     </>
   );

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
@@ -107,7 +107,7 @@ export default function StepContent({ goNext, goPrev }: StepContentProps) {
     (purpose !== 'OTHER' || purposeDetail.trim().length > 0);
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    <div className="flex min-h-screen flex-col bg-white pt-[env(safe-area-inset-top)]">
       {/* 헤더 영역 */}
       <div className="flex h-[51px] items-center justify-between px-4 py-3">
         <button

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
@@ -81,7 +81,7 @@ export default function StepTitleDate({ goNext, goPrev }: StepTitleDateProps) {
     selectedDates.every((date) => selectedTimes[date]?.length > 0);
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    <div className="flex min-h-screen flex-col bg-white pt-[env(safe-area-inset-top)]">
       {/* 헤더 영역 */}
       <div className="flex h-[51px] items-center justify-between px-4 py-3">
         <button

--- a/src/app/(designer)/myRecruitment/page.tsx
+++ b/src/app/(designer)/myRecruitment/page.tsx
@@ -121,7 +121,7 @@ export default function MyRecruitmentPage() {
       <button
         type="button"
         onClick={handleCreateClick}
-        className="animate-fab-float fixed bottom-[calc(80px+env(safe-area-inset-bottom))] left-1/2 z-40 flex cursor-pointer items-center gap-1 rounded-full bg-gray-900 px-[14px] py-3"
+        className="animate-fab-float fixed bottom-[calc(107px+env(safe-area-inset-bottom))] left-1/2 z-40 flex cursor-pointer items-center gap-1 rounded-full bg-gray-900 px-[14px] py-3"
       >
         <PlusIcon className="h-3 w-3" />
         <span className="text-body-1-medium text-white">새 모집글</span>

--- a/src/app/(designer)/myRecruitment/page.tsx
+++ b/src/app/(designer)/myRecruitment/page.tsx
@@ -121,7 +121,7 @@ export default function MyRecruitmentPage() {
       <button
         type="button"
         onClick={handleCreateClick}
-        className="animate-fab-float fixed bottom-24 left-1/2 z-40 flex cursor-pointer items-center gap-1 rounded-full bg-gray-900 px-[14px] py-3"
+        className="animate-fab-float fixed bottom-[calc(80px+env(safe-area-inset-bottom))] left-1/2 z-40 flex cursor-pointer items-center gap-1 rounded-full bg-gray-900 px-[14px] py-3"
       >
         <PlusIcon className="h-3 w-3" />
         <span className="text-body-1-medium text-white">새 모집글</span>

--- a/src/app/(model)/layout.tsx
+++ b/src/app/(model)/layout.tsx
@@ -7,12 +7,14 @@ export default function ModelLayout({ children }: { children: React.ReactNode })
   const pathname = usePathname();
   const isPostDetail = pathname.startsWith('/post/');
 
+  // 메인 컨텐츠 클래스 결정
+  const mainClassName = isPostDetail
+    ? '' // post 상세: safe-area 불필요 (이미지 갤러리가 상단까지)
+    : 'pt-[env(safe-area-inset-top)] pb-[calc(60px+env(safe-area-inset-bottom))]';
+
   return (
     <>
-      {/* 메인 컨텐츠 - post 상세 페이지가 아닐 때만 하단 네비게이션 높이만큼 padding 추가 */}
-      <main className={isPostDetail ? '' : 'pb-[calc(60px+env(safe-area-inset-bottom))]'}>{children}</main>
-
-      {/* 하단 네비게이션 */}
+      <main className={mainClassName}>{children}</main>
       <BottomNav />
     </>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 5,
   userScalable: true,
-  themeColor: '#ffffff',
+  themeColor: '#00000000',
   viewportFit: 'cover',
 };
 

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -14,7 +14,7 @@ export default function manifest(): MetadataRoute.Manifest {
     // 배경색 (theme.css의 white)
     background_color: '#ffffff',
     // 테마 컬러 (theme.css의 white)
-    theme_color: '#ffffff',
+    theme_color: '#00000000',
     // PWA 아이콘 설정
     icons: [
       {

--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -111,7 +111,7 @@ export default function BottomNav() {
   };
 
   return (
-    <nav className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 border-t border-gray-200 bg-white pt-2 pb-[env(safe-area-inset-bottom)] sm:w-[375px]">
+    <nav className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 border-t border-gray-200 bg-white pt-2 pb-[calc(16px+env(safe-area-inset-bottom))] sm:w-[375px]">
       <div className="flex">
         {navItems.map((item) => {
           const active = isActive(item.href);

--- a/src/components/explore/Header/ExploreHeader.tsx
+++ b/src/components/explore/Header/ExploreHeader.tsx
@@ -9,7 +9,7 @@ interface ExploreHeaderProps {
 
 export default function ExploreHeader({ view, onViewChange }: ExploreHeaderProps) {
   return (
-    <header className="flex items-center justify-between px-4 py-4 safe-area-top">
+    <header className="flex items-center justify-between px-4 py-4">
       {/* 로고 */}
       <div className="relative h-[25.52px] w-[102.3px]">
         <Image src="/icons/explore/logo.svg" alt="Monde" fill className="object-contain" />

--- a/src/components/myRecruitment/Header/MyRecruitmentHeader.tsx
+++ b/src/components/myRecruitment/Header/MyRecruitmentHeader.tsx
@@ -2,7 +2,7 @@
 
 export default function MyRecruitmentHeader() {
   return (
-    <header className="px-5 py-[13px] safe-area-top">
+    <header className="px-5 py-[13px]">
       <h1 className="text-head-3-semibold text-gray-950">내 모집글</h1>
     </header>
   );


### PR DESCRIPTION
### 💡 To Reviewers

- 새로 설치한 라이브러리 없음
- PWA 앱에서 상태바와 헤더가 겹치는 문제 수정
- 기존 `safe-area-top` 유틸리티는 **standalone 모드(PWA)에서만** 작동하여, Safari 브라우저 접속 시 적용되지 않음
- Safari 브라우저 적용까진 너무 복잡해질거 같아서 뺐습니다.
- Layout 레벨에서 safe-area를 통합 관리하도록 리팩토링

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

#### 1. (model) Layout - Safe Area 통합 처리
- **파일**: `src/app/(model)/layout.tsx`
- `pt-[env(safe-area-inset-top)]` 추가
- `/post/[id]` 페이지는 이미지 갤러리가 상단까지 차야 하므로 제외

```tsx
const mainClassName = isPostDetail
  ? '' // post 상세: safe-area 불필요
  : 'pt-[env(safe-area-inset-top)] pb-[calc(60px+env(safe-area-inset-bottom))]';
```

#### 2. (designer) Layout - Safe Area 통합 처리
- **파일**: `src/app/(designer)/layout.tsx`
- `pt-[env(safe-area-inset-top)]` 추가
- 상세/폼 페이지는 제외 (개별 컴포넌트에서 처리)

#### 3. ExploreHeader - safe-area-top 제거
- **파일**: `src/components/explore/Header/ExploreHeader.tsx`
- Layout에서 처리하므로 헤더에서 `safe-area-top` 제거

#### 4. MyRecruitmentHeader - safe-area-top 제거
- **파일**: `src/components/myRecruitment/Header/MyRecruitmentHeader.tsx`
- Layout에서 처리하므로 헤더에서 `safe-area-top` 제거

#### 5. 모집글 등록 Step 컴포넌트 - Safe Area 추가
- **파일**: `src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx`
- **파일**: `src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx`
- Layout에서 제외되므로 컴포넌트에서 직접 `pt-[env(safe-area-inset-top)]` 추가

#### 6. 채팅 목록 페이지 - Safe Area 추가
- **파일**: `src/app/(common)/chat/page.tsx`
- (common) 그룹은 Layout이 없으므로 페이지에서 직접 처리

---

## 가이드: Safe Area 적용 방법

### 현재 아키텍처

| 라우트 그룹 | Layout | Safe Area 처리 |
|------------|--------|---------------|
| `(model)` | ✅ 있음 | **Layout에서 자동 적용** |
| `(designer)` | ✅ 있음 | **Layout에서 자동 적용** (일부 예외) |
| `(common)` | ❌ 없음 | 페이지/컴포넌트에서 직접 처리 |
| `(auth)` | ❌ 없음 | AuthHeader에서 `safe-area-top` 사용 |

### 새 페이지 작업 시 체크리스트

#### Case 1: (model) 또는 (designer) 그룹에 일반 페이지 추가
```
✅ 아무것도 안 해도 됨 - Layout에서 자동 적용
```

#### Case 2: (model) 그룹에 풀블리드 이미지 페이지 추가
```tsx
// layout.tsx에 예외 조건 추가 필요
const isFullBleedPage = pathname.startsWith('/post/') || pathname.startsWith('/new-page/');
```

#### Case 3: (designer) 그룹에 폼/상세 페이지 추가
```tsx
// 1. layout.tsx의 isDetailOrFormPage 조건에 추가
const isDetailOrFormPage =
  pathname.match(/^\/myRecruitment\/\d+/) ||
  pathname === '/myRecruitment/create' ||
  pathname === '/new-form-page';  // ← 추가

// 2. 해당 페이지 컴포넌트에서 직접 처리
<div className="pt-[env(safe-area-inset-top)]">
```

#### Case 4: (common) 또는 (auth) 그룹에 페이지 추가
```tsx
// 방법 1: 페이지 최상위 div에 직접 추가
<div className="min-h-screen pt-[env(safe-area-inset-top)]">

// 방법 2: 헤더 컴포넌트에 safe-area-top 클래스 사용
<header className="safe-area-top">
```

### ⚠️ 주의사항

1. **`safe-area-top` vs `pt-[env(safe-area-inset-top)]`**
   - `safe-area-top`: standalone PWA 모드에서만 작동
   - `pt-[env(...)]`: 브라우저 + PWA 모두 작동

2. **이중 적용 주의**
   - Layout에서 이미 처리하는 경우, 컴포넌트에서 중복 추가하면 패딩이 두 배가 됨

3. **풀블리드 페이지**
   - 이미지 갤러리 등 상단까지 콘텐츠가 차야 하는 경우 Layout에서 제외 필요

---

### 🤔 추후 작업 예정

- `safe-area-top` 유틸리티를 브라우저에서도 작동하도록 수정 검토 -(권장하지 않음 ㅎㅎ..)
  ```css
  /* 현재 (standalone만) */
  @utility safe-area-top {
    @media (display-mode: standalone) {
      padding-top: env(safe-area-inset-top);
    }
  }

  /* 변경 검토 (항상 적용) */
  @utility safe-area-top {
    padding-top: env(safe-area-inset-top);
  }
  ```
- ChatHeader, AuthHeader 등 `safe-area-top` 사용 컴포넌트 일괄 수정 검토

### 📸 작업 결과 (스크린샷)

- iOS Safari 브라우저에서 테스트 필요
- PWA 설치 후 standalone 모드에서도 테스트 필요 (IOS)

### 🔗 관련 이슈

- #38


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 여러 화면에서 노치/상태표시줄을 고려한 상단 안전 영역 패딩을 일관되게 추가했습니다.
  * 특정 헤더에서 상단 안전 영역 유틸을 제거해 일부 화면의 상단 여백을 조정했습니다.
  * 하단 네비게이션의 패딩과 FAB의 수직 위치를 기기 안전 영역에 맞춰 최적화했습니다.
  * 앱 테마 색상을 투명으로 변경했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->