### PR TITLE
[FIX] 디자이너 회원가입 한줄 소개 필드 추가

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -129,7 +129,7 @@ const LoginContent = () => {
             {/* 카카오 로그인 */}
             <button
               onClick={() => (window.location.href = SOCIAL_LOGIN_URLS.kakao)}
-              className="flex h-[60px] w-[60px] cursor-pointer justify-center rounded-full bg-[#FFE812] pt-[14px] pb-[10px]"
+              className="flex h-[60px] w-[60px] cursor-pointer justify-center rounded-full bg-[#FFE812] pt-3.5 pb-2.5"
             >
               <Image src="/icons/login/kakao.svg" alt="카카오 로그인" width={36} height={36} />
             </button>

--- a/src/app/(auth)/signup/_funnel/steps/1-Terms.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/1-Terms.tsx
@@ -33,7 +33,7 @@ export const StepTerms: React.FC<StepTermsProps> = ({ goNext, isSocial }) => {
       <SignupHeader onBack={() => router.push('/login')} totalSteps={totalSteps} currentStep={1} />
       <SignupTitle line1={SIGNUP_MESSAGES.TERMS.TITLE_1} line2={SIGNUP_MESSAGES.TERMS.TITLE_2} />
       <div
-        className="mx-4 mt-8 flex w-[calc(100%-2rem)] cursor-pointer items-center gap-4 rounded-xl bg-gray-100 p-[16px] sm:w-[343px]"
+        className="mx-4 mt-8 flex w-[calc(100%-2rem)] cursor-pointer items-center gap-4 rounded-xl bg-gray-100 p-4 sm:w-[343px]"
         onClick={handleAllAgree}
       >
         {allAgreed ? <SelectedIcon /> : <SelectIcon />}

--- a/src/app/(auth)/signup/_funnel/steps/4-LoginInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/4-LoginInfo.tsx
@@ -99,7 +99,7 @@ export const StepLoginInfo: React.FC<StepLoginInfoProps> = ({ goPrev, goNext, is
             <div className="flex items-center gap-2">
               <input
                 type="text"
-                className="text-body-2-medium min-w-0 flex-1 rounded-xl bg-gray-100 px-4 py-[14px] text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent"
+                className="text-body-2-medium min-w-0 flex-1 rounded-xl bg-gray-100 px-4 py-3.5 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent"
                 placeholder="아이디를 입력해주세요"
                 value={username}
                 onChange={(e) => handleUsernameChange(e.target.value)}
@@ -107,7 +107,7 @@ export const StepLoginInfo: React.FC<StepLoginInfoProps> = ({ goPrev, goNext, is
               />
               <button
                 type="button"
-                className={`text-body-2-medium w-20 shrink-0 rounded-xl py-[14px] ${
+                className={`text-body-2-medium w-20 shrink-0 rounded-xl py-3.5 ${
                   username && username.length >= 1 ? 'bg-purple-200 text-purple-700' : 'bg-gray-200 text-gray-600'
                 } cursor-pointer`}
                 onClick={checkUsername}
@@ -117,12 +117,12 @@ export const StepLoginInfo: React.FC<StepLoginInfoProps> = ({ goPrev, goNext, is
               </button>
             </div>
             {isUsernameAvailable === true && (
-              <div className="px-[6px] pt-[6px]">
+              <div className="px-1.5 pt-1.5">
                 <p className="text-caption-1-medium text-purple-700">사용 가능한 아이디입니다.</p>
               </div>
             )}
             {isUsernameAvailable === false && (
-              <div className="px-[6px] pt-[6px]">
+              <div className="px-1.5 pt-1.5">
                 <p className="text-caption-1-medium text-error">이미 사용 중인 아이디입니다.</p>
               </div>
             )}

--- a/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
@@ -28,6 +28,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
     nickname,
     gender,
     birthDate,
+    intro,
     storeName,
     address,
     detailAddress,
@@ -75,7 +76,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
 
   // 폼 유효성 검사
   const isFormValid = isDesigner
-    ? nickname && gender && birthDate && storeName && address && category
+    ? nickname && gender && birthDate && intro && storeName && address && category
     : nickname && gender && birthDate;
 
   const isSubmitting = isSocial ? socialSignupMutation.isPending : signupMutation.isPending;
@@ -99,6 +100,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
           ? {
               designer: {
                 shop: storeName,
+                intro: intro,
                 addressLine1: addressLine1,
                 addressLine2: addressLine2 || '',
                 category: convertCategoryToApi(category),
@@ -147,6 +149,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
           ? {
               designer: {
                 shop: storeName,
+                intro: intro,
                 addressLine1: addressLine1,
                 addressLine2: addressLine2 || '',
                 category: convertCategoryToApi(category),
@@ -207,7 +210,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
             <label className="text-body-1-medium text-gray-900">생년월일</label>
             <input
               type="text"
-              className="text-body-2-medium rounded-xl bg-gray-100 px-4 py-[14px] text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent"
+              className="text-body-2-medium rounded-xl bg-gray-100 px-4 py-3.5 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent"
               placeholder="생년월일을 입력해주세요"
               value={birthDate}
               onChange={(e) => handleBirthDateChange(e.target.value)}
@@ -218,6 +221,19 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
           {/* 디자이너 용 필드들 */}
           {isDesigner && (
             <>
+              <div className="relative flex flex-col gap-2">
+                <label className="text-body-1-semibold text-gray-900">한 줄 소개</label>
+                <textarea
+                  value={intro}
+                  onChange={(e) => setField('intro', e.target.value.slice(0, 100))}
+                  placeholder="디자이너 서비스를 소개해주세요"
+                  maxLength={100}
+                  className="text-body-2-medium h-[120px] w-full resize-none overflow-y-auto rounded-xl bg-gray-100 px-4 py-3.5 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent"
+                />
+                <span className="text-body-2-medium absolute right-4 bottom-3 text-gray-600">
+                  {intro.length}/100
+                </span>
+              </div>
               <TextInput
                 label="매장 이름"
                 value={storeName}

--- a/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
@@ -225,7 +225,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
           {isDesigner && (
             <>
               <div className="relative flex flex-col gap-2">
-                <label className="text-body-1-semibold text-gray-900">한 줄 소개</label>
+                <label className="text-body-1-medium text-gray-900">한 줄 소개</label>
                 <textarea
                   value={intro}
                   onChange={(e) => setField('intro', e.target.value.slice(0, 100))}
@@ -233,9 +233,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
                   maxLength={100}
                   className="text-body-2-medium h-[120px] w-full resize-none overflow-y-auto rounded-xl bg-gray-100 px-4 py-3.5 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent"
                 />
-                <span className="text-body-2-medium absolute right-4 bottom-3 text-gray-600">
-                  {intro.length}/100
-                </span>
+                <span className="text-body-2-medium absolute right-4 bottom-3 text-gray-600">{intro.length}/100</span>
               </div>
               <TextInput
                 label="매장 이름"

--- a/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
@@ -102,17 +102,17 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
         ...(isDesigner
           ? {
               designer: {
-                shop: storeName,
-                intro: intro,
+                shop: storeNameTrimmed,
+                intro: introTrimmed,
                 addressLine1: addressLine1,
                 addressLine2: addressLine2 || '',
                 category: convertCategoryToApi(category),
-                nickname: nickname,
+                nickname: nicknameTrimmed,
               },
             }
           : {
               model: {
-                nickname: nickname,
+                nickname: nicknameTrimmed,
               },
             }),
       };
@@ -151,17 +151,17 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
         ...(isDesigner
           ? {
               designer: {
-                shop: storeName,
-                intro: intro,
+                shop: storeNameTrimmed,
+                intro: introTrimmed,
                 addressLine1: addressLine1,
                 addressLine2: addressLine2 || '',
                 category: convertCategoryToApi(category),
-                nickname: nickname,
+                nickname: nicknameTrimmed,
               },
             }
           : {
               model: {
-                nickname: nickname,
+                nickname: nicknameTrimmed,
               },
             }),
       };

--- a/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
@@ -73,11 +73,14 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
   };
 
   const isDesigner = role === 'designer';
+  const nicknameTrimmed = nickname.trim();
+  const introTrimmed = intro.trim();
+  const storeNameTrimmed = storeName.trim();
 
   // 폼 유효성 검사
   const isFormValid = isDesigner
-    ? nickname && gender && birthDate && intro && storeName && address && category
-    : nickname && gender && birthDate;
+    ? nicknameTrimmed && gender && birthDate && introTrimmed && storeNameTrimmed && address && category
+    : nicknameTrimmed && gender && birthDate;
 
   const isSubmitting = isSocial ? socialSignupMutation.isPending : signupMutation.isPending;
 

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -168,7 +168,11 @@ export default function Dropdown({
                       isFocused ? 'bg-gray-50' : ''
                     }`}
                   >
-                    <span className={`text-body-2-medium ${isSelected ? 'text-gray-900' : 'text-gray-500'}`}>
+                    <span
+                      className={`text-body-2-medium ${
+                        value ? (isSelected ? 'text-gray-900' : 'text-gray-500') : 'text-gray-900'
+                      }`}
+                    >
                       {option.label}
                     </span>
                     {isSelected && <CheckIcon />}

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -110,7 +110,7 @@ export default function Dropdown({
     <div className="flex flex-col gap-2" ref={dropdownRef}>
       {/* 라벨 */}
       <div className="flex items-center gap-1">
-        <span id={`${listboxId}-label`} className="text-body-1-semibold text-gray-900">
+        <span id={`${listboxId}-label`} className="text-body-1-medium text-gray-900">
           {label}
         </span>
         {required && <span className="text-head-3-semibold text-purple-500">*</span>}
@@ -145,7 +145,7 @@ export default function Dropdown({
             role="listbox"
             aria-labelledby={`${listboxId}-label`}
             aria-activedescendant={focusedIndex >= 0 ? `${listboxId}-option-${focusedIndex}` : undefined}
-            className="absolute top-14 z-10 w-full rounded-xl border border-solid border-gray-400 bg-white px-4 py-3.5 shadow-dropdown"
+            className="shadow-dropdown absolute top-14 z-10 w-full rounded-xl border border-solid border-gray-400 bg-white px-4 py-3.5"
           >
             <div className="flex flex-col gap-3">
               {options.map((option, index) => {

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -128,7 +128,7 @@ export default function Dropdown({
           aria-labelledby={`${listboxId}-label`}
           aria-controls={isOpen ? listboxId : undefined}
           disabled={disabled}
-          className={`flex w-full items-center justify-between rounded-xl bg-gray-100 px-4 py-[14px] ${
+          className={`flex w-full items-center justify-between rounded-xl bg-gray-100 px-4 py-3.5 ${
             disabled ? 'cursor-not-allowed text-gray-700' : 'cursor-pointer'
           }`}
         >

--- a/src/components/common/Input/PasswordInput.tsx
+++ b/src/components/common/Input/PasswordInput.tsx
@@ -57,7 +57,7 @@ export default function PasswordInput({
           placeholder={placeholder}
           maxLength={maxLength}
           disabled={disabled}
-          className={`text-body-2-medium w-full rounded-xl bg-gray-100 px-4 py-[14px] pr-12 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent disabled:cursor-not-allowed disabled:text-gray-700 ${getStatusRingClass()}`}
+          className={`text-body-2-medium w-full rounded-xl bg-gray-100 px-4 py-3.5 pr-12 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent disabled:cursor-not-allowed disabled:text-gray-700 ${getStatusRingClass()}`}
         />
         {value && !disabled && (
           <button
@@ -72,7 +72,7 @@ export default function PasswordInput({
 
       {/* 하단 메시지 */}
       {message && (
-        <div className="px-[6px]">
+        <div className="px-1.5">
           <p className={`text-caption-1-medium ${getMessageColorClass()}`}>{message}</p>
         </div>
       )}

--- a/src/components/common/Input/PasswordInput.tsx
+++ b/src/components/common/Input/PasswordInput.tsx
@@ -46,7 +46,7 @@ export default function PasswordInput({
   return (
     <div className="flex flex-col gap-2">
       {/* 라벨 */}
-      <span className="text-body-1-semibold text-gray-900">{label}</span>
+      <span className="text-body-1-medium text-gray-900">{label}</span>
 
       {/* 입력 필드 */}
       <div className="relative">
@@ -57,7 +57,7 @@ export default function PasswordInput({
           placeholder={placeholder}
           maxLength={maxLength}
           disabled={disabled}
-          className={`text-body-2-medium w-full rounded-xl bg-gray-100 px-4 py-[14px] pr-12 text-gray-900 placeholder:text-gray-600 focus:placeholder:text-transparent focus:outline-none disabled:text-gray-700 disabled:cursor-not-allowed ${getStatusRingClass()}`}
+          className={`text-body-2-medium w-full rounded-xl bg-gray-100 px-4 py-[14px] pr-12 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent disabled:cursor-not-allowed disabled:text-gray-700 ${getStatusRingClass()}`}
         />
         {value && !disabled && (
           <button

--- a/src/components/common/Input/TextInput.tsx
+++ b/src/components/common/Input/TextInput.tsx
@@ -110,7 +110,7 @@ export default function TextInput({
           onCompositionEnd={handleCompositionEnd}
           placeholder={placeholder}
           disabled={disabled}
-          className={`text-body-2-medium w-full rounded-xl bg-gray-100 px-4 py-[14px] text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent disabled:cursor-not-allowed disabled:text-gray-700 ${
+          className={`text-body-2-medium w-full rounded-xl bg-gray-100 px-4 py-3.5 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent disabled:cursor-not-allowed disabled:text-gray-700 ${
             showClearButton && localValue ? 'pr-10' : ''
           } ${getStatusRingClass()}`}
         />
@@ -127,7 +127,7 @@ export default function TextInput({
 
       {/* 하단 메시지 */}
       {message && (
-        <div className="px-[6px]">
+        <div className="px-1.5">
           <p className={`text-caption-1-medium ${getMessageColorClass()}`}>{message}</p>
         </div>
       )}

--- a/src/components/common/Input/TextInput.tsx
+++ b/src/components/common/Input/TextInput.tsx
@@ -96,7 +96,7 @@ export default function TextInput({
     <div className="flex flex-col gap-2">
       {/* 라벨 */}
       <div className="flex items-center gap-1">
-        <span className="text-body-1-semibold text-gray-900">{label}</span>
+        <span className="text-body-1-medium text-gray-900">{label}</span>
         {required && <span className="text-head-3-semibold text-purple-500">*</span>}
       </div>
 
@@ -110,7 +110,7 @@ export default function TextInput({
           onCompositionEnd={handleCompositionEnd}
           placeholder={placeholder}
           disabled={disabled}
-          className={`text-body-2-medium w-full rounded-xl bg-gray-100 px-4 py-[14px] text-gray-900 placeholder:text-gray-600 focus:placeholder:text-transparent focus:outline-none disabled:text-gray-700 disabled:cursor-not-allowed ${
+          className={`text-body-2-medium w-full rounded-xl bg-gray-100 px-4 py-[14px] text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent disabled:cursor-not-allowed disabled:text-gray-700 ${
             showClearButton && localValue ? 'pr-10' : ''
           } ${getStatusRingClass()}`}
         />

--- a/src/components/signup/3-BasicInfo/AuthCodeInput.tsx
+++ b/src/components/signup/3-BasicInfo/AuthCodeInput.tsx
@@ -27,7 +27,7 @@ export const AuthCodeInput: React.FC<AuthCodeInputProps> = ({
         <div className="relative min-w-0 flex-1">
           <input
             type="text"
-            className={`w-full bg-gray-100 ${authCodeValid === false ? 'ring-1 ring-error' : ''} text-body-2-medium rounded-xl px-4 py-[14px] text-gray-900 placeholder:text-gray-600 focus:placeholder:text-transparent focus:outline-none disabled:text-gray-700`}
+            className={`w-full bg-gray-100 ${authCodeValid === false ? 'ring-error ring-1' : ''} text-body-2-medium rounded-xl px-4 py-3.5 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent disabled:text-gray-700`}
             placeholder="인증번호 입력"
             value={authCode}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAuthCode(e.target.value)}
@@ -43,7 +43,7 @@ export const AuthCodeInput: React.FC<AuthCodeInputProps> = ({
         </div>
         <button
           type="button"
-          className={`text-body-2-medium w-20 shrink-0 rounded-xl py-[14px] ${
+          className={`text-body-2-medium w-20 shrink-0 rounded-xl py-3.5 ${
             authCodeValid === true
               ? 'cursor-not-allowed bg-gray-200 text-gray-600'
               : authCode.length >= 4
@@ -57,12 +57,12 @@ export const AuthCodeInput: React.FC<AuthCodeInputProps> = ({
         </button>
       </div>
       {authCodeError && (
-        <div className="px-[6px] pt-[6px]">
+        <div className="px-1.5 pt-1.5">
           <p className="text-caption-1-medium text-error">{authCodeError}</p>
         </div>
       )}
       {authCodeValid === true && (
-        <div className="px-[6px] pt-[6px]">
+        <div className="px-1.5 pt-1.5">
           <p className="text-caption-1-medium text-purple-700">인증번호가 확인되었습니다.</p>
         </div>
       )}

--- a/src/components/signup/3-BasicInfo/BasicInfoInput.tsx
+++ b/src/components/signup/3-BasicInfo/BasicInfoInput.tsx
@@ -58,7 +58,7 @@ export const BasicInfoInput: React.FC<BasicInfoInputProps> = ({ name, email, set
         <label className="text-body-1-medium text-gray-900">이름 (실명)</label>
         <input
           type="text"
-          className="text-body-2-medium rounded-xl bg-gray-100 px-4 py-[14px] text-gray-900 placeholder:text-gray-600 focus:placeholder:text-transparent focus:outline-none"
+          className="text-body-2-medium rounded-xl bg-gray-100 px-4 py-3.5 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent"
           placeholder="이름을 입력해주세요"
           value={name}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setField('name', e.target.value)}
@@ -71,8 +71,8 @@ export const BasicInfoInput: React.FC<BasicInfoInputProps> = ({ name, email, set
           <input
             type="email"
             className={`min-w-0 flex-1 bg-gray-100 ${
-              emailStatus === 'invalid' ? 'ring-1 ring-error' : ''
-            } text-body-2-medium rounded-xl px-4 py-[14px] text-gray-900 placeholder:text-gray-600 focus:placeholder:text-transparent focus:outline-none`}
+              emailStatus === 'invalid' ? 'ring-error ring-1' : ''
+            } text-body-2-medium py-3.5xt-gray-900 rounded-xl px-4 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent`}
             placeholder="이메일을 입력해주세요"
             value={email}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleEmailChange(e.target.value)}
@@ -81,11 +81,7 @@ export const BasicInfoInput: React.FC<BasicInfoInputProps> = ({ name, email, set
           />
           <button
             type="button"
-            className={`text-body-2-medium w-20 shrink-0 rounded-xl px-4 py-[14px] ${
-              email && isValidEmailFormat(email)
-                ? 'cursor-pointer bg-purple-200 text-purple-700'
-                : 'cursor-not-allowed bg-gray-200 text-gray-600'
-            }`}
+            className={`text-body-2-medium email && isValidEmailFormat(email) ? 'cursor-pointer text-purple-700' : 'cursor-not-allowed text-gray-600' } w-20 shrink-0 rounded-xl bg-gray-200 bg-purple-200 px-4 py-3.5`}
             onClick={handleCheckEmail}
             disabled={!email || !isValidEmailFormat(email) || emailStatus === 'checking'}
           >
@@ -99,12 +95,12 @@ export const BasicInfoInput: React.FC<BasicInfoInputProps> = ({ name, email, set
           </button>
         </div>
         {emailStatus === 'valid' && (
-          <div className="px-[6px] pt-[6px]">
+          <div className="px-1.5 pt-1.5">
             <p className="text-caption-1-medium text-purple-700">{emailMessage}</p>
           </div>
         )}
         {emailStatus === 'invalid' && (
-          <div className="px-[6px] pt-[6px]">
+          <div className="px-1.5 pt-1.5">
             <p className="text-caption-1-medium text-error">{emailMessage}</p>
           </div>
         )}

--- a/src/components/signup/3-BasicInfo/BasicInfoInput.tsx
+++ b/src/components/signup/3-BasicInfo/BasicInfoInput.tsx
@@ -72,7 +72,7 @@ export const BasicInfoInput: React.FC<BasicInfoInputProps> = ({ name, email, set
             type="email"
             className={`min-w-0 flex-1 bg-gray-100 ${
               emailStatus === 'invalid' ? 'ring-error ring-1' : ''
-            } text-body-2-medium py-3.5xt-gray-900 rounded-xl px-4 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent`}
+            } text-body-2-medium rounded-xl px-4 py-3.5 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent`}
             placeholder="이메일을 입력해주세요"
             value={email}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleEmailChange(e.target.value)}
@@ -81,7 +81,11 @@ export const BasicInfoInput: React.FC<BasicInfoInputProps> = ({ name, email, set
           />
           <button
             type="button"
-            className={`text-body-2-medium email && isValidEmailFormat(email) ? 'cursor-pointer text-purple-700' : 'cursor-not-allowed text-gray-600' } w-20 shrink-0 rounded-xl bg-gray-200 bg-purple-200 px-4 py-3.5`}
+            className={`text-body-2-medium w-20 shrink-0 rounded-xl px-4 py-3.5 ${
+              email && isValidEmailFormat(email)
+                ? 'cursor-pointer bg-purple-200 text-purple-700'
+                : 'cursor-not-allowed bg-gray-200 text-gray-600'
+            }`}
             onClick={handleCheckEmail}
             disabled={!email || !isValidEmailFormat(email) || emailStatus === 'checking'}
           >

--- a/src/components/signup/3-BasicInfo/PhoneInputWithAuth.tsx
+++ b/src/components/signup/3-BasicInfo/PhoneInputWithAuth.tsx
@@ -39,7 +39,7 @@ export const PhoneInputWithAuth: React.FC<PhoneInputWithAuthProps> = ({
       <div className="flex min-w-0 items-center gap-2">
         <input
           type="tel"
-          className={`text-body-2-medium min-w-0 flex-1 rounded-xl bg-gray-100 px-4 py-[14px] placeholder:text-gray-600 focus:placeholder:text-transparent focus:outline-none ${
+          className={`text-body-2-medium min-w-0 flex-1 rounded-xl bg-gray-100 px-4 py-3.5 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent ${
             requestSent ? 'text-gray-700' : 'text-gray-900'
           }`}
           placeholder="휴대폰 번호 (숫자만 입력)"
@@ -51,7 +51,7 @@ export const PhoneInputWithAuth: React.FC<PhoneInputWithAuthProps> = ({
         />
         <button
           type="button"
-          className={`text-body-2-medium w-20 shrink-0 rounded-xl px-4 py-[14px] ${
+          className={`text-body-2-medium w-20 shrink-0 rounded-xl px-4 py-3.5 ${
             requestSent
               ? 'border border-purple-400 bg-white text-purple-700'
               : isValidPhone

--- a/src/components/signup/5-ProfileInfo/AddressInput.tsx
+++ b/src/components/signup/5-ProfileInfo/AddressInput.tsx
@@ -42,7 +42,7 @@ export const AddressInput: React.FC<AddressInputProps> = ({
       <div className="relative">
         <input
           type="text"
-          className="text-body-2-medium py-3.5-10 w-full cursor-pointer rounded-xl border border-gray-400 px-4 text-gray-900 placeholder:text-gray-600 focus:outline-none"
+          className="text-body-2-medium w-full cursor-pointer rounded-xl border border-gray-400 px-4 py-3.5 pr-10 text-gray-900 placeholder:text-gray-600 focus:outline-none"
           placeholder="매장 주소를 입력해주세요"
           value={address}
           readOnly

--- a/src/components/signup/5-ProfileInfo/AddressInput.tsx
+++ b/src/components/signup/5-ProfileInfo/AddressInput.tsx
@@ -42,7 +42,7 @@ export const AddressInput: React.FC<AddressInputProps> = ({
       <div className="relative">
         <input
           type="text"
-          className="text-body-2-medium w-full cursor-pointer rounded-xl border border-gray-400 px-4 py-[14px] pr-10 text-gray-900 placeholder:text-gray-600 focus:outline-none"
+          className="text-body-2-medium py-3.5-10 w-full cursor-pointer rounded-xl border border-gray-400 px-4 text-gray-900 placeholder:text-gray-600 focus:outline-none"
           placeholder="매장 주소를 입력해주세요"
           value={address}
           readOnly
@@ -58,7 +58,7 @@ export const AddressInput: React.FC<AddressInputProps> = ({
       </div>
       <input
         type="text"
-        className="text-body-2-medium rounded-xl border border-gray-400 px-4 py-[14px] text-gray-900 placeholder:text-gray-600 focus:outline-none"
+        className="text-body-2-medium rounded-xl border border-gray-400 px-4 py-3.5 text-gray-900 placeholder:text-gray-600 focus:outline-none"
         placeholder="상세주소"
         value={detailAddress}
         onChange={(e) => onDetailAddressChange(e.target.value)}

--- a/src/components/signup/5-ProfileInfo/GenderSelect.tsx
+++ b/src/components/signup/5-ProfileInfo/GenderSelect.tsx
@@ -13,7 +13,7 @@ export const GenderSelect: React.FC<GenderSelectProps> = ({ value, onChange }) =
         <button
           type="button"
           onClick={() => onChange('남자')}
-          className={`text-body-2-medium flex-1 cursor-pointer rounded-xl py-[14px] ${
+          className={`text-body-2-medium flex-1 cursor-pointer rounded-xl py-3.5 ${
             value === '남자' ? 'border-none bg-purple-600 text-white' : 'border border-gray-400 bg-white text-gray-600'
           }`}
         >
@@ -22,7 +22,7 @@ export const GenderSelect: React.FC<GenderSelectProps> = ({ value, onChange }) =
         <button
           type="button"
           onClick={() => onChange('여자')}
-          className={`text-body-2-medium flex-1 cursor-pointer rounded-xl py-[14px] ${
+          className={`text-body-2-medium flex-1 cursor-pointer rounded-xl py-3.5 ${
             value === '여자' ? 'border-none bg-purple-600 text-white' : 'border border-gray-400 bg-white text-gray-600'
           }`}
         >

--- a/src/stores/signup/useSignupStore.ts
+++ b/src/stores/signup/useSignupStore.ts
@@ -17,6 +17,7 @@ export type SignupStoreField =
   | 'nickname'
   | 'gender'
   | 'birthDate'
+  | 'intro'
   | 'storeName'
   | 'address'
   | 'detailAddress'
@@ -38,6 +39,7 @@ interface SignupStore {
   nickname: string;
   gender: string;
   birthDate: string;
+  intro: string;
   storeName: string;
   address: string;
   detailAddress: string;
@@ -84,6 +86,7 @@ export const useSignupStore = create<SignupStore>((set) => ({
   nickname: '',
   gender: '',
   birthDate: '',
+  intro: '',
   storeName: '',
   address: '',
   detailAddress: '',
@@ -128,6 +131,7 @@ export const useSignupStore = create<SignupStore>((set) => ({
       nickname: '',
       gender: '',
       birthDate: '',
+      intro: '',
       storeName: '',
       address: '',
       detailAddress: '',

--- a/src/types/auth/auth.ts
+++ b/src/types/auth/auth.ts
@@ -14,6 +14,7 @@ export interface SignupRequest {
   };
   designer?: {
     shop: string;
+    intro: string;
     addressLine1: string;
     addressLine2: string;
     category: 'HAIR' | 'NAIL' | 'TATTOO' | 'EYELASH';
@@ -35,6 +36,7 @@ export interface SocialSignupRequest {
   };
   designer?: {
     shop: string;
+    intro: string;
     addressLine1: string;
     addressLine2: string;
     category: 'HAIR' | 'NAIL' | 'TATTOO' | 'EYELASH';
@@ -123,4 +125,3 @@ export interface SocialLoginCallbackResponse {
   userRole: 'MODEL' | 'DESIGNER';
   category?: 'HAIR' | 'NAIL' | 'TATTOO' | 'EYELASH'; // 디자이너 카테고리
 }
-


### PR DESCRIPTION
### 💡 To Reviewers

- 디자이너 회원가입 시 필요한 한줄 소개 필드를 추가했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 필드 추가
- UI (100자 제한) 
- auth, singupStore 추가

### 📸 작업 결과 (스크린샷)
- 입력 전
<img width="292" height="639" alt="image" src="https://github.com/user-attachments/assets/5a37d9ec-bd70-4bdd-beb9-f434c24f8f1f" />

- 입력 후
<img width="296" height="642" alt="image" src="https://github.com/user-attachments/assets/6f7c802d-a346-46a6-9694-94851d121188" />

### 🔗 관련 이슈

- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #46 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 디자이너 회원가입에 "한 줄 소개" 입력란 추가(100자 제한, 실시간 글자수 표시).  
  * 가입 흐름에 소개(intro) 필드가 추가되어 소셜/일반 가입 모두에서 활용.

* **버그 수정 / 개선**
  * 닉네임·소개·상점명 제출값을 앞뒤 공백 제거한 값으로 통일해 제출 일관성 향상.
  * 디자이너 가입 유효성 강화(닉네임·생년월일·소개·상점명 검증).

* **스타일**
  * 여러 입력 필드·버튼의 세로 패딩 축소로 UI 간결화 및 중복확인 버튼 비활성화 로직 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->