### PR TITLE
[FIX] 디자이너 내 공고 목록 무한 스크롤 커서 기반 페이지네이션 수정

### DIFF
--- a/src/app/(designer)/myRecruitment/page.tsx
+++ b/src/app/(designer)/myRecruitment/page.tsx
@@ -21,13 +21,22 @@ export default function MyRecruitmentPage() {
   const { isOpen: deleteModalOpen, selectedId: selectedRecruitmentId, openModal, closeModal } = useDeleteModal<number>();
 
   // API Hooks
-  const { data, isLoading } = useDesignerRecruitments({ month: monthString });
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useDesignerRecruitments({
+    month: monthString,
+  });
   const { mutate: deleteRecruitment, isPending: isDeleting } = useDeleteRecruitment();
 
-  // 모든 페이지의 아이템을 평탄화
+  // 모든 페이지의 아이템을 평탄화 + 중복 제거
   const recruitments = useMemo(() => {
     if (!data?.pages) return [];
-    return data.pages.flatMap((page) => page.result.items);
+    const allItems = data.pages.flatMap((page) => page.result.items);
+    // recruitmentId 기준 중복 제거
+    const seen = new Set<number>();
+    return allItems.filter((item) => {
+      if (seen.has(item.recruitmentId)) return false;
+      seen.add(item.recruitmentId);
+      return true;
+    });
   }, [data]);
 
   // 카드 클릭 핸들러
@@ -74,6 +83,9 @@ export default function MyRecruitmentPage() {
             onEdit={handleEdit}
             onDelete={openModal}
             onClick={handleCardClick}
+            onLoadMore={fetchNextPage}
+            hasMore={hasNextPage}
+            isLoadingMore={isFetchingNextPage}
           />
         ) : (
           <RecruitmentEmpty />

--- a/src/components/myRecruitment/List/RecruitmentList.tsx
+++ b/src/components/myRecruitment/List/RecruitmentList.tsx
@@ -5,6 +5,7 @@ import 'swiper/css/pagination';
 
 import { Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import type { Swiper as SwiperType } from 'swiper';
 
 import { RecruitmentCard } from '@/src/components/myRecruitment/Card';
 import type { MyRecruitmentListItem } from '@/src/types/myRecruitment/recruitment';
@@ -14,9 +15,28 @@ interface RecruitmentListProps {
   onEdit?: (id: number) => void;
   onDelete?: (id: number) => void;
   onClick?: (id: number) => void;
+  onLoadMore?: () => void;
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
 }
 
-export default function RecruitmentList({ recruitments, onEdit, onDelete, onClick }: RecruitmentListProps) {
+export default function RecruitmentList({
+  recruitments,
+  onEdit,
+  onDelete,
+  onClick,
+  onLoadMore,
+  hasMore,
+  isLoadingMore,
+}: RecruitmentListProps) {
+  // 마지막 슬라이드 근처에 도달하면 다음 페이지 로드
+  const handleSlideChange = (swiper: SwiperType) => {
+    const isNearEnd = swiper.activeIndex >= swiper.slides.length - 3;
+    if (isNearEnd && hasMore && !isLoadingMore && onLoadMore) {
+      onLoadMore();
+    }
+  };
+
   return (
     <div className="w-full">
       <Swiper
@@ -30,12 +50,25 @@ export default function RecruitmentList({ recruitments, onEdit, onDelete, onClic
         slidesPerView="auto"
         centeredSlides
         className="pb-8!"
+        onSlideChange={handleSlideChange}
+        onReachEnd={() => {
+          if (hasMore && !isLoadingMore && onLoadMore) {
+            onLoadMore();
+          }
+        }}
       >
         {recruitments.map((recruitment) => (
           <SwiperSlide key={recruitment.recruitmentId} className="w-[286px]!">
             <RecruitmentCard recruitment={recruitment} onEdit={onEdit} onDelete={onDelete} onClick={onClick} />
           </SwiperSlide>
         ))}
+        {isLoadingMore && (
+          <SwiperSlide className="w-[286px]! flex items-center justify-center">
+            <div className="flex h-full items-center justify-center">
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-gray-300 border-t-gray-900" />
+            </div>
+          </SwiperSlide>
+        )}
       </Swiper>
 
       <style jsx global>{`

--- a/src/hooks/queries/myRecruitment/useDesignerRecruitments.ts
+++ b/src/hooks/queries/myRecruitment/useDesignerRecruitments.ts
@@ -21,25 +21,45 @@ interface UseDesignerRecruitmentsParams {
 export function useDesignerRecruitments(params: UseDesignerRecruitmentsParams) {
   const { month, size = 10, enabled = true } = params;
 
+  type CursorParam = { cursorId?: number; cursorEarliestDate?: string } | undefined;
+
   return useInfiniteQuery<
     ApiResponse<MyRecruitmentListResponse>,
     Error,
-    { pages: ApiResponse<MyRecruitmentListResponse>[]; pageParams: (number | undefined)[] },
+    { pages: ApiResponse<MyRecruitmentListResponse>[]; pageParams: CursorParam[] },
     ReturnType<typeof myRecruitmentKeys.list>,
-    number | undefined
+    CursorParam
   >({
     queryKey: myRecruitmentKeys.list(month),
     queryFn: async ({ pageParam }) => {
       return getDesignerRecruitments({
         month,
         size,
-        cursorId: pageParam,
+        cursorId: pageParam?.cursorId,
+        cursorEarliestDate: pageParam?.cursorEarliestDate,
       });
     },
-    initialPageParam: undefined,
-    getNextPageParam: (lastPage) => {
+    initialPageParam: undefined as { cursorId?: number; cursorEarliestDate?: string } | undefined,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) => {
       if (!lastPage.result.hasNext) return undefined;
-      return lastPage.result.nextCursor;
+
+      const items = lastPage.result.items;
+      if (items.length === 0) return undefined;
+
+      // 마지막 아이템에서 커서 정보 추출
+      const lastItem = items[items.length - 1];
+      const nextCursorId = lastItem.recruitmentId;
+
+      // period에서 시작 날짜 추출 ("2026-01-03 ~ 2026-01-17" → "2026-01-03")
+      const periodMatch = lastItem.period?.match(/^(\d{4}-\d{2}-\d{2})/);
+      const nextCursorEarliestDate = periodMatch ? periodMatch[1] : undefined;
+
+      // 무한 루프 방지
+      if (nextCursorId === lastPageParam?.cursorId) {
+        return undefined;
+      }
+
+      return { cursorId: nextCursorId, cursorEarliestDate: nextCursorEarliestDate };
     },
     enabled,
     staleTime: 1000 * 60 * 5, // 5분

--- a/src/types/myRecruitment/recruitment.ts
+++ b/src/types/myRecruitment/recruitment.ts
@@ -38,7 +38,7 @@ export interface MyRecruitmentListParams {
 export interface MyRecruitmentListItem {
   recruitmentId: number;
   title: string;
-  period: string; // "12.28 ~ 1.1" 형식
+  period: string; // "2026-01-03 ~ 2026-01-17" 형식 (YYYY-MM-DD ~ YYYY-MM-DD)
   reviewCount: number;
   averageRating: number;
   thumbnail?: string;


### PR DESCRIPTION
### 💡 To Reviewers

- 무한 스크롤 구현 안하고 10개씩만 가져오도록 하는거 수정했음. parameter에 month만 전달하고 있었음.
- 백엔드 커서 기반 페이지네이션이 `cursorId`와 `cursorEarliestDate` 두 가지 파라미터를 모두 필요로 함
- 왜 두개 다 필요하냐면 `cursorId = "마지막 공고 id"`, `cursorEarliestDate = "마지막 공고 시작 날짜"` 이 두 개를 다 보내줘야 DB에서 쉽게 다음 날짜 순으로 보내 줄 수 있음. (기본적으로 보내주는 값이 날짜 이른 순임)

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

**수정 내용**

1. **`useDesignerRecruitments.ts`**
   - `pageParam` 타입을 `number | undefined`에서 `{ cursorId?: number; cursorEarliestDate?: string } | undefined`로 변경
   - `getNextPageParam`에서 마지막 아이템의 `period` 필드에서 시작 날짜 추출 (`"2026-01-03 ~ 2026-01-17"` → `"2026-01-03"`)
   - 무한 루프 방지 로직 추가 (이전 커서와 동일하면 `undefined` 반환)

2. **`RecruitmentList.tsx`**
   - `onLoadMore`, `hasMore`, `isLoadingMore` props 추가
   - Swiper `onSlideChange` 이벤트로 마지막 3개 슬라이드 근처 도달 시 다음 페이지 로드
   - Swiper `onReachEnd` 이벤트로 끝 도달 시 다음 페이지 로드
   - 로딩 중 스피너 슬라이드 추가

3. **`page.tsx`**
   - `useDesignerRecruitments`에서 `fetchNextPage`, `hasNextPage`, `isFetchingNextPage` 추가 구조분해
   - `recruitments` 평탄화 시 `recruitmentId` 기준 중복 제거 로직 추가
   - `RecruitmentList`에 무한 스크롤 관련 props 전달

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- X

### 🔗 관련 이슈

- #67


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 디자이너 모집 피드에 페이지네이션 및 더보기(onLoadMore) 지원 추가
  * 점진적 로드 상태(isLoadingMore) 및 더보기 가능 여부(hasMore) 노출

* **개선 / 버그 픽스**
  * 추가 페이지 병합 시 모집 항목 중복을 제거하도록 집계 로직 개선

* **문서**
  * 모집 기간 표기 예시 형식을 YYYY-MM-DD ~ YYYY-MM-DD로 명시 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->