### PR TITLE
[FIX] 디자이너 홈 - 예약 대기/상세 페이지 recruitmentTitle 추가

### DIFF
--- a/src/app/(common)/mypage/reviews/_components/DesignerReviewsPage.tsx
+++ b/src/app/(common)/mypage/reviews/_components/DesignerReviewsPage.tsx
@@ -3,7 +3,6 @@
 import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import ArrowLeftIcon from '@/public/icons/common/arrow-left.svg';
-import BellIcon from '@/public/icons/designer-home/bell.svg';
 import { useDesignerReviews, useCreateReply, useUpdateReply, usePinReview } from '@/src/hooks/queries/review';
 import { useInfiniteScroll } from '@/src/hooks/common/useInfiniteScroll';
 import { DesignerReviewCard } from '@/src/components/mypage/designer-reviews';
@@ -101,13 +100,7 @@ export default function DesignerReviewsPage() {
           <ArrowLeftIcon className="text-black" />
         </button>
         <h1 className="text-head-4-medium text-center text-black">리뷰 관리</h1>
-        <button
-          type="button"
-          className="flex size-6 cursor-pointer items-center justify-center"
-          aria-label="알림"
-        >
-          <BellIcon className="text-black" />
-        </button>
+        <div className="size-6" />
       </header>
 
       {/* 전체 개수 */}

--- a/src/app/(common)/mypage/reviews/_components/ModelReviewsPage.tsx
+++ b/src/app/(common)/mypage/reviews/_components/ModelReviewsPage.tsx
@@ -3,7 +3,6 @@
 import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import ArrowLeftIcon from '@/public/icons/common/arrow-left.svg';
-import BellIcon from '@/public/icons/designer-home/bell.svg';
 import { useUnreviewedReservations, useWrittenReviews, useDeleteReview } from '@/src/hooks/queries/review';
 import {
   ReviewTabs,
@@ -91,13 +90,7 @@ export default function ModelReviewsPage() {
           <ArrowLeftIcon className="text-black" />
         </button>
         <h1 className="text-head-4-medium text-center text-black">나의 리뷰</h1>
-        <button
-          type="button"
-          className="flex size-6 cursor-pointer items-center justify-center"
-          aria-label="알림"
-        >
-          <BellIcon className="text-black" />
-        </button>
+        <div className="size-6" />
       </header>
 
       {/* 탭 */}

--- a/src/app/(designer)/reservations/[reservationId]/page.tsx
+++ b/src/app/(designer)/reservations/[reservationId]/page.tsx
@@ -107,13 +107,16 @@ export default function ReservationDetailPage() {
 
       {/* 콘텐츠 */}
       <div className="flex-1 overflow-y-auto px-4 pb-24">
-        {/* 카테고리 배지 */}
-        <div className="mb-4 flex flex-wrap items-center gap-2">
-          {[reservation.category, ...reservation.subCategories].map((cat) => (
-            <span key={cat} className="text-caption-1-medium rounded-lg bg-purple-600 px-2 py-1 text-white">
-              {cat}
-            </span>
-          ))}
+        {/* 카테고리 배지 + 공고 제목 */}
+        <div className="mb-4 flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            {[reservation.category, ...reservation.subCategories].map((cat) => (
+              <span key={cat} className="text-caption-1-medium rounded-lg bg-purple-600 px-2 py-1 text-white">
+                {cat}
+              </span>
+            ))}
+          </div>
+          <p className="text-head-4-semibold text-gray-900">{reservation.recruitmentTitle}</p>
         </div>
 
         <div className="flex flex-col gap-4">

--- a/src/components/designerHome/pending/PendingReservationListItem.tsx
+++ b/src/components/designerHome/pending/PendingReservationListItem.tsx
@@ -38,11 +38,14 @@ export function PendingReservationListItem({ item }: PendingReservationListItemP
       href={`/reservations/${item.reservationId}`}
       className="flex flex-col gap-[14px] rounded-[12px] bg-white py-4 pl-5 pr-4"
     >
-      {/* 카테고리 뱃지 */}
-      <div className="flex items-center">
-        <span className="rounded-lg bg-purple-600 px-2 py-1 text-caption-1-medium text-white">
-          {category}
-        </span>
+      {/* 카테고리 뱃지 + 공고 제목 */}
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center">
+          <span className="rounded-lg bg-purple-600 px-2 py-1 text-caption-1-medium text-white">
+            {category}
+          </span>
+        </div>
+        <p className="text-head-4-semibold text-gray-900">{item.recruitmentTitle}</p>
       </div>
 
       {/* 예약 정보 */}

--- a/src/types/designerHome/reservation.ts
+++ b/src/types/designerHome/reservation.ts
@@ -24,6 +24,7 @@ export interface TodayReservationsResult {
 /** 신규 예약 신청 아이템 */
 export interface PendingReservationItem {
   reservationId: number;
+  recruitmentTitle: string;
   modelUserId?: number;
   modelName: string;
   subCategories: string[];
@@ -49,6 +50,7 @@ export type ReservationStatus = '예약대기' | '예약확정' | '예약거절'
 /** 예약 상세 정보 */
 export interface ReservationDetailResult {
   reservationId: number;
+  recruitmentTitle: string;
   modelUserId: number;
   modelName: string;
   category: string;


### PR DESCRIPTION
### 💡 To Reviewers

- 디자이너 홈 - 예약 대기/상세 페이지 -> 타입 변경 및 UI 수정 작업
- - 리뷰 페이지 헤더 수정 -> 벨 아이콘 삭제함.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 디자이너 예약 페이지에 공고 제목(recruitmentTitle) 표시 추가
  - `PendingReservationItem`, `ReservationDetailResult` 타입에 `recruitmentTitle` 필드 추가
  - `/reservations/pending` 페이지 리스트 아이템에 공고 제목 표시
  - `/reservations/[reservationId]` 상세 페이지에 공고 제목 표시
- 리뷰 페이지 헤더 수정
  - `DesignerReviewsPage`, `ModelReviewsPage` 헤더에서 BellIcon 제거
  - 타이틀 중앙 정렬을 위한 여백 요소 추가

### 🤔 추후 작업 예정

- 공고 제목 클릭 시 해당 공고글로 이동하는 기능 (백엔드에서 `recruitmentId` 필드 추가 필요)
- 이유 : 백엔드한테도 전달해야 돼서 미룸.

### 📸 작업 결과 (스크린샷)

<img width="401" height="909" alt="image" src="https://github.com/user-attachments/assets/e4eb04f2-f4cf-4e64-8547-75a830153e86" />

<img width="446" height="907" alt="image" src="https://github.com/user-attachments/assets/d47e1904-dbcb-4930-b685-72177bc4dd4a" />


### 🔗 관련 이슈

- #69


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 예약 상세 페이지에서 모집 제목 정보 표시 추가

* **레이아웃 개선**
  * 카테고리 배지와 모집 제목을 수직 정렬로 변경하여 정보 가독성 향상

* **변경사항**
  * 리뷰 페이지의 알림 버튼 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->