### PR TITLE
[Fix] 디자이너 홈 UI 수정

### DIFF
--- a/public/icons/designer-home/chevron-right.svg
+++ b/public/icons/designer-home/chevron-right.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4.5 2.5L8 6L4.5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/designer-home/profile-placeholder-sm.svg
+++ b/public/icons/designer-home/profile-placeholder-sm.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 14 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="7" cy="4.5" r="3.5" stroke="currentColor" stroke-width="1.5"/>
+  <path d="M1 16.5C1 13.1863 3.68629 10.5 7 10.5C10.3137 10.5 13 13.1863 13 16.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/public/icons/designer-home/profile-placeholder.svg
+++ b/public/icons/designer-home/profile-placeholder.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="7" r="5.5" stroke="currentColor" stroke-width="2"/>
+  <path d="M2 26C2 21.0294 6.02944 17 11 17H13C17.9706 17 22 21.0294 22 26" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/public/icons/designer-home/right-arrow.svg
+++ b/public/icons/designer-home/right-arrow.svg
@@ -1,3 +1,0 @@
-<svg viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M0.75 0.75L7.75 7.75L0.75 14.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/src/app/(designer)/reservations/[reservationId]/page.tsx
+++ b/src/app/(designer)/reservations/[reservationId]/page.tsx
@@ -15,6 +15,8 @@ import {
 import { useReservationDetail, useConfirmReservation, useRejectReservation } from '@/src/hooks/queries/designerHome';
 import { useCreateChatRoom } from '@/src/hooks/queries/chat';
 import { useToast } from '@/src/hooks/common/useToast';
+import Link from 'next/link';
+import ArrowRightIcon from '@/public/icons/common/arrow-right.svg';
 
 export default function ReservationDetailPage() {
   const router = useRouter();
@@ -116,7 +118,10 @@ export default function ReservationDetailPage() {
               </span>
             ))}
           </div>
-          <p className="text-head-4-semibold text-gray-900">{reservation.recruitmentTitle}</p>
+          <Link href={`/myRecruitment/${reservation.recruitmentId}`} className="flex items-center gap-1">
+            <span className="text-head-4-semibold text-gray-900">{reservation.recruitmentTitle}</span>
+            <ArrowRightIcon className="size-5 shrink-0 text-black" />
+          </Link>
         </div>
 
         <div className="flex flex-col gap-4">

--- a/src/components/designerHome/home/DateSelectorBar.tsx
+++ b/src/components/designerHome/home/DateSelectorBar.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+// ===== 요일 상수 =====
+const WEEKDAY_NAMES_KO = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'] as const;
+
+// ===== 날짜 유틸 함수 =====
+function formatDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function generateDateRange(startDate: Date, days: number): Date[] {
+  return Array.from({ length: days }, (_, i) => {
+    const date = new Date(startDate);
+    date.setDate(startDate.getDate() + i);
+    return date;
+  });
+}
+
+function isToday(date: Date): boolean {
+  const today = new Date();
+  return (
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate()
+  );
+}
+
+// ===== DateButton 컴포넌트 =====
+interface DateButtonProps {
+  date: Date;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+function DateButton({ date, isSelected, onClick }: DateButtonProps) {
+  const day = date.getDate();
+  const weekday = WEEKDAY_NAMES_KO[date.getDay()];
+  const isTodayDate = isToday(date);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`cursor-pointer flex w-[63px] shrink-0 flex-col items-center justify-center rounded-[12px] px-4 py-3 shadow-[0px_0px_4px_0px_rgba(34,34,34,0.09)] ${
+        isSelected ? 'bg-gray-900' : 'bg-white'
+      }`}
+    >
+      <span
+        className={`text-[16px] font-medium leading-[1.4] tracking-[-0.32px] ${
+          isSelected ? 'text-white' : 'text-gray-900'
+        }`}
+      >
+        {day}
+      </span>
+      <span
+        className={`text-caption-1-medium ${
+          isSelected ? 'text-gray-200' : 'text-gray-700'
+        }`}
+      >
+        {isTodayDate ? '오늘' : weekday}
+      </span>
+    </button>
+  );
+}
+
+// ===== DateSelectorBar 컴포넌트 =====
+interface DateSelectorBarProps {
+  selectedDate: string;
+  onDateSelect: (date: string) => void;
+}
+
+export function DateSelectorBar({ selectedDate, onDateSelect }: DateSelectorBarProps) {
+  const today = new Date();
+  const dates = generateDateRange(today, 5); // 오늘 + 4일
+
+  return (
+    <div className="flex gap-2 overflow-x-auto px-4 scrollbar-hide">
+      {dates.map((date) => {
+        const dateStr = formatDateString(date);
+        return (
+          <DateButton
+            key={dateStr}
+            date={date}
+            isSelected={dateStr === selectedDate}
+            onClick={() => onDateSelect(dateStr)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/designerHome/home/DesignerHomeContent.tsx
+++ b/src/components/designerHome/home/DesignerHomeContent.tsx
@@ -1,12 +1,17 @@
 'use client';
 
+import { useState } from 'react';
+import Image from 'next/image';
 import BellIcon from '@/public/icons/designer-home/bell.svg';
 import MoandiLogo from '@/public/icons/designer-home/moandiLogo.svg';
+import ProfilePlaceholderIcon from '@/public/icons/designer-home/profile-placeholder.svg';
 import { BottomNav } from '@/src/components/common';
+import { DateSelectorBar } from './DateSelectorBar';
 import { TodayReservationSection } from './TodayReservationSection';
 import { PendingReservationSection } from './PendingReservationSection';
 import { QuickActionButtons } from './QuickActionButtons';
 import { useTodayReservations, usePendingReservations } from '@/src/hooks/queries/designerHome';
+import { useDesignerProfile } from '@/src/hooks/queries/mypage';
 
 // 오늘 날짜를 yyyy-MM-dd 형식으로 반환
 function getTodayDate(): string {
@@ -18,13 +23,18 @@ function getTodayDate(): string {
 }
 
 export function DesignerHomeContent() {
-  const userName = '유디'; // TODO: useAuthStore에서 가져옴
-  const todayDate = getTodayDate();
+  const [selectedDate, setSelectedDate] = useState(getTodayDate());
 
-  const { data: todayData, isLoading: isTodayLoading } = useTodayReservations(todayDate);
+  // 디자이너 프로필 조회
+  const { data: profileData } = useDesignerProfile(true);
+  const designerName = profileData?.result?.nickname ?? '디자이너';
+  const profileImageUrl = profileData?.result?.profileImageUrl ?? null;
+
+  // 예약 데이터 조회
+  const { data: todayData, isLoading: isTodayLoading } = useTodayReservations(selectedDate);
   const { data: pendingData, isLoading: isPendingLoading } = usePendingReservations();
 
-  const todayReservations = todayData?.result ?? { date: todayDate, totalCount: 0, reservations: [] };
+  const todayReservations = todayData?.result ?? { date: selectedDate, totalCount: 0, reservations: [] };
   const pendingReservations = pendingData?.result ?? {
     reservations: [],
     totalCount: 0,
@@ -36,7 +46,7 @@ export function DesignerHomeContent() {
 
   return (
     <>
-      <div className="flex min-h-screen flex-col bg-gray-200 pb-[calc(60px+env(safe-area-inset-bottom)+16px)]">
+      <div className="flex min-h-screen flex-col bg-gray-200">
         {/* 헤더 */}
         <header className="flex h-14 items-center justify-between px-5">
           <MoandiLogo />
@@ -45,22 +55,41 @@ export function DesignerHomeContent() {
           </button>
         </header>
 
-        {/* 환영 메시지 */}
-        <div className="px-4 py-2">
-          <h1 className="text-head-3-semibold text-gray-900">{userName} 디자이너님</h1>
-          <p className="text-head-3-semibold text-gray-900">오늘도 좋은 하루 되세요!</p>
+        {/* 환영 메시지 + 프로필 이미지 */}
+        <div className="flex items-start justify-between px-4 py-2">
+          <div>
+            <h1 className="text-head-3-semibold text-gray-900">{designerName} 디자이너님</h1>
+            <p className="text-head-3-semibold text-gray-900">오늘도 좋은 하루 되세요!</p>
+          </div>
+          <div className="relative size-16 shrink-0 overflow-hidden rounded-full bg-gray-300">
+            {profileImageUrl ? (
+              <Image src={profileImageUrl} alt="프로필" fill className="object-cover" />
+            ) : (
+              <div className="flex size-full items-center justify-center text-gray-500">
+                <ProfilePlaceholderIcon className="size-6" />
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 날짜 선택 바 */}
+        <div className="mt-4">
+          <DateSelectorBar selectedDate={selectedDate} onDateSelect={setSelectedDate} />
         </div>
 
         {/* 오늘의 예약 섹션 */}
-        <div className="mt-4">
+        <div className="mt-5">
           <TodayReservationSection data={todayReservations} isLoading={isTodayLoading} />
         </div>
 
-        {/* 새로운 예약 신청 섹션 */}
-        <PendingReservationSection data={pendingReservations} isLoading={isPendingLoading} />
+        {/* 하단 영역 - BottomNav(87px)와 16px 간격 유지 */}
+        <div className="mt-auto pb-[calc(87px+env(safe-area-inset-bottom)+16px)]">
+          {/* 새로운 예약 신청 섹션 */}
+          <PendingReservationSection data={pendingReservations} isLoading={isPendingLoading} />
 
-        {/* 퀵 액션 버튼 */}
-        <QuickActionButtons />
+          {/* 퀵 액션 버튼 */}
+          <QuickActionButtons />
+        </div>
       </div>
 
       {/* 하단 네비게이션 */}

--- a/src/components/designerHome/home/QuickActionButtons.tsx
+++ b/src/components/designerHome/home/QuickActionButtons.tsx
@@ -19,12 +19,9 @@ export function QuickActionButtons() {
       </Link>
       <Link
         href="/mypage/reviews"
-        className="flex flex-1 items-center justify-center gap-1 rounded-[12px] bg-white py-3 shadow-[0px_0px_11px_0px_rgba(34,34,34,0.04)]"
+        className="flex flex-1 items-center justify-center rounded-[12px] bg-white py-3 shadow-[0px_0px_11px_0px_rgba(34,34,34,0.04)]"
       >
         <span className="text-body-2-semibold text-gray-900">리뷰 관리</span>
-        <span className="flex size-5 items-center justify-center rounded-full bg-purple-600 text-caption-1-medium text-white">
-          7
-        </span>
       </Link>
     </section>
   );

--- a/src/components/designerHome/home/TodayReservationItem.tsx
+++ b/src/components/designerHome/home/TodayReservationItem.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import ClockIcon from '@/public/icons/designer-home/clock.svg';
+import ChevronRightIcon from '@/public/icons/designer-home/chevron-right.svg';
+import ProfilePlaceholderSmIcon from '@/public/icons/designer-home/profile-placeholder-sm.svg';
+import { formatTimeWithPeriod } from '@/src/utils/common';
+import type { TodayReservationItem as TodayReservationItemType } from '@/src/types/designerHome';
+
+interface TodayReservationItemProps {
+  item: TodayReservationItemType;
+}
+
+export function TodayReservationItem({ item }: TodayReservationItemProps) {
+  return (
+    <div className="flex items-center justify-between rounded-[12px] bg-white p-4">
+      {/* 좌측: 프로필 이미지 + 이름 + 모집글 버튼 */}
+      <div className="flex items-center gap-3">
+        {/* 프로필 이미지 */}
+        <div className="relative size-[34px] shrink-0 overflow-hidden rounded-full bg-gray-200">
+          {item.imageUrl ? (
+            <Image src={item.imageUrl} alt={item.modelName} fill className="object-cover" />
+          ) : (
+            <div className="flex size-full items-center justify-center bg-gray-300 text-gray-600">
+              <ProfilePlaceholderSmIcon className="size-[14px]" />
+            </div>
+          )}
+        </div>
+
+        {/* 이름 + 모집글 버튼 */}
+        <div className="flex items-center gap-2">
+          <span className="text-body-1-semibold text-gray-900">{item.modelName} 님</span>
+          <Link
+            href={`/myRecruitment/${item.recruitmentId}`}
+            className="flex items-center gap-0.5 rounded-[8px] border border-gray-400 px-2 py-[5px]"
+          >
+            <span className="text-caption-1-medium text-gray-800">모집글</span>
+            <ChevronRightIcon className="size-3 text-gray-500" />
+          </Link>
+        </div>
+      </div>
+
+      {/* 우측: 시간 배지 */}
+      <div className="flex items-center gap-2 rounded-[8px] bg-purple-100 px-2 py-1">
+        <ClockIcon className="size-4 text-purple-700" />
+        <span className="text-body-2-medium text-purple-700">{formatTimeWithPeriod(item.time)}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/designerHome/home/TodayReservationSection.tsx
+++ b/src/components/designerHome/home/TodayReservationSection.tsx
@@ -1,84 +1,30 @@
 'use client';
 
-import ClockIcon from '@/public/icons/designer-home/clock.svg';
-import RectangleIcon from '@/public/icons/designer-home/rectangle.svg';
-import { formatTimeWithPeriod } from '@/src/utils/common';
-import type { TodayReservationItem, TodayReservationsResult } from '@/src/types/designerHome';
-
-// ===== 요일 상수 =====
-const WEEKDAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
-
-// ===== 날짜 포맷 함수 =====
-function formatDateCard(dateStr: string) {
-  const date = new Date(dateStr);
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const weekday = WEEKDAY_NAMES[date.getDay()];
-  return { month, day, weekday };
-}
-
-// ===== 오늘의 예약 아이템 =====
-function TodayReservationItemRow({ item }: { item: TodayReservationItem }) {
-  return (
-    <div className="flex items-center gap-2 rounded-[12px] bg-purple-100 p-3">
-      <ClockIcon className="size-4 text-purple-700" />
-      <span className="text-body-1-medium text-purple-700">{formatTimeWithPeriod(item.time)}</span>
-      <span className="text-body-1-medium text-purple-700">·</span>
-      <span className="text-body-1-medium text-purple-700">{item.modelName} 님</span>
-      <span className="text-body-1-medium text-purple-700">·</span>
-      <span className="text-body-1-medium text-purple-700">{item.subCategories?.[0] ?? '기타'}</span>
-    </div>
-  );
-}
+import { TodayReservationItem } from './TodayReservationItem';
+import type { TodayReservationsResult } from '@/src/types/designerHome';
 
 interface TodayReservationSectionProps {
   data: TodayReservationsResult;
   isLoading?: boolean;
 }
 
-// ===== 오늘의 예약 섹션 =====
 export function TodayReservationSection({ data, isLoading }: TodayReservationSectionProps) {
-  const { month, day, weekday } = formatDateCard(data.date);
-
   return (
-    <section className="mx-4">
-      <div className="relative">
-        {/* 좌측 스크롤 인디케이터 */}
-        <div className="absolute -top-3 left-16">
-          <RectangleIcon className="h-6 w-4" />
+    <section className="flex flex-col gap-[10px] px-4">
+      {isLoading ? (
+        <>
+          <div className="h-[66px] animate-skeleton rounded-[12px] bg-gray-300" />
+          <div className="h-[66px] animate-skeleton rounded-[12px] bg-gray-300" />
+        </>
+      ) : data.reservations && data.reservations.length > 0 ? (
+        data.reservations.map((item) => (
+          <TodayReservationItem key={item.reservationId} item={item} />
+        ))
+      ) : (
+        <div className="flex h-[66px] items-center justify-center rounded-[12px] bg-white">
+          <p className="text-body-2-medium text-gray-600">예약이 없습니다</p>
         </div>
-
-        {/* 우측 스크롤 인디케이터 */}
-        <div className="absolute -top-3 right-16">
-          <RectangleIcon className="h-6 w-4" />
-        </div>
-
-        {/* 카드 */}
-        <div className="rounded-[20px] border border-gray-300 bg-white px-5 pb-5 pt-7">
-          {/* 날짜 */}
-          <div className="flex items-end gap-2 text-gray-900">
-            <span className="text-[38px] font-medium leading-[1.2] tracking-[-0.76px]">
-              {month}/{day}
-            </span>
-            <span className="text-[23px] font-medium leading-[1.5] tracking-[-0.46px]">
-              {weekday}
-            </span>
-          </div>
-
-          {/* 예약 리스트 */}
-          <div className="mt-4 flex flex-col gap-2">
-            {isLoading ? (
-              <div className="animate-skeleton h-10 rounded-[12px] bg-gray-200" />
-            ) : data.reservations && data.reservations.length > 0 ? (
-              data.reservations.map((item) => (
-                <TodayReservationItemRow key={item.reservationId} item={item} />
-              ))
-            ) : (
-              <p className="text-body-2-medium text-gray-700">오늘 예약이 없습니다</p>
-            )}
-          </div>
-        </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/src/components/designerHome/home/index.ts
+++ b/src/components/designerHome/home/index.ts
@@ -1,4 +1,6 @@
 export { DesignerHomeContent } from './DesignerHomeContent';
+export { DateSelectorBar } from './DateSelectorBar';
 export { TodayReservationSection } from './TodayReservationSection';
+export { TodayReservationItem } from './TodayReservationItem';
 export { PendingReservationSection } from './PendingReservationSection';
 export { QuickActionButtons } from './QuickActionButtons';

--- a/src/types/designerHome/reservation.ts
+++ b/src/types/designerHome/reservation.ts
@@ -7,9 +7,11 @@
 /** 오늘의 예약 아이템 */
 export interface TodayReservationItem {
   reservationId: number;
-  modelName: string;
-  subCategories: string[];
+  recruitmentId: number;
   time: string; // HH:mm
+  modelName: string;
+  imageUrl: string | null;
+  subCategories: string[];
 }
 
 /** 오늘의 예약 목록 응답 */

--- a/src/types/designerHome/reservation.ts
+++ b/src/types/designerHome/reservation.ts
@@ -52,6 +52,7 @@ export type ReservationStatus = '예약대기' | '예약확정' | '예약거절'
 /** 예약 상세 정보 */
 export interface ReservationDetailResult {
   reservationId: number;
+  recruitmentId: number;
   recruitmentTitle: string;
   modelUserId: number;
   modelName: string;


### PR DESCRIPTION
### 💡 To Reviewers

- 디자이너 홈 UI를 Figma 디자인에 맞게 리팩토링했습니다

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

**타입 변경**
- `TodayReservationItem` 타입에 `recruitmentId`, `imageUrl` 필드 추가 (API 스펙 변경 반영)

**새 컴포넌트 추가**
- `DateSelectorBar.tsx`: 오늘 + 4일 날짜 선택 바 컴포넌트
- `TodayReservationItem.tsx`: 예약 아이템 컴포넌트 (프로필 이미지, 이름, 모집글 링크, 시간 배지)

**SVG 아이콘 추가**
- `chevron-right.svg`: 모집글 버튼 화살표 아이콘
- `profile-placeholder.svg`: 프로필 placeholder 아이콘 (64px용)
- `profile-placeholder-sm.svg`: 프로필 placeholder 아이콘 (34px용)

**UI 리팩토링**
- `DesignerHomeContent.tsx`:
  - 날짜 선택 상태 관리 추가
  - `useDesignerProfile` API 연동으로 디자이너 이름/프로필 이미지 표시
  - 인라인 SVG를 파일 import로 변경
- `TodayReservationSection.tsx`: 기존 카드 레이아웃에서 리스트 레이아웃으로 변경
- `QuickActionButtons.tsx`: 리뷰 관리 버튼 배지 제거

**정리**
- 미사용 `right-arrow.svg` 파일 삭제

### 🤔 추후 작업 예정

- 날짜 유틸 함수 통합 리팩토링 (중복 코드 정리)
- 요일 상수 파일 분리
- 예약 상세 페이지 모달 FIGMA 디자인에 맞게 수정

### 📸 작업 결과 (스크린샷)

<img width="450" height="908" alt="image" src="https://github.com/user-attachments/assets/951a91de-eb93-497f-85d7-fa83c1980826" />

### 🔗 관련 이슈

- #76 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 오늘부터 향후 4일 간 날짜 선택바 추가 — 날짜별 예약 확인 가능
  * 예약 항목에 프로필 이미지와 시간이 표시되는 신규 항목 UI 추가
  * 예약 제목에서 관련 모집글로 이동 가능한 링크 추가

* **개선 사항**
  * 예약 목록 렌더링 단순화 및 빈 상태 처리 개선
  * 레이아웃·간격 최적화로 하단 네비게이션과의 정렬 개선
  * 빠른 작업 버튼 영역에서 불필요한 배지 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->