### PR TITLE
[FEAT] 모델 마이페이지 예약 목록 - 대기 중 탭 추가

### DIFF
--- a/src/app/(common)/mypage/reservations/page.tsx
+++ b/src/app/(common)/mypage/reservations/page.tsx
@@ -35,8 +35,8 @@ export default function MyReservationsPage() {
   const role = isClient ? (getUserRole() ?? 'model') : 'model';
   const isLoggedIn = isClient ? !!getAccessToken() : false;
 
-  // 탭 상태
-  const [activeTab, setActiveTab] = useState<ReservationListType>('UPCOMING');
+  // 탭 상태 (대기 중 탭이 기본)
+  const [activeTab, setActiveTab] = useState<ReservationListType>('PENDING');
 
   // 카테고리 필터 상태
   const [selectedCategory, setSelectedCategory] = useState<ReservationCategoryFilter>('ALL');
@@ -136,18 +136,20 @@ export default function MyReservationsPage() {
           />
         )}
 
-        {/* 월 선택 및 전체 개수 */}
-        <div className="flex items-center justify-between">
-          <MonthDropdown
-            options={monthOptions}
-            selectedMonth={selectedMonth}
-            onMonthChange={setSelectedMonth}
-          />
-          <div className="flex items-center gap-1">
-            <span className="text-body-2-medium text-black">전체</span>
-            <span className="text-body-2-semibold text-gray-600">{totalCount}</span>
+        {/* 월 선택 및 전체 개수 (대기 중 탭에서는 월 선택 숨김) */}
+        {activeTab !== 'PENDING' && (
+          <div className="flex items-center justify-between">
+            <MonthDropdown
+              options={monthOptions}
+              selectedMonth={selectedMonth}
+              onMonthChange={setSelectedMonth}
+            />
+            <div className="flex items-center gap-1">
+              <span className="text-body-2-medium text-black">전체</span>
+              <span className="text-body-2-semibold text-gray-600">{totalCount}</span>
+            </div>
           </div>
-        </div>
+        )}
 
         {/* 예약 목록 */}
         <ReservationList

--- a/src/components/mypage/reservations/Card/ModelReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/ModelReservationCard.tsx
@@ -2,16 +2,20 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Image from 'next/image';
-import type { ModelReservationItem, ReservationListType, ReservationInfo, ReservationChangeRequest, ReservationCancelRequest } from '@/src/types';
-import { subCategoryCodeToName, categoryCodeToName } from '@/src/utils/myRecruitment';
-import { formatDateToKorean, formatTimeToKorean } from '@/src/utils/common';
+import type {
+  ModelReservationItem,
+  ReservationListType,
+  ReservationInfo,
+  ReservationChangeRequest,
+  ReservationCancelRequest,
+} from '@/src/types';
 import {
   ReservationChangeModal,
   ReservationCancelModal,
   ReservationSuccessModal,
 } from '@/src/components/reservation';
 import { MOCK_TIME_SLOTS } from '@/src/mocks/calendar';
+import { CategoryBadges, ReservationInfo as ReservationInfoComponent, ReservationTitle } from './common';
 
 interface ModelReservationCardProps {
   reservation: ModelReservationItem;
@@ -33,16 +37,15 @@ export default function ModelReservationCard({
   const isUpcoming = tabType === 'UPCOMING';
   const isCompleted = reservation.status === 'RESERVATION_CANCELLED' || tabType === 'COMPLETED';
 
-  // 예약 정보를 모달에 전달할 형식으로 변환 (모델 입장에서 디자이너 정보 표시)
+  // 예약 정보를 모달에 전달할 형식으로 변환
   const reservationInfo: ReservationInfo = {
     reservationId: reservation.reservationId,
-    modelUserId: reservation.designerUserId, // 디자이너 유저 ID
-    modelName: reservation.designerNickname, // 디자이너 닉네임 표시
+    modelUserId: reservation.designerUserId,
+    modelName: reservation.designerNickname,
     date: reservation.date,
     startTime: reservation.startTime,
   };
 
-  // 카드 클릭 시 공고 상세로 이동
   const handleCardClick = () => {
     router.push(`/post/${reservation.recruitmentId}`);
   };
@@ -55,7 +58,6 @@ export default function ModelReservationCard({
     setIsCancelModalOpen(true);
   };
 
-  // Mock: 예약 변경 요청 처리
   const handleChangeSubmit = (data: ReservationChangeRequest) => {
     console.log('예약 변경 요청:', data);
     setIsChangeModalOpen(false);
@@ -63,7 +65,6 @@ export default function ModelReservationCard({
     setIsSuccessModalOpen(true);
   };
 
-  // Mock: 예약 취소 요청 처리
   const handleCancelSubmit = (data: ReservationCancelRequest) => {
     console.log('예약 취소 요청:', data);
     setIsCancelModalOpen(false);
@@ -71,80 +72,35 @@ export default function ModelReservationCard({
     setIsSuccessModalOpen(true);
   };
 
-  // 성공 모달 확인 버튼 처리
   const handleSuccessConfirm = () => {
     setIsSuccessModalOpen(false);
     setSuccessMessage('');
   };
 
-  // 서브카테고리 한글 변환
-  const subCategoryLabels = reservation.subCategories.map((code) =>
-    subCategoryCodeToName(reservation.category, code)
-  );
-
-  // 카테고리 한글 변환
-  const categoryLabel = categoryCodeToName(reservation.category as 'HAIR' | 'NAIL' | 'TATTOO' | 'EYELASH') ?? reservation.category;
-
   return (
     <div className="flex w-full flex-col gap-5 rounded-[20px] bg-white px-5 py-4">
-      {/* 카테고리 뱃지 */}
       <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-1">
-          {/* 메인 카테고리 뱃지 */}
-          <span className="text-caption-1-medium rounded-lg bg-purple-600 px-2 py-1 text-white">
-            {categoryLabel}
-          </span>
-          {/* 서브카테고리 뱃지 */}
-          {subCategoryLabels.map((label) => (
-            <span
-              key={label}
-              className="text-caption-1-medium rounded-lg bg-purple-200 px-2 py-1 text-purple-700"
-            >
-              {label}
-            </span>
-          ))}
-          {/* 완료 상태 뱃지 */}
-          {isCompleted && (
-            <span className="text-caption-1-medium rounded-lg border border-gray-400 px-2 py-1 text-gray-800">
-              완료
-            </span>
-          )}
-        </div>
+        {/* 카테고리 뱃지 */}
+        <CategoryBadges
+          category={reservation.category}
+          subCategories={reservation.subCategories}
+          statusBadge={isCompleted ? 'completed' : null}
+        />
 
-        {/* 공고 제목 */}
         <div className="flex flex-col gap-4">
-          <button
-            type="button"
+          {/* 공고 제목 */}
+          <ReservationTitle
+            title={reservation.recruitmentTitle}
             onClick={handleCardClick}
-            className="flex cursor-pointer items-center gap-0.5"
-          >
-            <p className="text-head-4-semibold text-gray-900">{reservation.recruitmentTitle}</p>
-            <Image
-              src="/icons/common/chevron-right.svg"
-              alt="상세보기"
-              width={20}
-              height={20}
-              className="text-gray-800"
-            />
-          </button>
+          />
 
           {/* 예약 정보 */}
-          <div className="flex flex-col gap-1">
-            <div className="text-body-2-medium flex items-center gap-4">
-              <span className="w-[51px] text-gray-600">예약 일시</span>
-              <span className="text-gray-900">
-                {formatDateToKorean(reservation.date)} {formatTimeToKorean(reservation.startTime)}
-              </span>
-            </div>
-            <div className="text-body-2-medium flex items-center gap-4">
-              <span className="w-[51px] text-gray-600">디자이너</span>
-              <span className="text-gray-900">{reservation.designerNickname}</span>
-            </div>
-            <div className="text-body-2-medium flex items-center gap-4">
-              <span className="w-[51px] text-gray-600">매장명</span>
-              <span className="text-gray-900">{reservation.shop}</span>
-            </div>
-          </div>
+          <ReservationInfoComponent
+            date={reservation.date}
+            startTime={reservation.startTime}
+            designerNickname={reservation.designerNickname}
+            shop={reservation.shop}
+          />
         </div>
       </div>
 

--- a/src/components/mypage/reservations/Card/PendingReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/PendingReservationCard.tsx
@@ -2,14 +2,12 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Image from 'next/image';
 import type { ModelReservationItem, ReservationInfo, ReservationCancelRequest } from '@/src/types';
-import { subCategoryCodeToName, categoryCodeToName } from '@/src/utils/myRecruitment';
-import { formatDateToKorean, formatTimeToKorean } from '@/src/utils/common';
 import {
   ReservationCancelModal,
   ReservationSuccessModal,
 } from '@/src/components/reservation';
+import { CategoryBadges, ReservationInfo as ReservationInfoComponent, ReservationTitle } from './common';
 
 interface PendingReservationCardProps {
   reservation: ModelReservationItem;
@@ -34,22 +32,18 @@ export default function PendingReservationCard({
     startTime: reservation.startTime,
   };
 
-  // 카드 클릭 시 공고 상세로 이동
   const handleCardClick = () => {
     router.push(`/post/${reservation.recruitmentId}`);
   };
 
-  // 프로필 보기 클릭
   const handleProfileClick = () => {
     router.push(`/designer/${reservation.designerId}`);
   };
 
-  // 신청 취소 클릭
   const handleCancelClick = () => {
     setIsCancelModalOpen(true);
   };
 
-  // 신청 취소 요청 처리
   const handleCancelSubmit = (data: ReservationCancelRequest) => {
     console.log('신청 취소 요청:', data);
     setIsCancelModalOpen(false);
@@ -57,78 +51,35 @@ export default function PendingReservationCard({
     setIsSuccessModalOpen(true);
   };
 
-  // 성공 모달 확인 버튼 처리
   const handleSuccessConfirm = () => {
     setIsSuccessModalOpen(false);
     setSuccessMessage('');
   };
 
-  // 서브카테고리 한글 변환
-  const subCategoryLabels = reservation.subCategories.map((code) =>
-    subCategoryCodeToName(reservation.category, code)
-  );
-
-  // 카테고리 한글 변환
-  const categoryLabel = categoryCodeToName(reservation.category as 'HAIR' | 'NAIL' | 'TATTOO' | 'EYELASH') ?? reservation.category;
-
   return (
     <div className="flex w-full flex-col gap-5 rounded-[20px] bg-white px-5 py-4">
-      {/* 카테고리 뱃지 */}
       <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-1">
-          {/* 메인 카테고리 뱃지 */}
-          <span className="text-caption-1-medium rounded-lg bg-purple-600 px-2 py-1 text-white">
-            {categoryLabel}
-          </span>
-          {/* 서브카테고리 뱃지 */}
-          {subCategoryLabels.map((label) => (
-            <span
-              key={label}
-              className="text-caption-1-medium rounded-lg bg-purple-200 px-2 py-1 text-purple-700"
-            >
-              {label}
-            </span>
-          ))}
-          {/* 확정 대기중 상태 뱃지 */}
-          <span className="text-caption-1-medium rounded-lg border border-gray-400 px-2 py-1 text-gray-800">
-            확정 대기중
-          </span>
-        </div>
+        {/* 카테고리 뱃지 */}
+        <CategoryBadges
+          category={reservation.category}
+          subCategories={reservation.subCategories}
+          statusBadge="pending"
+        />
 
-        {/* 공고 제목 */}
         <div className="flex flex-col gap-4">
-          <button
-            type="button"
+          {/* 공고 제목 */}
+          <ReservationTitle
+            title={reservation.recruitmentTitle}
             onClick={handleCardClick}
-            className="flex cursor-pointer items-center gap-0.5"
-          >
-            <p className="text-head-4-semibold text-gray-900">{reservation.recruitmentTitle}</p>
-            <Image
-              src="/icons/common/chevron-right.svg"
-              alt="상세보기"
-              width={20}
-              height={20}
-              className="text-gray-800"
-            />
-          </button>
+          />
 
           {/* 예약 정보 */}
-          <div className="flex flex-col gap-1">
-            <div className="text-body-2-medium flex items-center gap-4">
-              <span className="w-[51px] text-gray-600">예약 일시</span>
-              <span className="text-gray-900">
-                {formatDateToKorean(reservation.date)} {formatTimeToKorean(reservation.startTime)}
-              </span>
-            </div>
-            <div className="text-body-2-medium flex items-center gap-4">
-              <span className="w-[51px] text-gray-600">디자이너</span>
-              <span className="text-gray-900">{reservation.designerNickname}</span>
-            </div>
-            <div className="text-body-2-medium flex items-center gap-4">
-              <span className="w-[51px] text-gray-600">매장명</span>
-              <span className="text-gray-900">{reservation.shop}</span>
-            </div>
-          </div>
+          <ReservationInfoComponent
+            date={reservation.date}
+            startTime={reservation.startTime}
+            designerNickname={reservation.designerNickname}
+            shop={reservation.shop}
+          />
         </div>
       </div>
 

--- a/src/components/mypage/reservations/Card/PendingReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/PendingReservationCard.tsx
@@ -2,11 +2,8 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import type { ModelReservationItem, ReservationInfo, ReservationCancelRequest } from '@/src/types';
-import {
-  ReservationCancelModal,
-  ReservationSuccessModal,
-} from '@/src/components/reservation';
+import type { ModelReservationItem } from '@/src/types';
+import { ConfirmModal } from '@/src/components/common/Modal';
 import { CategoryBadges, ReservationInfo as ReservationInfoComponent, ReservationTitle } from './common';
 
 interface PendingReservationCardProps {
@@ -20,17 +17,6 @@ export default function PendingReservationCard({
 
   // 모달 상태 관리
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
-  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
-  const [successMessage, setSuccessMessage] = useState('');
-
-  // 예약 정보를 모달에 전달할 형식으로 변환
-  const reservationInfo: ReservationInfo = {
-    reservationId: reservation.reservationId,
-    modelUserId: reservation.designerUserId,
-    modelName: reservation.designerNickname,
-    date: reservation.date,
-    startTime: reservation.startTime,
-  };
 
   const handleCardClick = () => {
     router.push(`/post/${reservation.recruitmentId}`);
@@ -44,16 +30,9 @@ export default function PendingReservationCard({
     setIsCancelModalOpen(true);
   };
 
-  const handleCancelSubmit = (data: ReservationCancelRequest) => {
-    console.log('신청 취소 요청:', data);
+  const handleCancelConfirm = () => {
+    // TODO: API 연동 - 신청 취소 처리
     setIsCancelModalOpen(false);
-    setSuccessMessage('신청이 취소되었습니다');
-    setIsSuccessModalOpen(true);
-  };
-
-  const handleSuccessConfirm = () => {
-    setIsSuccessModalOpen(false);
-    setSuccessMessage('');
   };
 
   return (
@@ -101,20 +80,14 @@ export default function PendingReservationCard({
         </button>
       </div>
 
-      {/* 신청 취소 모달 */}
-      <ReservationCancelModal
+      {/* 신청 취소 확인 모달 */}
+      <ConfirmModal
         isOpen={isCancelModalOpen}
         onClose={() => setIsCancelModalOpen(false)}
-        reservation={reservationInfo}
-        onSubmit={handleCancelSubmit}
-      />
-
-      {/* 성공 모달 */}
-      <ReservationSuccessModal
-        isOpen={isSuccessModalOpen}
-        onClose={() => setIsSuccessModalOpen(false)}
-        message={successMessage}
-        onConfirm={handleSuccessConfirm}
+        onConfirm={handleCancelConfirm}
+        message="예약 신청을 취소하시겠습니까?"
+        cancelText="아니오"
+        confirmText="네"
       />
     </div>
   );

--- a/src/components/mypage/reservations/Card/PendingReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/PendingReservationCard.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import type { ModelReservationItem, ReservationInfo, ReservationCancelRequest } from '@/src/types';
+import { subCategoryCodeToName, categoryCodeToName } from '@/src/utils/myRecruitment';
+import { formatDateToKorean, formatTimeToKorean } from '@/src/utils/common';
+import {
+  ReservationCancelModal,
+  ReservationSuccessModal,
+} from '@/src/components/reservation';
+
+interface PendingReservationCardProps {
+  reservation: ModelReservationItem;
+}
+
+export default function PendingReservationCard({
+  reservation,
+}: PendingReservationCardProps) {
+  const router = useRouter();
+
+  // 모달 상태 관리
+  const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+
+  // 예약 정보를 모달에 전달할 형식으로 변환
+  const reservationInfo: ReservationInfo = {
+    reservationId: reservation.reservationId,
+    modelUserId: reservation.designerUserId,
+    modelName: reservation.designerNickname,
+    date: reservation.date,
+    startTime: reservation.startTime,
+  };
+
+  // 카드 클릭 시 공고 상세로 이동
+  const handleCardClick = () => {
+    router.push(`/post/${reservation.recruitmentId}`);
+  };
+
+  // 프로필 보기 클릭
+  const handleProfileClick = () => {
+    router.push(`/designer/${reservation.designerId}`);
+  };
+
+  // 신청 취소 클릭
+  const handleCancelClick = () => {
+    setIsCancelModalOpen(true);
+  };
+
+  // 신청 취소 요청 처리
+  const handleCancelSubmit = (data: ReservationCancelRequest) => {
+    console.log('신청 취소 요청:', data);
+    setIsCancelModalOpen(false);
+    setSuccessMessage('신청이 취소되었습니다');
+    setIsSuccessModalOpen(true);
+  };
+
+  // 성공 모달 확인 버튼 처리
+  const handleSuccessConfirm = () => {
+    setIsSuccessModalOpen(false);
+    setSuccessMessage('');
+  };
+
+  // 서브카테고리 한글 변환
+  const subCategoryLabels = reservation.subCategories.map((code) =>
+    subCategoryCodeToName(reservation.category, code)
+  );
+
+  // 카테고리 한글 변환
+  const categoryLabel = categoryCodeToName(reservation.category as 'HAIR' | 'NAIL' | 'TATTOO' | 'EYELASH') ?? reservation.category;
+
+  return (
+    <div className="flex w-full flex-col gap-5 rounded-[20px] bg-white px-5 py-4">
+      {/* 카테고리 뱃지 */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-1">
+          {/* 메인 카테고리 뱃지 */}
+          <span className="text-caption-1-medium rounded-lg bg-purple-600 px-2 py-1 text-white">
+            {categoryLabel}
+          </span>
+          {/* 서브카테고리 뱃지 */}
+          {subCategoryLabels.map((label) => (
+            <span
+              key={label}
+              className="text-caption-1-medium rounded-lg bg-purple-200 px-2 py-1 text-purple-700"
+            >
+              {label}
+            </span>
+          ))}
+          {/* 확정 대기중 상태 뱃지 */}
+          <span className="text-caption-1-medium rounded-lg border border-gray-400 px-2 py-1 text-gray-800">
+            확정 대기중
+          </span>
+        </div>
+
+        {/* 공고 제목 */}
+        <div className="flex flex-col gap-4">
+          <button
+            type="button"
+            onClick={handleCardClick}
+            className="flex cursor-pointer items-center gap-0.5"
+          >
+            <p className="text-head-4-semibold text-gray-900">{reservation.recruitmentTitle}</p>
+            <Image
+              src="/icons/common/chevron-right.svg"
+              alt="상세보기"
+              width={20}
+              height={20}
+              className="text-gray-800"
+            />
+          </button>
+
+          {/* 예약 정보 */}
+          <div className="flex flex-col gap-1">
+            <div className="text-body-2-medium flex items-center gap-4">
+              <span className="w-[51px] text-gray-600">예약 일시</span>
+              <span className="text-gray-900">
+                {formatDateToKorean(reservation.date)} {formatTimeToKorean(reservation.startTime)}
+              </span>
+            </div>
+            <div className="text-body-2-medium flex items-center gap-4">
+              <span className="w-[51px] text-gray-600">디자이너</span>
+              <span className="text-gray-900">{reservation.designerNickname}</span>
+            </div>
+            <div className="text-body-2-medium flex items-center gap-4">
+              <span className="w-[51px] text-gray-600">매장명</span>
+              <span className="text-gray-900">{reservation.shop}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 액션 버튼 */}
+      <div className="flex w-full items-center gap-2">
+        <button
+          type="button"
+          onClick={handleProfileClick}
+          className="text-body-2-medium flex h-[41px] flex-1 cursor-pointer items-center justify-center rounded-full bg-gray-900 px-5 py-2.5 text-white"
+        >
+          프로필 보기
+        </button>
+        <button
+          type="button"
+          onClick={handleCancelClick}
+          className="text-body-2-medium flex h-[41px] flex-1 cursor-pointer items-center justify-center rounded-full border border-gray-400 bg-white px-5 py-2.5 text-gray-900"
+        >
+          신청 취소
+        </button>
+      </div>
+
+      {/* 신청 취소 모달 */}
+      <ReservationCancelModal
+        isOpen={isCancelModalOpen}
+        onClose={() => setIsCancelModalOpen(false)}
+        reservation={reservationInfo}
+        onSubmit={handleCancelSubmit}
+      />
+
+      {/* 성공 모달 */}
+      <ReservationSuccessModal
+        isOpen={isSuccessModalOpen}
+        onClose={() => setIsSuccessModalOpen(false)}
+        message={successMessage}
+        onConfirm={handleSuccessConfirm}
+      />
+    </div>
+  );
+}

--- a/src/components/mypage/reservations/Card/common/CategoryBadges.tsx
+++ b/src/components/mypage/reservations/Card/common/CategoryBadges.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { subCategoryCodeToName, categoryCodeToName } from '@/src/utils/myRecruitment';
+
+type StatusBadgeType = 'pending' | 'completed' | null;
+
+interface CategoryBadgesProps {
+  category: string;
+  subCategories: string[];
+  statusBadge?: StatusBadgeType;
+}
+
+const STATUS_BADGE_CONFIG: Record<NonNullable<StatusBadgeType>, string> = {
+  pending: '확정 대기중',
+  completed: '완료',
+};
+
+export default function CategoryBadges({
+  category,
+  subCategories,
+  statusBadge = null,
+}: CategoryBadgesProps) {
+  const categoryLabel =
+    categoryCodeToName(category as 'HAIR' | 'NAIL' | 'TATTOO' | 'EYELASH') ?? category;
+
+  const subCategoryLabels = subCategories.map((code) =>
+    subCategoryCodeToName(category, code)
+  );
+
+  return (
+    <div className="flex items-center gap-1">
+      {/* 메인 카테고리 뱃지 */}
+      <span className="text-caption-1-medium rounded-lg bg-purple-600 px-2 py-1 text-white">
+        {categoryLabel}
+      </span>
+
+      {/* 서브카테고리 뱃지 */}
+      {subCategoryLabels.map((label) => (
+        <span
+          key={label}
+          className="text-caption-1-medium rounded-lg bg-purple-200 px-2 py-1 text-purple-700"
+        >
+          {label}
+        </span>
+      ))}
+
+      {/* 상태 뱃지 */}
+      {statusBadge && (
+        <span className="text-caption-1-medium rounded-lg border border-gray-400 px-2 py-1 text-gray-800">
+          {STATUS_BADGE_CONFIG[statusBadge]}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/mypage/reservations/Card/common/ReservationInfo.tsx
+++ b/src/components/mypage/reservations/Card/common/ReservationInfo.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { formatDateToKorean, formatTimeToKorean } from '@/src/utils/common';
+
+interface ReservationInfoProps {
+  date: string;
+  startTime: string;
+  designerNickname: string;
+  shop: string;
+}
+
+export default function ReservationInfo({
+  date,
+  startTime,
+  designerNickname,
+  shop,
+}: ReservationInfoProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-body-2-medium flex items-center gap-4">
+        <span className="w-[51px] text-gray-600">예약 일시</span>
+        <span className="text-gray-900">
+          {formatDateToKorean(date)} {formatTimeToKorean(startTime)}
+        </span>
+      </div>
+      <div className="text-body-2-medium flex items-center gap-4">
+        <span className="w-[51px] text-gray-600">디자이너</span>
+        <span className="text-gray-900">{designerNickname}</span>
+      </div>
+      <div className="text-body-2-medium flex items-center gap-4">
+        <span className="w-[51px] text-gray-600">매장명</span>
+        <span className="text-gray-900">{shop}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/mypage/reservations/Card/common/ReservationTitle.tsx
+++ b/src/components/mypage/reservations/Card/common/ReservationTitle.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import Image from 'next/image';
+
+interface ReservationTitleProps {
+  title: string;
+  onClick: () => void;
+}
+
+export default function ReservationTitle({ title, onClick }: ReservationTitleProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex cursor-pointer items-center gap-0.5"
+    >
+      <p className="text-head-4-semibold text-gray-900">{title}</p>
+      <Image
+        src="/icons/common/chevron-right.svg"
+        alt="상세보기"
+        width={20}
+        height={20}
+        className="text-gray-800"
+      />
+    </button>
+  );
+}

--- a/src/components/mypage/reservations/Card/common/index.ts
+++ b/src/components/mypage/reservations/Card/common/index.ts
@@ -1,0 +1,3 @@
+export { default as CategoryBadges } from './CategoryBadges';
+export { default as ReservationInfo } from './ReservationInfo';
+export { default as ReservationTitle } from './ReservationTitle';

--- a/src/components/mypage/reservations/Card/index.ts
+++ b/src/components/mypage/reservations/Card/index.ts
@@ -1,2 +1,3 @@
 export { default as ModelReservationCard } from './ModelReservationCard';
 export { default as DesignerReservationCard } from './DesignerReservationCard';
+export { default as PendingReservationCard } from './PendingReservationCard';

--- a/src/components/mypage/reservations/List/ReservationList.tsx
+++ b/src/components/mypage/reservations/List/ReservationList.tsx
@@ -6,7 +6,7 @@ import type {
   ReservationListType,
 } from '@/src/types';
 import { useInfiniteScroll } from '@/src/hooks/common';
-import { ModelReservationCard, DesignerReservationCard } from '../Card';
+import { ModelReservationCard, DesignerReservationCard, PendingReservationCard } from '../Card';
 import ReservationListSkeleton from './ReservationListSkeleton';
 
 type ReservationItem = ModelReservationItem | DesignerReservationItem;
@@ -52,21 +52,35 @@ export default function ReservationList({
 
   return (
     <div className="flex flex-col gap-4">
-      {items.map((item) =>
-        role === 'model' ? (
-          <ModelReservationCard
-            key={item.reservationId}
-            reservation={item as ModelReservationItem}
-            tabType={tabType}
-          />
-        ) : (
+      {items.map((item) => {
+        // 모델 - 대기 중 탭
+        if (role === 'model' && tabType === 'PENDING') {
+          return (
+            <PendingReservationCard
+              key={item.reservationId}
+              reservation={item as ModelReservationItem}
+            />
+          );
+        }
+        // 모델 - 다가오는 일정 / 완료된 일정
+        if (role === 'model') {
+          return (
+            <ModelReservationCard
+              key={item.reservationId}
+              reservation={item as ModelReservationItem}
+              tabType={tabType}
+            />
+          );
+        }
+        // 디자이너
+        return (
           <DesignerReservationCard
             key={item.reservationId}
             reservation={item as DesignerReservationItem}
             tabType={tabType}
           />
-        )
-      )}
+        );
+      })}
 
       {/* 무한 스크롤 트리거 */}
       <div ref={loadMoreRef} className="h-4" />

--- a/src/constants/reservation.ts
+++ b/src/constants/reservation.ts
@@ -4,6 +4,7 @@ import type { ReservationListType, MyReservationStatus, ReservationCategoryFilte
 
 /** 예약 내역 탭 옵션 */
 export const RESERVATION_TABS: { value: ReservationListType; label: string }[] = [
+  { value: 'PENDING', label: '대기 중' },
   { value: 'UPCOMING', label: '다가오는 일정' },
   { value: 'COMPLETED', label: '완료된 일정' },
 ];

--- a/src/types/reservation/myReservations.ts
+++ b/src/types/reservation/myReservations.ts
@@ -7,7 +7,7 @@ export type MyReservationStatus =
   | 'RESERVATION_CANCELLED';
 
 // 예약 목록 타입 (탭)
-export type ReservationListType = 'UPCOMING' | 'COMPLETED';
+export type ReservationListType = 'PENDING' | 'UPCOMING' | 'COMPLETED';
 
 // 예약 카테고리 필터
 export type ReservationCategoryFilter = 'ALL' | 'HAIR' | 'NAIL' | 'TATTOO' | 'EYELASH';


### PR DESCRIPTION
### 💡 To Reviewers

- 기존 `ConfirmModal` 공통 컴포넌트를 재사용하여 신청 취소 모달 구현
- 예약 카드 컴포넌트 간 중복 코드를 `common/` 폴더로 추출하여 리팩토링

### 🔥 작업 내용

- **대기 중(PENDING) 탭 추가**: 예약 목록 페이지에 "대기 중" 탭을 첫 번째 탭으로 추가
- **PendingReservationCard 컴포넌트 생성**: 대기 중 예약 전용 카드 컴포넌트
  - "확정 대기중" 상태 뱃지 표시
  - "프로필 보기", "신청 취소" 버튼 제공
- **신청 취소 모달**: `ConfirmModal`을 사용한 간단한 확인 모달 ("예약 신청을 취소하시겠습니까?")
- **공통 컴포넌트 추출** (리팩토링):
  - `CategoryBadges`: 카테고리/서브카테고리/상태 뱃지
  - `ReservationInfo`: 예약 일시, 디자이너, 매장명
  - `ReservationTitle`: 공고 제목 + 화살표
- **기본 탭 변경**: 페이지 진입 시 "대기 중" 탭이 기본 선택
- **월 선택 UI**: 대기 중 탭에서는 월 선택 드롭다운 숨김

### 🤔 추후 작업 예정

- 신청 취소 API 연동 (현재 TODO 상태)

### 📸 작업 결과 (스크린샷)

#### 대기 중 탭
<img width="479" height="906" alt="image" src="https://github.com/user-attachments/assets/d090de97-2c85-4777-b799-ac8f568dc7ed" />

#### 신청 취소 모달
<img width="450" height="908" alt="image" src="https://github.com/user-attachments/assets/28c4df4d-87c2-48bc-b6a1-5327f00fd197" />

### 🔗 관련 이슈

- #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 예약 관리 페이지 업데이트

* **New Features**
  * 예약 탭에 "대기 중" 옵션이 추가되었습니다.
  * 대기 중인 예약을 위한 새로운 카드 디자인이 추가되었습니다.
  * 예약 취소 시 확인 모달이 표시됩니다.

* **Changes**
  * 예약 페이지의 기본 탭이 "대기 중"으로 변경되었습니다.
  * "대기 중" 탭 보기 시 월간 드롭다운이 숨겨집니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->