### PR TITLE
[FEAT] 내 모집글 페이지 모집중/마감 탭 UI 구현

### DIFF
--- a/src/apis/designer/recruitments.ts
+++ b/src/apis/designer/recruitments.ts
@@ -139,13 +139,22 @@ export async function uploadRecruitmentImages(files: File[]): Promise<ImageUploa
 function getMockDesignerRecruitments(
   params: MyRecruitmentListParams
 ): Promise<ApiResponse<MyRecruitmentListResponse>> {
-  const { month, size = DEFAULT_PAGE_SIZE, cursorId } = params;
+  const { status, month, size = DEFAULT_PAGE_SIZE, cursorId } = params;
 
-  // 해당 월에 맞는 공고 필터링 (_month 필드로 필터링 후 제거)
-  const filteredItems = mockMyRecruitmentItems
-    .filter((item) => item._month === month)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    .map(({ _month, ...rest }) => rest);
+  let filteredItems;
+
+  if (status === 'CLOSED') {
+    // 마감 공고: 월 필터 없이 전체 반환 (실제로는 마감된 공고만)
+    filteredItems = mockMyRecruitmentItems
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      .map(({ _month, ...rest }) => rest);
+  } else {
+    // 모집중 공고: 해당 월에 맞는 공고 필터링
+    filteredItems = mockMyRecruitmentItems
+      .filter((item) => item._month === month)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      .map(({ _month, ...rest }) => rest);
+  }
 
   // 커서 기반 페이징
   const startIndex = cursorId

--- a/src/app/(designer)/myRecruitment/page.tsx
+++ b/src/app/(designer)/myRecruitment/page.tsx
@@ -42,6 +42,9 @@ export default function MyRecruitmentPage() {
   const {
     data: closedData,
     isLoading: isClosedLoading,
+    fetchNextPage: fetchClosedNextPage,
+    hasNextPage: hasClosedNextPage,
+    isFetchingNextPage: isFetchingClosedNextPage,
   } = useDesignerRecruitments({
     status: 'CLOSED',
     month: monthString, // 임시: 백엔드에서 month 필수로 요구
@@ -150,6 +153,9 @@ export default function MyRecruitmentPage() {
             recruitments={closedRecruitments}
             totalCount={closedRecruitments.length}
             onClick={handleCardClick}
+            onLoadMore={fetchClosedNextPage}
+            hasMore={hasClosedNextPage}
+            isLoadingMore={isFetchingClosedNextPage}
           />
         )
       )}

--- a/src/app/(designer)/myRecruitment/page.tsx
+++ b/src/app/(designer)/myRecruitment/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import PlusIcon from '@/public/icons/myRecruitment/plus.svg';
 import { CalendarHeader } from '@/src/components/myRecruitment/Calendar';
 import { MyRecruitmentHeader } from '@/src/components/myRecruitment/Header';
-import { RecruitmentList, RecruitmentEmpty } from '@/src/components/myRecruitment/List';
+import { RecruitmentList, RecruitmentEmpty, ClosedRecruitmentList } from '@/src/components/myRecruitment/List';
+import { RecruitmentTabs, type RecruitmentTabType } from '@/src/components/myRecruitment/Tabs';
 import { ConfirmModal } from '@/src/components/common';
 import { useDesignerRecruitments, useDeleteRecruitment } from '@/src/hooks/queries/myRecruitment';
 import { useMonthNavigation, useDeleteModal } from '@/src/hooks/custom/myRecruitment';
@@ -14,30 +15,64 @@ import { useMonthNavigation, useDeleteModal } from '@/src/hooks/custom/myRecruit
 export default function MyRecruitmentPage() {
   const router = useRouter();
 
+  // 탭 상태
+  const [activeTab, setActiveTab] = useState<RecruitmentTabType>('active');
+
   // 월 네비게이션 상태
   const { year, month, monthString, handlePrevMonth, handleNextMonth } = useMonthNavigation();
 
   // 삭제 모달 상태
   const { isOpen: deleteModalOpen, selectedId: selectedRecruitmentId, openModal, closeModal } = useDeleteModal<number>();
 
-  // API Hooks
-  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useDesignerRecruitments({
+  // API Hooks - 모집중 공고
+  const {
+    data: activeData,
+    isLoading: isActiveLoading,
+    fetchNextPage: fetchActiveNextPage,
+    hasNextPage: hasActiveNextPage,
+    isFetchingNextPage: isFetchingActiveNextPage,
+  } = useDesignerRecruitments({
+    status: 'ACTIVE',
     month: monthString,
+    enabled: activeTab === 'active',
   });
+
+  // API Hooks - 마감 공고
+  // TODO: 백엔드에서 CLOSED일 때 month 파라미터를 optional로 변경 필요
+  const {
+    data: closedData,
+    isLoading: isClosedLoading,
+  } = useDesignerRecruitments({
+    status: 'CLOSED',
+    month: monthString, // 임시: 백엔드에서 month 필수로 요구
+    enabled: activeTab === 'closed',
+  });
+
   const { mutate: deleteRecruitment, isPending: isDeleting } = useDeleteRecruitment();
 
-  // 모든 페이지의 아이템을 평탄화 + 중복 제거
-  const recruitments = useMemo(() => {
-    if (!data?.pages) return [];
-    const allItems = data.pages.flatMap((page) => page.result.items);
-    // recruitmentId 기준 중복 제거
+  // 모집중 공고 리스트
+  const activeRecruitments = useMemo(() => {
+    if (!activeData?.pages) return [];
+    const allItems = activeData.pages.flatMap((page) => page.result.items);
     const seen = new Set<number>();
     return allItems.filter((item) => {
       if (seen.has(item.recruitmentId)) return false;
       seen.add(item.recruitmentId);
       return true;
     });
-  }, [data]);
+  }, [activeData]);
+
+  // 마감 공고 리스트
+  const closedRecruitments = useMemo(() => {
+    if (!closedData?.pages) return [];
+    const allItems = closedData.pages.flatMap((page) => page.result.items);
+    const seen = new Set<number>();
+    return allItems.filter((item) => {
+      if (seen.has(item.recruitmentId)) return false;
+      seen.add(item.recruitmentId);
+      return true;
+    });
+  }, [closedData]);
 
   // 카드 클릭 핸들러
   const handleCardClick = (id: number) => {
@@ -68,39 +103,68 @@ export default function MyRecruitmentPage() {
       {/* 헤더 */}
       <MyRecruitmentHeader />
 
-      {/* 캘린더 헤더 */}
-      <CalendarHeader year={year} month={month} onPrevMonth={handlePrevMonth} onNextMonth={handleNextMonth} />
+      {/* 탭 */}
+      <RecruitmentTabs
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        activeCount={activeRecruitments.length}
+      />
 
-      {/* 공고 리스트 */}
-      <div className="mt-4">
-        {isLoading ? (
+      {/* 모집중 탭 */}
+      {activeTab === 'active' && (
+        <>
+          {/* 캘린더 헤더 */}
+          <CalendarHeader year={year} month={month} onPrevMonth={handlePrevMonth} onNextMonth={handleNextMonth} />
+
+          {/* 공고 리스트 */}
+          <div className="mt-4">
+            {isActiveLoading ? (
+              <div className="flex items-center justify-center py-20">
+                <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-gray-900" />
+              </div>
+            ) : activeRecruitments.length > 0 ? (
+              <RecruitmentList
+                recruitments={activeRecruitments}
+                onEdit={handleEdit}
+                onDelete={openModal}
+                onClick={handleCardClick}
+                onLoadMore={fetchActiveNextPage}
+                hasMore={hasActiveNextPage}
+                isLoadingMore={isFetchingActiveNextPage}
+              />
+            ) : (
+              <RecruitmentEmpty />
+            )}
+          </div>
+        </>
+      )}
+
+      {/* 마감 탭 */}
+      {activeTab === 'closed' && (
+        isClosedLoading ? (
           <div className="flex items-center justify-center py-20">
             <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-gray-900" />
           </div>
-        ) : recruitments.length > 0 ? (
-          <RecruitmentList
-            recruitments={recruitments}
-            onEdit={handleEdit}
-            onDelete={openModal}
-            onClick={handleCardClick}
-            onLoadMore={fetchNextPage}
-            hasMore={hasNextPage}
-            isLoadingMore={isFetchingNextPage}
-          />
         ) : (
-          <RecruitmentEmpty />
-        )}
-      </div>
+          <ClosedRecruitmentList
+            recruitments={closedRecruitments}
+            totalCount={closedRecruitments.length}
+            onClick={handleCardClick}
+          />
+        )
+      )}
 
-      {/* 새 모집글 FAB 버튼 */}
-      <button
-        type="button"
-        onClick={handleCreateClick}
-        className="animate-fab-float fixed bottom-[calc(107px+env(safe-area-inset-bottom))] left-1/2 z-40 flex cursor-pointer items-center gap-1 rounded-full bg-gray-900 px-[14px] py-3"
-      >
-        <PlusIcon className="h-3 w-3" />
-        <span className="text-body-1-medium text-white">새 모집글</span>
-      </button>
+      {/* 새 모집글 FAB 버튼 - 모집중 탭에서만 표시 */}
+      {activeTab === 'active' && (
+        <button
+          type="button"
+          onClick={handleCreateClick}
+          className="animate-fab-float fixed bottom-[calc(107px+env(safe-area-inset-bottom))] left-1/2 z-40 flex cursor-pointer items-center gap-1 rounded-full bg-gray-900 px-[14px] py-3"
+        >
+          <PlusIcon className="h-3 w-3" />
+          <span className="text-body-1-medium text-white">새 모집글</span>
+        </button>
+      )}
 
       {/* 삭제 확인 모달 */}
       <ConfirmModal

--- a/src/components/myRecruitment/Card/RecruitmentCard.tsx
+++ b/src/components/myRecruitment/Card/RecruitmentCard.tsx
@@ -7,6 +7,7 @@ import CalendarIcon from '@/public/icons/myRecruitment/calendar.svg';
 import DotIcon from '@/public/icons/myRecruitment/dot.svg';
 import { CategoryBadge } from '@/src/components/common';
 import type { MyRecruitmentListItem } from '@/src/types/myRecruitment/recruitment';
+import { formatPeriodToMonthDay } from '@/src/utils/common';
 
 interface RecruitmentCardProps {
   recruitment: MyRecruitmentListItem;
@@ -49,8 +50,8 @@ export default function RecruitmentCard({ recruitment, onEdit, onDelete, onClick
   // 서브카테고리 배열 (API에서 subCategory로 반환)
   const subCategories = recruitment.subCategory || [];
 
-  // 날짜 표시 (API에서 period 형식으로 제공)
-  const dateText = recruitment.period;
+  // 날짜 표시 (M.D~M.D 형식)
+  const dateText = formatPeriodToMonthDay(recruitment.period);
 
   return (
     <div className="w-[286px] cursor-pointer shadow-[0px_4px_11px_0px_rgba(34,34,34,0.06)]" onClick={handleCardClick}>

--- a/src/components/myRecruitment/List/ClosedRecruitmentList.tsx
+++ b/src/components/myRecruitment/List/ClosedRecruitmentList.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
+
 import type { MyRecruitmentListItem } from '@/src/types/myRecruitment/recruitment';
 
 import ClosedRecruitmentListItem from './ClosedRecruitmentListItem';
@@ -9,13 +11,39 @@ interface ClosedRecruitmentListProps {
   recruitments: MyRecruitmentListItem[];
   totalCount: number;
   onClick?: (id: number) => void;
+  onLoadMore?: () => void;
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
 }
 
 export default function ClosedRecruitmentList({
   recruitments,
   totalCount,
   onClick,
+  onLoadMore,
+  hasMore,
+  isLoadingMore,
 }: ClosedRecruitmentListProps) {
+  const observerRef = useRef<HTMLDivElement>(null);
+
+  // IntersectionObserver로 무한 스크롤 구현
+  useEffect(() => {
+    if (!observerRef.current || !hasMore || isLoadingMore) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore && !isLoadingMore && onLoadMore) {
+          onLoadMore();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(observerRef.current);
+
+    return () => observer.disconnect();
+  }, [hasMore, isLoadingMore, onLoadMore]);
+
   if (recruitments.length === 0) {
     return <RecruitmentEmpty />;
   }
@@ -38,6 +66,15 @@ export default function ClosedRecruitmentList({
           />
         ))}
       </div>
+
+      {/* 무한 스크롤 감지 영역 */}
+      {hasMore && (
+        <div ref={observerRef} className="flex items-center justify-center py-4">
+          {isLoadingMore && (
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-gray-300 border-t-gray-900" />
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/myRecruitment/List/ClosedRecruitmentList.tsx
+++ b/src/components/myRecruitment/List/ClosedRecruitmentList.tsx
@@ -21,7 +21,7 @@ export default function ClosedRecruitmentList({
   }
 
   return (
-    <div className="flex flex-col gap-3 px-4 pt-6">
+    <div className="flex flex-col gap-3 px-4 pt-3">
       {/* 전체 카운트 */}
       <div className="flex items-center gap-1">
         <span className="text-body-2-medium text-black">전체</span>

--- a/src/components/myRecruitment/List/ClosedRecruitmentList.tsx
+++ b/src/components/myRecruitment/List/ClosedRecruitmentList.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type { MyRecruitmentListItem } from '@/src/types/myRecruitment/recruitment';
+
+import ClosedRecruitmentListItem from './ClosedRecruitmentListItem';
+import RecruitmentEmpty from './RecruitmentEmpty';
+
+interface ClosedRecruitmentListProps {
+  recruitments: MyRecruitmentListItem[];
+  totalCount: number;
+  onClick?: (id: number) => void;
+}
+
+export default function ClosedRecruitmentList({
+  recruitments,
+  totalCount,
+  onClick,
+}: ClosedRecruitmentListProps) {
+  if (recruitments.length === 0) {
+    return <RecruitmentEmpty />;
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-4 pt-6">
+      {/* 전체 카운트 */}
+      <div className="flex items-center gap-1">
+        <span className="text-body-2-medium text-black">전체</span>
+        <span className="text-body-2-semibold text-gray-600">{totalCount}</span>
+      </div>
+
+      {/* 리스트 */}
+      <div className="flex flex-col gap-4">
+        {recruitments.map((recruitment) => (
+          <ClosedRecruitmentListItem
+            key={recruitment.recruitmentId}
+            recruitment={recruitment}
+            onClick={onClick}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/myRecruitment/List/ClosedRecruitmentListItem.tsx
+++ b/src/components/myRecruitment/List/ClosedRecruitmentListItem.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import Image from 'next/image';
+import { useState } from 'react';
+
+import CalendarIcon from '@/public/icons/myRecruitment/calendar.svg';
+import { CategoryBadge } from '@/src/components/common';
+import type { MyRecruitmentListItem } from '@/src/types/myRecruitment/recruitment';
+
+interface ClosedRecruitmentListItemProps {
+  recruitment: MyRecruitmentListItem;
+  onClick?: (id: number) => void;
+}
+
+export default function ClosedRecruitmentListItem({
+  recruitment,
+  onClick,
+}: ClosedRecruitmentListItemProps) {
+  const [imageError, setImageError] = useState(false);
+
+  const handleClick = () => {
+    onClick?.(recruitment.recruitmentId);
+  };
+
+  const subCategories = recruitment.subCategory || [];
+  const dateText = recruitment.period;
+
+  return (
+    <div
+      className="flex w-full cursor-pointer items-center gap-3"
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          handleClick();
+        }
+      }}
+    >
+      {/* 썸네일 */}
+      <div className="relative h-[85px] w-[85px] shrink-0 overflow-hidden rounded-xl bg-gray-200">
+        {recruitment.thumbnail && !imageError ? (
+          <Image
+            src={recruitment.thumbnail}
+            alt={recruitment.title}
+            fill
+            sizes="85px"
+            className="object-cover"
+            onError={() => setImageError(true)}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <span className="text-caption-1-medium text-gray-500">이미지 없음</span>
+          </div>
+        )}
+      </div>
+
+      {/* 정보 영역 */}
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        {/* 카테고리 배지 */}
+        {subCategories.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {subCategories.map((category) => (
+              <CategoryBadge key={category} category={category} />
+            ))}
+          </div>
+        )}
+
+        {/* 제목 */}
+        <p className="text-body-1-medium line-clamp-1 text-gray-900">{recruitment.title}</p>
+
+        {/* 날짜 */}
+        <div className="flex items-center gap-1">
+          <CalendarIcon className="h-4 w-4 text-gray-700" />
+          <span className="text-caption-1-medium text-gray-700">{dateText}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/myRecruitment/List/ClosedRecruitmentListItem.tsx
+++ b/src/components/myRecruitment/List/ClosedRecruitmentListItem.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import CalendarIcon from '@/public/icons/myRecruitment/calendar.svg';
 import { CategoryBadge } from '@/src/components/common';
 import type { MyRecruitmentListItem } from '@/src/types/myRecruitment/recruitment';
+import { formatPeriodToMonthDay } from '@/src/utils/common';
 
 interface ClosedRecruitmentListItemProps {
   recruitment: MyRecruitmentListItem;
@@ -23,7 +24,7 @@ export default function ClosedRecruitmentListItem({
   };
 
   const subCategories = recruitment.subCategory || [];
-  const dateText = recruitment.period;
+  const dateText = formatPeriodToMonthDay(recruitment.period);
 
   return (
     <div
@@ -57,17 +58,20 @@ export default function ClosedRecruitmentListItem({
 
       {/* 정보 영역 */}
       <div className="flex min-w-0 flex-1 flex-col gap-2">
-        {/* 카테고리 배지 */}
-        {subCategories.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {subCategories.map((category) => (
-              <CategoryBadge key={category} category={category} />
-            ))}
-          </div>
-        )}
+        {/* 카테고리 + 제목 (4px gap) */}
+        <div className="flex flex-col gap-1">
+          {/* 카테고리 배지 */}
+          {subCategories.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {subCategories.map((category) => (
+                <CategoryBadge key={category} category={category} />
+              ))}
+            </div>
+          )}
 
-        {/* 제목 */}
-        <p className="text-body-1-medium line-clamp-1 text-gray-900">{recruitment.title}</p>
+          {/* 제목 */}
+          <p className="text-body-1-medium line-clamp-1 text-gray-900">{recruitment.title}</p>
+        </div>
 
         {/* 날짜 */}
         <div className="flex items-center gap-1">

--- a/src/components/myRecruitment/List/index.ts
+++ b/src/components/myRecruitment/List/index.ts
@@ -1,2 +1,3 @@
 export { default as RecruitmentList } from './RecruitmentList';
 export { default as RecruitmentEmpty } from './RecruitmentEmpty';
+export { default as ClosedRecruitmentListItem } from './ClosedRecruitmentListItem';

--- a/src/components/myRecruitment/List/index.ts
+++ b/src/components/myRecruitment/List/index.ts
@@ -1,3 +1,4 @@
 export { default as RecruitmentList } from './RecruitmentList';
 export { default as RecruitmentEmpty } from './RecruitmentEmpty';
 export { default as ClosedRecruitmentListItem } from './ClosedRecruitmentListItem';
+export { default as ClosedRecruitmentList } from './ClosedRecruitmentList';

--- a/src/components/myRecruitment/Tabs/RecruitmentTabs.tsx
+++ b/src/components/myRecruitment/Tabs/RecruitmentTabs.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+export type RecruitmentTabType = 'active' | 'closed';
+
+interface RecruitmentTabsProps {
+  activeTab: RecruitmentTabType;
+  onTabChange: (tab: RecruitmentTabType) => void;
+  activeCount?: number;
+}
+
+export default function RecruitmentTabs({
+  activeTab,
+  onTabChange,
+  activeCount,
+}: RecruitmentTabsProps) {
+  const tabs: { value: RecruitmentTabType; label: string }[] = [
+    { value: 'active', label: activeCount !== undefined ? `모집중 (${activeCount})` : '모집중' },
+    { value: 'closed', label: '마감' },
+  ];
+
+  return (
+    <div className="flex gap-4 border-b border-gray-300 px-5">
+      {tabs.map((tab) => {
+        const isActive = activeTab === tab.value;
+        return (
+          <button
+            key={tab.value}
+            type="button"
+            onClick={() => onTabChange(tab.value)}
+            className={`cursor-pointer px-0.5 py-2 ${
+              isActive
+                ? 'border-b-2 border-gray-900 text-body-1-semibold text-gray-900'
+                : 'text-body-1-medium text-gray-600'
+            }`}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/myRecruitment/Tabs/index.ts
+++ b/src/components/myRecruitment/Tabs/index.ts
@@ -1,0 +1,2 @@
+export { default as RecruitmentTabs } from './RecruitmentTabs';
+export type { RecruitmentTabType } from './RecruitmentTabs';

--- a/src/hooks/queries/myRecruitment/useDesignerRecruitments.ts
+++ b/src/hooks/queries/myRecruitment/useDesignerRecruitments.ts
@@ -1,15 +1,17 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getDesignerRecruitments } from '@/src/apis';
-import type { ApiResponse, MyRecruitmentListResponse } from '@/src/types';
+import type { ApiResponse, MyRecruitmentListResponse, RecruitmentStatus } from '@/src/types';
 
 export const myRecruitmentKeys = {
   all: ['myRecruitments'] as const,
   lists: () => [...myRecruitmentKeys.all, 'list'] as const,
-  list: (month: string) => [...myRecruitmentKeys.lists(), month] as const,
+  list: (status: RecruitmentStatus, month?: string) =>
+    [...myRecruitmentKeys.lists(), status, month] as const,
 };
 
 interface UseDesignerRecruitmentsParams {
-  month: string;
+  status: RecruitmentStatus;
+  month?: string; // ACTIVE일 때만 필요
   size?: number;
   enabled?: boolean;
 }
@@ -19,7 +21,7 @@ interface UseDesignerRecruitmentsParams {
  * useInfiniteQuery를 사용하여 커서 기반 페이징 지원
  */
 export function useDesignerRecruitments(params: UseDesignerRecruitmentsParams) {
-  const { month, size = 10, enabled = true } = params;
+  const { status, month, size = 10, enabled = true } = params;
 
   type CursorParam = { cursorId?: number; cursorEarliestDate?: string } | undefined;
 
@@ -30,9 +32,10 @@ export function useDesignerRecruitments(params: UseDesignerRecruitmentsParams) {
     ReturnType<typeof myRecruitmentKeys.list>,
     CursorParam
   >({
-    queryKey: myRecruitmentKeys.list(month),
+    queryKey: myRecruitmentKeys.list(status, month),
     queryFn: async ({ pageParam }) => {
       return getDesignerRecruitments({
+        status,
         month,
         size,
         cursorId: pageParam?.cursorId,

--- a/src/types/myRecruitment/recruitment.ts
+++ b/src/types/myRecruitment/recruitment.ts
@@ -26,9 +26,13 @@ export interface ImageUploadResult {
 
 // ===== 내 공고 리스트 조회 =====
 
+/** 모집글 상태 */
+export type RecruitmentStatus = 'ACTIVE' | 'CLOSED';
+
 /** 내 공고 리스트 조회 파라미터 */
 export interface MyRecruitmentListParams {
-  month: string; // "2025-11" 형식
+  status?: RecruitmentStatus; // 상태 필터 (ACTIVE: 모집중, CLOSED: 마감)
+  month?: string; // "2025-11" 형식 (ACTIVE일 때만 사용)
   size?: number;
   cursorEarliestDate?: string;
   cursorId?: number;

--- a/src/utils/common/formatPeriodToMonthDay.ts
+++ b/src/utils/common/formatPeriodToMonthDay.ts
@@ -1,0 +1,16 @@
+/**
+ * 기간 문자열을 월.일~월.일 형식으로 포맷
+ * @param period - "yyyy-MM-dd ~ yyyy-MM-dd" 형식의 기간 문자열 (예: "2026-01-03 ~ 2026-01-17")
+ * @returns "M.D~M.D" 형식의 기간 문자열 (예: "1.3~1.17")
+ */
+export function formatPeriodToMonthDay(period: string | undefined): string {
+  if (!period) return '';
+
+  const match = period.match(/(\d{4})-(\d{2})-(\d{2})\s*~\s*(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return period;
+
+  const [, , startMonth, startDay, , endMonth, endDay] = match;
+  const formatPart = (m: string, d: string) => `${parseInt(m, 10)}.${parseInt(d, 10)}`;
+
+  return `${formatPart(startMonth, startDay)}~${formatPart(endMonth, endDay)}`;
+}

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -5,4 +5,5 @@ export * from './formatTimeWithPeriod';
 export * from './formatDateToShort';
 export * from './formatDateToKorean';
 export * from './formatTimeToKorean';
+export * from './formatPeriodToMonthDay';
 


### PR DESCRIPTION
### 💡 To Reviewers

- 마감 공고 API 호출 시 `month` 파라미터가 필수로 요구되어 임시로 현재 월을 전달하고 있습니다. 백엔드에서 CLOSED 상태일 때 month를 optional로 변경해야 합니다.
- 현재는 `모집중`에서 선택한 `month`에 따라서 표시됩니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

**내 모집글 페이지 탭 UI 구현**

- 모집중/마감 탭 컴포넌트 추가 (`RecruitmentTabs`)
- 마감 공고 리스트 컴포넌트 추가 (`ClosedRecruitmentList`, `ClosedRecruitmentListItem`)
- API에 `status` 파라미터 지원 추가 (`ACTIVE` | `CLOSED`)
- 탭별 조건부 렌더링 및 API 호출 분리
- 마감 탭에서 "새 모집글" FAB 버튼 숨김 처리
- 날짜 포맷 유틸 함수 추가 (`formatPeriodToMonthDay`: "2026-01-03 ~ 2026-01-17" → "1.3~1.17")
- 공고 카드/리스트 아이템에 날짜 포맷 유틸 적용

**주요 변경 파일**
| 파일 | 변경 내용 |
|------|----------|
| `src/components/myRecruitment/Tabs/RecruitmentTabs.tsx` | 탭 컴포넌트 신규 |
| `src/components/myRecruitment/List/ClosedRecruitmentList.tsx` | 마감 리스트 컴포넌트 |
| `src/components/myRecruitment/List/ClosedRecruitmentListItem.tsx` | 마감 리스트 아이템 |
| `src/utils/common/formatPeriodToMonthDay.ts` | 날짜 포맷 유틸 함수 |
| `src/types/myRecruitment/recruitment.ts` | `RecruitmentStatus` 타입 추가 |
| `src/apis/designer/recruitments.ts` | status 파라미터 지원 |
| `src/hooks/queries/myRecruitment/useDesignerRecruitments.ts` | status별 queryKey 분리 |
| `src/app/(designer)/myRecruitment/page.tsx` | 탭 전환 로직 및 마감 탭 연동 |

### 🤔 추후 작업 예정

- 백엔드에서 CLOSED 상태 조회 시 `month` 파라미터를 optional로 변경 필요

### 📸 작업 결과 (스크린샷)

- Figma 디자인 기준으로 구현
  - 모집중 탭: https://www.figma.com/design/6jJxKYjpKgrWKbsQwIcV3a/모앤디?node-id=6155-34349
  - 마감 탭: https://www.figma.com/design/6jJxKYjpKgrWKbsQwIcV3a/모앤디?node-id=6155-34463

### 🔗 관련 이슈

- #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모집을 '모집중' / '종료된 모집' 탭으로 분리해 탭별 조회·조작 가능
  * 종료된 모집 전용 목록(무한스크롤 포함)과 항목 뷰 추가
  * 모집 탭에 따라 FAB(새 모집글) 노출 제어

* **개선사항**
  * 모집 기간을 "M.D~M.D" 형태로 간결하게 표시
  * 상태 기반 필터링 및 탭별 페이징/로딩 흐름 분리로 UX 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->