### PR TITLE
[FIX] 디자이너 마이페이지 예약 목록에서 대기중 탭 제거

### DIFF
--- a/src/app/(common)/mypage/reservations/page.tsx
+++ b/src/app/(common)/mypage/reservations/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect, useSyncExternalStore } from 'react';
+import { useState, useMemo, useEffect, useSyncExternalStore, useLayoutEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import ArrowLeftIcon from '@/public/icons/common/arrow-left.svg';
 import { getAccessToken, getUserRole } from '@/src/stores';
@@ -35,8 +35,19 @@ export default function MyReservationsPage() {
   const role = isClient ? (getUserRole() ?? 'model') : 'model';
   const isLoggedIn = isClient ? !!getAccessToken() : false;
 
-  // 탭 상태 (대기 중 탭이 기본)
-  const [activeTab, setActiveTab] = useState<ReservationListType>('PENDING');
+  // 탭 상태 (디자이너는 UPCOMING이 기본, 모델은 PENDING이 기본)
+  const [activeTab, setActiveTab] = useState<ReservationListType>('UPCOMING');
+  const [isTabInitialized, setIsTabInitialized] = useState(false);
+
+  // 클라이언트에서 role 확인 후 초기 탭 설정 (동기적 실행으로 깜빡임 방지)
+  // hydration 후 한 번만 실행되는 초기화 로직
+  useLayoutEffect(() => {
+    if (!isTabInitialized && role === 'model') {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setActiveTab('PENDING');
+    }
+    setIsTabInitialized(true);
+  }, [role, isTabInitialized]);
 
   // 카테고리 필터 상태
   const [selectedCategory, setSelectedCategory] = useState<ReservationCategoryFilter>('ALL');
@@ -124,7 +135,7 @@ export default function MyReservationsPage() {
       </header>
 
       {/* 탭 */}
-      <ReservationTabs activeTab={activeTab} onTabChange={setActiveTab} />
+      <ReservationTabs activeTab={activeTab} onTabChange={setActiveTab} role={role} />
 
       {/* 콘텐츠 */}
       <div className="flex flex-1 flex-col gap-4 px-4 py-4">

--- a/src/components/mypage/reservations/Tabs/ReservationTabs.tsx
+++ b/src/components/mypage/reservations/Tabs/ReservationTabs.tsx
@@ -6,13 +6,18 @@ import { RESERVATION_TABS } from '@/src/constants';
 interface ReservationTabsProps {
   activeTab: ReservationListType;
   onTabChange: (tab: ReservationListType) => void;
+  role?: 'model' | 'designer';
 }
 
-export default function ReservationTabs({ activeTab, onTabChange }: ReservationTabsProps) {
+export default function ReservationTabs({ activeTab, onTabChange, role }: ReservationTabsProps) {
+  // 디자이너는 PENDING 탭 제외 (대기중 예약은 별도 페이지에서 관리)
+  const tabs =
+    role === 'designer' ? RESERVATION_TABS.filter((tab) => tab.value !== 'PENDING') : RESERVATION_TABS;
+
   return (
     <div className="bg-white px-4">
       <div className="flex w-full border-b border-gray-400">
-        {RESERVATION_TABS.map((tab) => {
+        {tabs.map((tab) => {
           const isActive = activeTab === tab.value;
           return (
             <button


### PR DESCRIPTION
### 💡 To Reviewers

- 디자이너 마이페이지 예약 목록에서 Figma 디자인에 맞게 `대기 중` 탭을 제거했습니다.

### 🔥 작업 내용

- `ReservationTabs` 컴포넌트에 `role` prop 추가
- 디자이너일 경우 PENDING 탭 필터링하여 2개 탭만 표시 (다가오는 일정, 완료된 일정)
- 예약 목록 페이지에서 role에 따른 기본 탭 설정 (디자이너: UPCOMING, 모델: PENDING)

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 디자이너: 2개 탭 (다가오는 일정, 완료된 일정)
<img width="433" height="908" alt="image" src="https://github.com/user-attachments/assets/7e460273-c6fd-4cea-bd62-95f443b60385" />

- 모델: 3개 탭 (대기 중, 다가오는 일정, 완료된 일정)
<img width="426" height="908" alt="image" src="https://github.com/user-attachments/assets/74352e9e-c7d8-44d1-95aa-e9fee8f930e6" />


### 🔗 관련 이슈

- #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 예약 탭 페이지의 하이드레이션 안정성을 개선하여 초기 로드 시 화면 깜빡임을 방지했습니다.

* **개선 사항**
  * 사용자 역할에 기반한 탭 표시 필터링 기능을 추가했습니다. 특정 사용자 역할은 특정 예약 상태 탭을 보이지 않도록 설정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->