### PR TITLE
[FIX] 내 공고 리스트 API status 파라미터 변경

### DIFF
--- a/src/app/(designer)/myRecruitment/page.tsx
+++ b/src/app/(designer)/myRecruitment/page.tsx
@@ -32,7 +32,7 @@ export default function MyRecruitmentPage() {
     hasNextPage: hasActiveNextPage,
     isFetchingNextPage: isFetchingActiveNextPage,
   } = useDesignerRecruitments({
-    status: 'ACTIVE',
+    status: 'OPEN',
     month: monthString,
     enabled: activeTab === 'active',
   });

--- a/src/hooks/queries/myRecruitment/useDesignerRecruitments.ts
+++ b/src/hooks/queries/myRecruitment/useDesignerRecruitments.ts
@@ -11,7 +11,7 @@ export const myRecruitmentKeys = {
 
 interface UseDesignerRecruitmentsParams {
   status: RecruitmentStatus;
-  month?: string; // ACTIVE일 때만 필요
+  month?: string; // OPEN일 때만 필요
   size?: number;
   enabled?: boolean;
 }

--- a/src/types/myRecruitment/recruitment.ts
+++ b/src/types/myRecruitment/recruitment.ts
@@ -27,12 +27,12 @@ export interface ImageUploadResult {
 // ===== 내 공고 리스트 조회 =====
 
 /** 모집글 상태 */
-export type RecruitmentStatus = 'ACTIVE' | 'CLOSED';
+export type RecruitmentStatus = 'OPEN' | 'CLOSED';
 
 /** 내 공고 리스트 조회 파라미터 */
 export interface MyRecruitmentListParams {
-  status?: RecruitmentStatus; // 상태 필터 (ACTIVE: 모집중, CLOSED: 마감)
-  month?: string; // "2025-11" 형식 (ACTIVE일 때만 사용)
+  status?: RecruitmentStatus; // 상태 필터 (OPEN: 모집중, CLOSED: 마감)
+  month?: string; // "2025-11" 형식 (OPEN일 때만 사용)
   size?: number;
   cursorEarliestDate?: string;
   cursorId?: number;


### PR DESCRIPTION
### 💡 To Reviewers

- API 스펙 변경에 따른 파라미터 수정

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- `GET /designers/recruitments` API의 status 파라미터 값 변경
  - `ACTIVE` → `OPEN` 
  - `CLOSED`는 그대로 유지
- 관련 타입 및 주석 업데이트

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 코드 변경만 있어 스크린샷 없음

### 🔗 관련 이슈

- #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 모집 상태 필터링이 업데이트되었습니다. 활성 모집 조회 시 상태 필터를 'OPEN'으로 변경하여 정확한 모집 목록을 표시하도록 수정했습니다. 종료된 모집 탭의 로직은 유지됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->