### PR TITLE
[FEAT] 모델/디자이너 마이페이지 UI 개선 및 API 연동(예약 변경, 취소 등)

### DIFF
--- a/src/app/(common)/mypage/reservations/page.tsx
+++ b/src/app/(common)/mypage/reservations/page.tsx
@@ -82,9 +82,10 @@ export default function MyReservationsPage() {
   const isModel = isClient && role === 'model';
 
   // 모델 필터 파라미터 (카테고리 포함)
+  // PENDING, UPCOMING 탭에서는 month를 보내지 않음 (날짜 분류 없음)
   const modelFilterParams = {
     category: currentCategory !== 'ALL' ? currentCategory : undefined,
-    month: selectedMonth,
+    month: activeTab === 'COMPLETED' ? selectedMonth : undefined,
   };
 
   // 디자이너 필터 파라미터 (카테고리 없음)

--- a/src/app/(common)/mypage/reservations/page.tsx
+++ b/src/app/(common)/mypage/reservations/page.tsx
@@ -49,8 +49,25 @@ export default function MyReservationsPage() {
     setIsTabInitialized(true);
   }, [role, isTabInitialized]);
 
-  // 카테고리 필터 상태
-  const [selectedCategory, setSelectedCategory] = useState<ReservationCategoryFilter>('ALL');
+  // 카테고리 필터 상태 (탭별로 독립적)
+  const [selectedCategoryByTab, setSelectedCategoryByTab] = useState<
+    Record<ReservationListType, ReservationCategoryFilter>
+  >({
+    PENDING: 'ALL',
+    UPCOMING: 'ALL',
+    COMPLETED: 'ALL',
+  });
+
+  // 카테고리 변경 핸들러 (현재 탭의 카테고리만 변경)
+  const handleCategoryChange = (category: ReservationCategoryFilter) => {
+    setSelectedCategoryByTab((prev) => ({
+      ...prev,
+      [activeTab]: category,
+    }));
+  };
+
+  // 현재 탭의 카테고리
+  const currentCategory = selectedCategoryByTab[activeTab];
 
   // 월 선택 상태 (현재 월로 초기화, yyyy-MM 형식)
   const now = new Date();
@@ -66,7 +83,7 @@ export default function MyReservationsPage() {
 
   // 모델 필터 파라미터 (카테고리 포함)
   const modelFilterParams = {
-    category: selectedCategory !== 'ALL' ? selectedCategory : undefined,
+    category: currentCategory !== 'ALL' ? currentCategory : undefined,
     month: selectedMonth,
   };
 
@@ -142,13 +159,13 @@ export default function MyReservationsPage() {
         {/* 카테고리 필터 (모델만) */}
         {isModel && (
           <CategoryChips
-            selectedCategory={selectedCategory}
-            onCategoryChange={setSelectedCategory}
+            selectedCategory={currentCategory}
+            onCategoryChange={handleCategoryChange}
           />
         )}
 
-        {/* 월 선택 및 전체 개수 (대기 중 탭에서는 월 선택 숨김) */}
-        {activeTab !== 'PENDING' && (
+        {/* 월 선택 및 전체 개수 (모델: 완료 탭만, 디자이너: 모든 탭) */}
+        {(activeTab === 'COMPLETED' || !isModel) && (
           <div className="flex items-center justify-between">
             <MonthDropdown
               options={monthOptions}

--- a/src/components/mypage/reservations/Card/DesignerReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/DesignerReservationCard.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import type { DesignerReservationItem, ReservationListType, ReservationInfo, ReservationChangeRequest, ReservationCancelRequest } from '@/src/types';
+import type { DesignerReservationItem, ReservationListType, ReservationInfo } from '@/src/types';
 import { formatDateToKorean, formatTimeToKorean } from '@/src/utils/common';
 import {
   ReservationChangeModal,
@@ -11,8 +10,8 @@ import {
   ReservationSuccessModal,
 } from '@/src/components/reservation';
 import { useCreateChatRoom } from '@/src/hooks/queries/chat';
-import { useRequestReservationChange, useCancelReservation } from '@/src/hooks/queries/reservation';
 import { useToast } from '@/src/hooks/common/useToast';
+import { useReservationActions } from '@/src/hooks/custom/mypage/reservations';
 
 interface DesignerReservationCardProps {
   reservation: DesignerReservationItem;
@@ -26,14 +25,22 @@ export default function DesignerReservationCard({
   const router = useRouter();
   const { showToast } = useToast();
   const createChatRoom = useCreateChatRoom();
-  const requestChange = useRequestReservationChange();
-  const cancelReservation = useCancelReservation();
 
-  // 모달 상태 관리
-  const [isChangeModalOpen, setIsChangeModalOpen] = useState(false);
-  const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
-  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
-  const [successMessage, setSuccessMessage] = useState('');
+  const {
+    modalState,
+    openChangeModal,
+    openCancelModal,
+    closeChangeModal,
+    closeCancelModal,
+    closeSuccessModal,
+    handleChangeSubmit,
+    handleCancelSubmit,
+    isChangeLoading,
+    isCancelLoading,
+  } = useReservationActions({
+    reservationId: reservation.reservationId,
+    targetUserId: reservation.modelUserId,
+  });
 
   const isUpcoming = tabType === 'UPCOMING';
   const isCompleted = reservation.status === 'RESERVATION_CANCELLED' || tabType === 'COMPLETED';
@@ -64,54 +71,6 @@ export default function DesignerReservationCard({
         showToast('채팅방 생성에 실패했습니다');
       },
     });
-  };
-
-  const handleChangeClick = () => {
-    setIsChangeModalOpen(true);
-  };
-
-  const handleCancelClick = () => {
-    setIsCancelModalOpen(true);
-  };
-
-  // 예약 변경 요청 처리
-  const handleChangeSubmit = async (data: ReservationChangeRequest) => {
-    try {
-      const response = await createChatRoom.mutateAsync(reservation.modelUserId);
-      const roomId = response.result.chatRoomId;
-      requestChange.mutate(
-        { reservationId: reservation.reservationId, payload: data, roomId },
-        {
-          onSuccess: () => {
-            setIsChangeModalOpen(false);
-            setSuccessMessage('예약 변경이 요청되었습니다');
-            setIsSuccessModalOpen(true);
-          },
-        },
-      );
-    } catch {
-      showToast('채팅방 생성에 실패했습니다.');
-    }
-  };
-
-  // 예약 취소 요청 처리
-  const handleCancelSubmit = (data: ReservationCancelRequest) => {
-    cancelReservation.mutate(
-      { reservationId: reservation.reservationId, payload: data },
-      {
-        onSuccess: () => {
-          setIsCancelModalOpen(false);
-          setSuccessMessage('예약 취소가 요청되었습니다');
-          setIsSuccessModalOpen(true);
-        },
-      },
-    );
-  };
-
-  // 성공 모달 확인 버튼 처리
-  const handleSuccessConfirm = () => {
-    setIsSuccessModalOpen(false);
-    setSuccessMessage('');
   };
 
   return (
@@ -184,14 +143,14 @@ export default function DesignerReservationCard({
           </button>
           <button
             type="button"
-            onClick={handleChangeClick}
+            onClick={openChangeModal}
             className="text-body-2-medium flex h-[42px] shrink-0 cursor-pointer items-center justify-center whitespace-nowrap rounded-full border border-gray-400 bg-white px-4 py-2.5 text-gray-900"
           >
             예약 변경
           </button>
           <button
             type="button"
-            onClick={handleCancelClick}
+            onClick={openCancelModal}
             className="text-body-2-medium flex h-[42px] shrink-0 cursor-pointer items-center justify-center whitespace-nowrap rounded-full border border-gray-400 bg-white px-4 py-2.5 text-gray-900"
           >
             예약 취소
@@ -201,28 +160,28 @@ export default function DesignerReservationCard({
 
       {/* 예약 변경 모달 */}
       <ReservationChangeModal
-        isOpen={isChangeModalOpen}
-        onClose={() => setIsChangeModalOpen(false)}
+        isOpen={modalState.isChangeOpen}
+        onClose={closeChangeModal}
         reservation={reservationInfo}
         onSubmit={handleChangeSubmit}
-        isLoading={requestChange.isPending || createChatRoom.isPending}
+        isLoading={isChangeLoading}
       />
 
       {/* 예약 취소 모달 */}
       <ReservationCancelModal
-        isOpen={isCancelModalOpen}
-        onClose={() => setIsCancelModalOpen(false)}
+        isOpen={modalState.isCancelOpen}
+        onClose={closeCancelModal}
         reservation={reservationInfo}
         onSubmit={handleCancelSubmit}
-        isLoading={cancelReservation.isPending}
+        isLoading={isCancelLoading}
       />
 
       {/* 성공 모달 */}
       <ReservationSuccessModal
-        isOpen={isSuccessModalOpen}
-        onClose={() => setIsSuccessModalOpen(false)}
-        message={successMessage}
-        onConfirm={handleSuccessConfirm}
+        isOpen={modalState.isSuccessOpen}
+        onClose={closeSuccessModal}
+        message={modalState.successMessage}
+        onConfirm={closeSuccessModal}
       />
     </div>
   );

--- a/src/components/mypage/reservations/Card/DesignerReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/DesignerReservationCard.tsx
@@ -11,6 +11,7 @@ import {
   ReservationSuccessModal,
 } from '@/src/components/reservation';
 import { useCreateChatRoom } from '@/src/hooks/queries/chat';
+import { useRequestReservationChange, useCancelReservation } from '@/src/hooks/queries/reservation';
 import { useToast } from '@/src/hooks/common/useToast';
 
 interface DesignerReservationCardProps {
@@ -25,6 +26,8 @@ export default function DesignerReservationCard({
   const router = useRouter();
   const { showToast } = useToast();
   const createChatRoom = useCreateChatRoom();
+  const requestChange = useRequestReservationChange();
+  const cancelReservation = useCancelReservation();
 
   // 모달 상태 관리
   const [isChangeModalOpen, setIsChangeModalOpen] = useState(false);
@@ -38,6 +41,7 @@ export default function DesignerReservationCard({
   // 예약 정보를 모달에 전달할 형식으로 변환
   const reservationInfo: ReservationInfo = {
     reservationId: reservation.reservationId,
+    recruitmentId: reservation.recruitmentId,
     modelUserId: reservation.modelUserId,
     modelName: reservation.modelName,
     date: reservation.date,
@@ -70,20 +74,38 @@ export default function DesignerReservationCard({
     setIsCancelModalOpen(true);
   };
 
-  // Mock: 예약 변경 요청 처리
-  const handleChangeSubmit = (data: ReservationChangeRequest) => {
-    console.log('예약 변경 요청:', data);
-    setIsChangeModalOpen(false);
-    setSuccessMessage('예약 변경이 요청되었습니다');
-    setIsSuccessModalOpen(true);
+  // 예약 변경 요청 처리
+  const handleChangeSubmit = async (data: ReservationChangeRequest) => {
+    try {
+      const response = await createChatRoom.mutateAsync(reservation.modelUserId);
+      const roomId = response.result.chatRoomId;
+      requestChange.mutate(
+        { reservationId: reservation.reservationId, payload: data, roomId },
+        {
+          onSuccess: () => {
+            setIsChangeModalOpen(false);
+            setSuccessMessage('예약 변경이 요청되었습니다');
+            setIsSuccessModalOpen(true);
+          },
+        },
+      );
+    } catch {
+      showToast('채팅방 생성에 실패했습니다.');
+    }
   };
 
-  // Mock: 예약 취소 요청 처리
+  // 예약 취소 요청 처리
   const handleCancelSubmit = (data: ReservationCancelRequest) => {
-    console.log('예약 취소 요청:', data);
-    setIsCancelModalOpen(false);
-    setSuccessMessage('예약 취소가 요청되었습니다');
-    setIsSuccessModalOpen(true);
+    cancelReservation.mutate(
+      { reservationId: reservation.reservationId, payload: data },
+      {
+        onSuccess: () => {
+          setIsCancelModalOpen(false);
+          setSuccessMessage('예약 취소가 요청되었습니다');
+          setIsSuccessModalOpen(true);
+        },
+      },
+    );
   };
 
   // 성공 모달 확인 버튼 처리
@@ -183,6 +205,7 @@ export default function DesignerReservationCard({
         onClose={() => setIsChangeModalOpen(false)}
         reservation={reservationInfo}
         onSubmit={handleChangeSubmit}
+        isLoading={requestChange.isPending || createChatRoom.isPending}
       />
 
       {/* 예약 취소 모달 */}
@@ -191,6 +214,7 @@ export default function DesignerReservationCard({
         onClose={() => setIsCancelModalOpen(false)}
         reservation={reservationInfo}
         onSubmit={handleCancelSubmit}
+        isLoading={cancelReservation.isPending}
       />
 
       {/* 성공 모달 */}

--- a/src/components/mypage/reservations/Card/ModelReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/ModelReservationCard.tsx
@@ -14,6 +14,9 @@ import {
   ReservationCancelModal,
   ReservationSuccessModal,
 } from '@/src/components/reservation';
+import { useCreateChatRoom } from '@/src/hooks/queries/chat';
+import { useRequestReservationChange, useCancelReservation } from '@/src/hooks/queries/reservation';
+import { useToast } from '@/src/hooks/common/useToast';
 import { CategoryBadges, ReservationInfo as ReservationInfoComponent, ReservationTitle } from './common';
 
 interface ModelReservationCardProps {
@@ -26,6 +29,10 @@ export default function ModelReservationCard({
   tabType,
 }: ModelReservationCardProps) {
   const router = useRouter();
+  const { showToast } = useToast();
+  const createChatRoom = useCreateChatRoom();
+  const requestChange = useRequestReservationChange();
+  const cancelReservation = useCancelReservation();
 
   // 모달 상태 관리
   const [isChangeModalOpen, setIsChangeModalOpen] = useState(false);
@@ -39,6 +46,7 @@ export default function ModelReservationCard({
   // 예약 정보를 모달에 전달할 형식으로 변환
   const reservationInfo: ReservationInfo = {
     reservationId: reservation.reservationId,
+    recruitmentId: reservation.recruitmentId,
     modelUserId: reservation.designerUserId,
     modelName: reservation.designerNickname,
     date: reservation.date,
@@ -57,18 +65,36 @@ export default function ModelReservationCard({
     setIsCancelModalOpen(true);
   };
 
-  const handleChangeSubmit = (data: ReservationChangeRequest) => {
-    console.log('예약 변경 요청:', data);
-    setIsChangeModalOpen(false);
-    setSuccessMessage('예약 변경이 요청되었습니다');
-    setIsSuccessModalOpen(true);
+  const handleChangeSubmit = async (data: ReservationChangeRequest) => {
+    try {
+      const response = await createChatRoom.mutateAsync(reservation.designerUserId);
+      const roomId = response.result.chatRoomId;
+      requestChange.mutate(
+        { reservationId: reservation.reservationId, payload: data, roomId },
+        {
+          onSuccess: () => {
+            setIsChangeModalOpen(false);
+            setSuccessMessage('예약 변경이 요청되었습니다');
+            setIsSuccessModalOpen(true);
+          },
+        },
+      );
+    } catch {
+      showToast('채팅방 생성에 실패했습니다.');
+    }
   };
 
   const handleCancelSubmit = (data: ReservationCancelRequest) => {
-    console.log('예약 취소 요청:', data);
-    setIsCancelModalOpen(false);
-    setSuccessMessage('예약 취소가 요청되었습니다');
-    setIsSuccessModalOpen(true);
+    cancelReservation.mutate(
+      { reservationId: reservation.reservationId, payload: data },
+      {
+        onSuccess: () => {
+          setIsCancelModalOpen(false);
+          setSuccessMessage('예약 취소가 요청되었습니다');
+          setIsSuccessModalOpen(true);
+        },
+      },
+    );
   };
 
   const handleSuccessConfirm = () => {
@@ -136,6 +162,7 @@ export default function ModelReservationCard({
         onClose={() => setIsChangeModalOpen(false)}
         reservation={reservationInfo}
         onSubmit={handleChangeSubmit}
+        isLoading={requestChange.isPending || createChatRoom.isPending}
       />
 
       {/* 예약 취소 모달 */}
@@ -144,6 +171,7 @@ export default function ModelReservationCard({
         onClose={() => setIsCancelModalOpen(false)}
         reservation={reservationInfo}
         onSubmit={handleCancelSubmit}
+        isLoading={cancelReservation.isPending}
       />
 
       {/* 성공 모달 */}

--- a/src/components/mypage/reservations/Card/ModelReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/ModelReservationCard.tsx
@@ -1,22 +1,13 @@
 'use client';
 
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import type {
-  ModelReservationItem,
-  ReservationListType,
-  ReservationInfo,
-  ReservationChangeRequest,
-  ReservationCancelRequest,
-} from '@/src/types';
+import type { ModelReservationItem, ReservationListType, ReservationInfo } from '@/src/types';
 import {
   ReservationChangeModal,
   ReservationCancelModal,
   ReservationSuccessModal,
 } from '@/src/components/reservation';
-import { useCreateChatRoom } from '@/src/hooks/queries/chat';
-import { useRequestReservationChange, useCancelReservation } from '@/src/hooks/queries/reservation';
-import { useToast } from '@/src/hooks/common/useToast';
+import { useReservationActions } from '@/src/hooks/custom/mypage/reservations';
 import { CategoryBadges, ReservationInfo as ReservationInfoComponent, ReservationTitle } from './common';
 
 interface ModelReservationCardProps {
@@ -29,16 +20,22 @@ export default function ModelReservationCard({
   tabType,
 }: ModelReservationCardProps) {
   const router = useRouter();
-  const { showToast } = useToast();
-  const createChatRoom = useCreateChatRoom();
-  const requestChange = useRequestReservationChange();
-  const cancelReservation = useCancelReservation();
 
-  // 모달 상태 관리
-  const [isChangeModalOpen, setIsChangeModalOpen] = useState(false);
-  const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
-  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
-  const [successMessage, setSuccessMessage] = useState('');
+  const {
+    modalState,
+    openChangeModal,
+    openCancelModal,
+    closeChangeModal,
+    closeCancelModal,
+    closeSuccessModal,
+    handleChangeSubmit,
+    handleCancelSubmit,
+    isChangeLoading,
+    isCancelLoading,
+  } = useReservationActions({
+    reservationId: reservation.reservationId,
+    targetUserId: reservation.designerUserId,
+  });
 
   const isUpcoming = tabType === 'UPCOMING';
   const isCompleted = reservation.status === 'RESERVATION_CANCELLED' || tabType === 'COMPLETED';
@@ -55,51 +52,6 @@ export default function ModelReservationCard({
 
   const handleCardClick = () => {
     router.push(`/post/${reservation.recruitmentId}`);
-  };
-
-  const handleChangeClick = () => {
-    setIsChangeModalOpen(true);
-  };
-
-  const handleCancelClick = () => {
-    setIsCancelModalOpen(true);
-  };
-
-  const handleChangeSubmit = async (data: ReservationChangeRequest) => {
-    try {
-      const response = await createChatRoom.mutateAsync(reservation.designerUserId);
-      const roomId = response.result.chatRoomId;
-      requestChange.mutate(
-        { reservationId: reservation.reservationId, payload: data, roomId },
-        {
-          onSuccess: () => {
-            setIsChangeModalOpen(false);
-            setSuccessMessage('예약 변경이 요청되었습니다');
-            setIsSuccessModalOpen(true);
-          },
-        },
-      );
-    } catch {
-      showToast('채팅방 생성에 실패했습니다.');
-    }
-  };
-
-  const handleCancelSubmit = (data: ReservationCancelRequest) => {
-    cancelReservation.mutate(
-      { reservationId: reservation.reservationId, payload: data },
-      {
-        onSuccess: () => {
-          setIsCancelModalOpen(false);
-          setSuccessMessage('예약 취소가 요청되었습니다');
-          setIsSuccessModalOpen(true);
-        },
-      },
-    );
-  };
-
-  const handleSuccessConfirm = () => {
-    setIsSuccessModalOpen(false);
-    setSuccessMessage('');
   };
 
   return (
@@ -141,14 +93,14 @@ export default function ModelReservationCard({
           </button>
           <button
             type="button"
-            onClick={handleChangeClick}
+            onClick={openChangeModal}
             className="text-body-2-medium flex h-[41px] cursor-pointer items-center justify-center rounded-full border border-gray-400 bg-white px-5 py-2.5 text-gray-900"
           >
             예약 변경
           </button>
           <button
             type="button"
-            onClick={handleCancelClick}
+            onClick={openCancelModal}
             className="text-body-2-medium flex h-[41px] cursor-pointer items-center justify-center rounded-full border border-gray-400 bg-white px-5 py-2.5 text-gray-900"
           >
             예약 취소
@@ -158,28 +110,28 @@ export default function ModelReservationCard({
 
       {/* 예약 변경 모달 */}
       <ReservationChangeModal
-        isOpen={isChangeModalOpen}
-        onClose={() => setIsChangeModalOpen(false)}
+        isOpen={modalState.isChangeOpen}
+        onClose={closeChangeModal}
         reservation={reservationInfo}
         onSubmit={handleChangeSubmit}
-        isLoading={requestChange.isPending || createChatRoom.isPending}
+        isLoading={isChangeLoading}
       />
 
       {/* 예약 취소 모달 */}
       <ReservationCancelModal
-        isOpen={isCancelModalOpen}
-        onClose={() => setIsCancelModalOpen(false)}
+        isOpen={modalState.isCancelOpen}
+        onClose={closeCancelModal}
         reservation={reservationInfo}
         onSubmit={handleCancelSubmit}
-        isLoading={cancelReservation.isPending}
+        isLoading={isCancelLoading}
       />
 
       {/* 성공 모달 */}
       <ReservationSuccessModal
-        isOpen={isSuccessModalOpen}
-        onClose={() => setIsSuccessModalOpen(false)}
-        message={successMessage}
-        onConfirm={handleSuccessConfirm}
+        isOpen={modalState.isSuccessOpen}
+        onClose={closeSuccessModal}
+        message={modalState.successMessage}
+        onConfirm={closeSuccessModal}
       />
     </div>
   );

--- a/src/components/mypage/reservations/Card/PendingReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/PendingReservationCard.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { ModelReservationItem } from '@/src/types';
 import { ConfirmModal } from '@/src/components/common/Modal';
+import { useCancelReservation } from '@/src/hooks/queries/reservation';
+import { useToast } from '@/src/hooks/common/useToast';
 import { CategoryBadges, ReservationInfo as ReservationInfoComponent, ReservationTitle } from './common';
 
 interface PendingReservationCardProps {
@@ -14,6 +16,8 @@ export default function PendingReservationCard({
   reservation,
 }: PendingReservationCardProps) {
   const router = useRouter();
+  const { showToast } = useToast();
+  const cancelReservation = useCancelReservation();
 
   // 모달 상태 관리
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
@@ -31,8 +35,18 @@ export default function PendingReservationCard({
   };
 
   const handleCancelConfirm = () => {
-    // TODO: API 연동 - 신청 취소 처리
-    setIsCancelModalOpen(false);
+    cancelReservation.mutate(
+      {
+        reservationId: reservation.reservationId,
+        payload: { reason: '예약 신청 취소' },
+      },
+      {
+        onSuccess: () => {
+          setIsCancelModalOpen(false);
+          showToast('예약 신청이 취소되었습니다.');
+        },
+      },
+    );
   };
 
   return (
@@ -74,9 +88,12 @@ export default function PendingReservationCard({
         <button
           type="button"
           onClick={handleCancelClick}
-          className="text-body-2-medium flex h-[41px] flex-1 cursor-pointer items-center justify-center rounded-full border border-gray-400 bg-white px-5 py-2.5 text-gray-900"
+          disabled={cancelReservation.isPending}
+          className={`text-body-2-medium flex h-[41px] flex-1 items-center justify-center rounded-full border border-gray-400 bg-white px-5 py-2.5 text-gray-900 ${
+            cancelReservation.isPending ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+          }`}
         >
-          신청 취소
+          {cancelReservation.isPending ? '취소 중...' : '신청 취소'}
         </button>
       </div>
 

--- a/src/components/mypage/reservations/Card/PendingReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/PendingReservationCard.tsx
@@ -105,6 +105,7 @@ export default function PendingReservationCard({
         message="예약 신청을 취소하시겠습니까?"
         cancelText="아니오"
         confirmText="네"
+        isLoading={cancelReservation.isPending}
       />
     </div>
   );

--- a/src/constants/mypage.ts
+++ b/src/constants/mypage.ts
@@ -2,7 +2,7 @@
 
 /** 설정 메뉴 항목 */
 export const SETTING_LINKS = [
-  { label: '알람설정', href: '/mypage/notification-settings' },
+  { label: '알림설정', href: '/mypage/notification-settings' },
   { label: '고객센터/FAQ' },
 ] as const;
 

--- a/src/hooks/custom/mypage/index.ts
+++ b/src/hooks/custom/mypage/index.ts
@@ -1,3 +1,4 @@
 export * from './useAuthReady';
 export * from './useProfileWithFallback';
 export * from './useProfileEditForm';
+export * from './reservations';

--- a/src/hooks/custom/mypage/reservations/index.ts
+++ b/src/hooks/custom/mypage/reservations/index.ts
@@ -1,0 +1,1 @@
+export * from './useReservationActions';

--- a/src/hooks/custom/mypage/reservations/useReservationActions.ts
+++ b/src/hooks/custom/mypage/reservations/useReservationActions.ts
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useCreateChatRoom } from '@/src/hooks/queries/chat';
+import { useRequestReservationChange, useCancelReservation } from '@/src/hooks/queries/reservation';
+import { useToast } from '@/src/hooks/common/useToast';
+import type { ReservationChangeRequest, ReservationCancelRequest } from '@/src/types';
+
+interface ModalState {
+  isChangeOpen: boolean;
+  isCancelOpen: boolean;
+  isSuccessOpen: boolean;
+  successMessage: string;
+}
+
+interface UseReservationActionsParams {
+  reservationId: number;
+  targetUserId: number; // 모델: designerUserId, 디자이너: modelUserId
+}
+
+interface UseReservationActionsReturn {
+  // 모달 상태
+  modalState: ModalState;
+  // 모달 열기/닫기
+  openChangeModal: () => void;
+  openCancelModal: () => void;
+  closeChangeModal: () => void;
+  closeCancelModal: () => void;
+  closeSuccessModal: () => void;
+  // 핸들러
+  handleChangeSubmit: (data: ReservationChangeRequest) => Promise<void>;
+  handleCancelSubmit: (data: ReservationCancelRequest) => void;
+  // 로딩 상태
+  isChangeLoading: boolean;
+  isCancelLoading: boolean;
+}
+
+/**
+ * 예약 변경/취소 공통 로직을 관리하는 커스텀 훅
+ * ModelReservationCard, DesignerReservationCard에서 공통으로 사용
+ */
+export function useReservationActions({
+  reservationId,
+  targetUserId,
+}: UseReservationActionsParams): UseReservationActionsReturn {
+  const { showToast } = useToast();
+  const createChatRoom = useCreateChatRoom();
+  const requestChange = useRequestReservationChange();
+  const cancelReservation = useCancelReservation();
+
+  // 모달 상태
+  const [modalState, setModalState] = useState<ModalState>({
+    isChangeOpen: false,
+    isCancelOpen: false,
+    isSuccessOpen: false,
+    successMessage: '',
+  });
+
+  // 모달 열기/닫기 핸들러
+  const openChangeModal = useCallback(() => {
+    setModalState((prev) => ({ ...prev, isChangeOpen: true }));
+  }, []);
+
+  const openCancelModal = useCallback(() => {
+    setModalState((prev) => ({ ...prev, isCancelOpen: true }));
+  }, []);
+
+  const closeChangeModal = useCallback(() => {
+    setModalState((prev) => ({ ...prev, isChangeOpen: false }));
+  }, []);
+
+  const closeCancelModal = useCallback(() => {
+    setModalState((prev) => ({ ...prev, isCancelOpen: false }));
+  }, []);
+
+  const closeSuccessModal = useCallback(() => {
+    setModalState((prev) => ({ ...prev, isSuccessOpen: false, successMessage: '' }));
+  }, []);
+
+  // 성공 모달 표시
+  const showSuccessModal = useCallback((message: string) => {
+    setModalState((prev) => ({
+      ...prev,
+      isSuccessOpen: true,
+      successMessage: message,
+    }));
+  }, []);
+
+  // 예약 변경 제출
+  const handleChangeSubmit = useCallback(
+    async (data: ReservationChangeRequest) => {
+      try {
+        const response = await createChatRoom.mutateAsync(targetUserId);
+        const roomId = response.result.chatRoomId;
+        requestChange.mutate(
+          { reservationId, payload: data, roomId },
+          {
+            onSuccess: () => {
+              closeChangeModal();
+              showSuccessModal('예약 변경이 요청되었습니다');
+            },
+          },
+        );
+      } catch {
+        showToast('채팅방 생성에 실패했습니다.');
+      }
+    },
+    [reservationId, targetUserId, createChatRoom, requestChange, closeChangeModal, showSuccessModal, showToast],
+  );
+
+  // 예약 취소 제출
+  const handleCancelSubmit = useCallback(
+    (data: ReservationCancelRequest) => {
+      cancelReservation.mutate(
+        { reservationId, payload: data },
+        {
+          onSuccess: () => {
+            closeCancelModal();
+            showSuccessModal('예약 취소가 요청되었습니다');
+          },
+        },
+      );
+    },
+    [reservationId, cancelReservation, closeCancelModal, showSuccessModal],
+  );
+
+  return {
+    modalState,
+    openChangeModal,
+    openCancelModal,
+    closeChangeModal,
+    closeCancelModal,
+    closeSuccessModal,
+    handleChangeSubmit,
+    handleCancelSubmit,
+    isChangeLoading: requestChange.isPending || createChatRoom.isPending,
+    isCancelLoading: cancelReservation.isPending,
+  };
+}

--- a/src/hooks/queries/reservation/useReservationChange.ts
+++ b/src/hooks/queries/reservation/useReservationChange.ts
@@ -9,6 +9,7 @@ import {
 } from '@/src/apis';
 import { useToast } from '@/src/hooks/common/useToast';
 import { calendarKeys } from '@/src/hooks/queries/calendar';
+import { myReservationKeys } from './useMyReservations';
 import type { ApiResponse, ReservationCancelRequest, ReservationChangeRequest, ReservationChangeResult } from '@/src/types';
 
 type RequestReservationChangeVariables = {
@@ -32,6 +33,7 @@ export function useRequestReservationChange() {
     mutationFn: ({ reservationId, payload, roomId }) => requestReservationChange(reservationId, payload, { roomId }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: calendarKeys.all });
+      queryClient.invalidateQueries({ queryKey: myReservationKeys.all });
     },
     onError: () => {
       showToast('예약 변경 요청에 실패했습니다.');
@@ -48,6 +50,7 @@ export function useCancelReservation() {
       cancelReservation(reservationId, payload, { roomId, reservationChangeId }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: calendarKeys.all });
+      queryClient.invalidateQueries({ queryKey: myReservationKeys.all });
     },
     onError: () => {
       showToast('예약 취소에 실패했습니다.');


### PR DESCRIPTION
### 💡 To Reviewers

- `useReservationActions` 커스텀 훅을 추출하여 ModelReservationCard와 DesignerReservationCard의 중복 코드를 제거했습니다.
- 캘린더 페이지의 `CalendarReservationCard` 구현을 참고하여 API 연동 패턴을 맞췄습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

#### API 연동
- **ModelReservationCard**: 예약 변경/취소 API 연동 (`useRequestReservationChange`, `useCancelReservation`)
- **DesignerReservationCard**: 예약 변경/취소 API 연동
- **PendingReservationCard**: 예약 신청 취소 API 연동
- **useReservationChange**: `myReservationKeys` invalidation 추가로 예약 목록 자동 갱신

#### UI 개선
- **모델 마이페이지**:
  - 대기중/다가오는 일정 탭: 월 선택 드롭다운 및 전체 갯수 숨김
  - 대기중/다가오는 일정 탭: API 호출 시 month 파라미터 제외
  - 완료된 일정 탭: 월 선택 드롭다운 및 전체 갯수 표시
- **디자이너 마이페이지**:
  - 모든 탭에서 월 선택 드롭다운 및 전체 갯수 표시
- **공통**:
  - 탭별 카테고리 필터 독립 적용 (탭 전환 시 각 탭의 카테고리 상태 유지)

#### 리팩토링
- `useReservationActions` 커스텀 훅 추출
  - 모달 상태 관리 (변경/취소/성공 모달)
  - 예약 변경/취소 핸들러 공통화
  - 로딩 상태 관리

### 🤔 추후 작업 예정

- 무한 스크롤 size 파라미터 설정 검토 (현재 서버 기본값 12 사용)

### 📸 작업 결과 (스크린샷)

<img width="532" height="1022" alt="image" src="https://github.com/user-attachments/assets/2e1c7cfb-b889-405a-b00f-9a8307db6695" />

<img width="557" height="1032" alt="image" src="https://github.com/user-attachments/assets/8457ed5a-6ff1-4a79-a911-c1e9c7d2a68f" />


### 🔗 관련 이슈

- #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 각 탭별 독립 카테고리 필터링 추가
  * 예약 관련 공통 행동을 제공하는 신규 훅으로 모달/작업 흐름 통합

* **개선사항**
  * 예약 변경/취소 모달 동작 및 로딩 상태 일관성 개선
  * 예약 취소 시 토스트 알림 및 취소 흐름 개선
  * 예약 관련 캐시 무효화 범위 확장으로 데이터 동기화 개선

* **버그 수정**
  * 설정 메뉴 텍스트 "알람설정" → "알림설정" 수정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->