### PR TITLE
[REFACTOR] 인증 에러 처리 개선

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -1,9 +1,33 @@
 import { useAuthStore, getAccessToken, setAccessToken } from '@/src/stores';
 import { apiLogger } from '@/src/utils';
-import axios from 'axios';
+import { dispatchAuthError } from '@/src/utils/auth/authErrorDispatcher';
+import axios, { AxiosRequestConfig } from 'axios';
 
-// 인증 없이 접근 가능한 API
-const NON_AUTH_URLS = ['/auth/login', '/auth/signup', '/auth/refresh', '/auth/sms', '/auth/check', '/presigned-url/profiles'];
+// 토큰 갱신 상태 관리 (Race Condition 방지)
+let isRefreshing = false;
+let refreshSubscribers: {
+  resolve: (token: string) => void;
+  reject: (error: Error) => void;
+}[] = [];
+
+function subscribeTokenRefresh(resolve: (token: string) => void, reject: (error: Error) => void) {
+  refreshSubscribers.push({ resolve, reject });
+}
+
+function onTokenRefreshed(token: string) {
+  refreshSubscribers.forEach(({ resolve }) => resolve(token));
+  refreshSubscribers = [];
+}
+
+function onRefreshFailed(error: Error) {
+  refreshSubscribers.forEach(({ reject }) => reject(error));
+  refreshSubscribers = [];
+}
+
+// _retry 플래그를 위한 타입 확장
+interface AxiosRequestConfigWithRetry extends AxiosRequestConfig {
+  _retry?: boolean;
+}
 
 export const axiosInstance = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_API_BASE_URL}/api`,
@@ -16,14 +40,10 @@ export const axiosInstance = axios.create({
 // Request Interceptor: 쿠키에서 accessToken 읽어서 헤더에 추가 + 로깅
 axiosInstance.interceptors.request.use(
   (config) => {
-    const isNonAuthRequest = NON_AUTH_URLS.some((path) => config.url?.includes(path));
-
-    if (!isNonAuthRequest) {
-      const token = getAccessToken(); // 쿠키에서 읽기
-      if (token) {
-        config.headers = config.headers || {};
-        config.headers.Authorization = `Bearer ${token}`;
-      }
+    const token = getAccessToken();
+    if (token) {
+      config.headers = config.headers || {};
+      config.headers.Authorization = `Bearer ${token}`;
     }
 
     // API 로깅 (NEXT_PUBLIC_API_LOGGING=true 일 때만 활성화)
@@ -48,21 +68,76 @@ axiosInstance.interceptors.response.use(
 
     return response;
   },
-  (error) => {
+  async (error) => {
     const { clearAuth } = useAuthStore.getState();
+    const originalRequest = error.config as AxiosRequestConfigWithRetry;
     const res = error.response;
     const code = res?.data?.serviceCode || res?.data?.data?.codeName || '';
 
     // API 로깅 (에러)
     apiLogger.error(res?.config?.url || '', res?.status || 0, res?.data || error.message);
 
-    const shouldLogout =
-      res?.status === 401 ||
-      (res?.status === 400 &&
-        (code === 'INVALID_REFRESH_TOKEN' || code === 'INVALID_TOKEN' || code === 'ACCESS_TOKEN_EXPIRED'));
+    // 401이고 아직 재시도 안 했으면 토큰 갱신 시도
+    if (res?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
 
-    if (shouldLogout) {
-      clearAuth(); // 쿠키도 함께 삭제됨
+      // 이미 갱신 중이면 대기
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          subscribeTokenRefresh(
+            (token: string) => {
+              if (originalRequest.headers) {
+                originalRequest.headers.Authorization = `Bearer ${token}`;
+              }
+              resolve(axiosInstance(originalRequest));
+            },
+            (err: Error) => {
+              reject(err);
+            },
+          );
+        });
+      }
+
+      isRefreshing = true;
+
+      try {
+        const refreshResponse = await axios.post(
+          `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auth/refresh`,
+          {},
+          { withCredentials: true },
+        );
+
+        if (refreshResponse.data?.isSuccess && refreshResponse.data?.result?.accessToken) {
+          const newToken = refreshResponse.data.result.accessToken;
+          setAccessToken(newToken);
+
+          // 대기 중인 요청들에게 새 토큰 전달
+          onTokenRefreshed(newToken);
+          isRefreshing = false;
+
+          if (originalRequest.headers) {
+            originalRequest.headers.Authorization = `Bearer ${newToken}`;
+          }
+          return axiosInstance(originalRequest); // 재요청
+        }
+      } catch (refreshError) {
+        // 갱신 실패 - 대기 중인 요청들에게 에러 전달
+        onRefreshFailed(refreshError instanceof Error ? refreshError : new Error('Token refresh failed'));
+      }
+
+      isRefreshing = false;
+      clearAuth();
+      dispatchAuthError({ type: 'TOKEN_EXPIRED', redirectUrl: window.location.pathname });
+      return Promise.reject(error);
+    }
+
+    // 400 특정 코드 처리 (토큰 관련 에러)
+    if (
+      res?.status === 400 &&
+      (code === 'INVALID_REFRESH_TOKEN' || code === 'INVALID_TOKEN' || code === 'ACCESS_TOKEN_EXPIRED')
+    ) {
+      clearAuth();
+      dispatchAuthError({ type: 'TOKEN_EXPIRED', redirectUrl: window.location.pathname });
     }
 
     return Promise.reject(error);

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -24,6 +24,12 @@ function onRefreshFailed(error: Error) {
   refreshSubscribers = [];
 }
 
+// SSR-safe redirectUrl 헬퍼 (쿼리 파라미터 포함)
+function getRedirectUrl(): string {
+  if (typeof window === 'undefined') return '/';
+  return `${window.location.pathname}${window.location.search}`;
+}
+
 // _retry 플래그를 위한 타입 확장
 interface AxiosRequestConfigWithRetry extends AxiosRequestConfig {
   _retry?: boolean;
@@ -113,22 +119,24 @@ axiosInstance.interceptors.response.use(
 
           // 대기 중인 요청들에게 새 토큰 전달
           onTokenRefreshed(newToken);
-          isRefreshing = false;
 
           if (originalRequest.headers) {
             originalRequest.headers.Authorization = `Bearer ${newToken}`;
           }
           return axiosInstance(originalRequest); // 재요청
         }
+
+        // isSuccess=false 또는 accessToken 없음 → 실패 처리
+        throw new Error('Token refresh returned no access token');
       } catch (refreshError) {
         // 갱신 실패 - 대기 중인 요청들에게 에러 전달
         onRefreshFailed(refreshError instanceof Error ? refreshError : new Error('Token refresh failed'));
+        clearAuth();
+        dispatchAuthError({ type: 'TOKEN_EXPIRED', redirectUrl: getRedirectUrl() });
+        return Promise.reject(error);
+      } finally {
+        isRefreshing = false;
       }
-
-      isRefreshing = false;
-      clearAuth();
-      dispatchAuthError({ type: 'TOKEN_EXPIRED', redirectUrl: window.location.pathname });
-      return Promise.reject(error);
     }
 
     // 400 특정 코드 처리 (토큰 관련 에러)
@@ -137,7 +145,7 @@ axiosInstance.interceptors.response.use(
       (code === 'INVALID_REFRESH_TOKEN' || code === 'INVALID_TOKEN' || code === 'ACCESS_TOKEN_EXPIRED')
     ) {
       clearAuth();
-      dispatchAuthError({ type: 'TOKEN_EXPIRED', redirectUrl: window.location.pathname });
+      dispatchAuthError({ type: 'TOKEN_EXPIRED', redirectUrl: getRedirectUrl() });
     }
 
     return Promise.reject(error);

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -60,7 +60,7 @@ const LoginContent = () => {
             // Designer: 항상 Designer 홈으로
             // Model: callbackUrl 또는 루트로
             const redirectUrl = userRole === 'designer' ? '/designer/home' : callbackUrl || '/';
-            router.push(redirectUrl);
+            router.replace(redirectUrl); // 로그인 페이지를 히스토리에서 제거
           } else {
             showToast(response.message || '로그인 실패');
           }

--- a/src/app/(common)/chat/[roomId]/page.tsx
+++ b/src/app/(common)/chat/[roomId]/page.tsx
@@ -15,9 +15,8 @@ import {
   useChatReservationSummary,
   useRequestReservationChange,
 } from '@/src/hooks/queries/reservation';
-import { useAuthHydration } from '@/src/hooks/custom';
+import { useAuthReady } from '@/src/hooks/custom/mypage';
 import useChatRoom from '@/src/hooks/custom/chat/useChatRoom';
-import { getUserRole, useAuthStore } from '@/src/stores';
 import { formatChatDateLabel } from '@/src/utils/chat';
 import type { ReservationCancelRequest, ReservationChangeRequest, ReservationInfo } from '@/src/types/reservation';
 
@@ -29,24 +28,22 @@ export default function ChatRoom() {
   const roomId = Array.isArray(roomIdParam) ? roomIdParam[0] : roomIdParam;
   const roomIdNumber = roomId ? Number(roomId) : undefined;
   const validRoomId = roomIdNumber != null && !Number.isNaN(roomIdNumber) ? roomIdNumber : undefined;
-  const { isAuthenticated, isHydrated } = useAuthHydration();
+  const { isLoggedIn, authReady, role } = useAuthReady();
   const [modalDismissed, setModalDismissed] = useState(false);
-  const showLoginModal = isHydrated && !isAuthenticated && !modalDismissed;
+  const showLoginModal = authReady && !isLoggedIn && !modalDismissed;
   const callbackUrl = useMemo(() => {
     const query = searchParams.toString();
     return query ? `${pathname}?${query}` : pathname;
   }, [pathname, searchParams]);
 
-  const activeRoomId = isAuthenticated ? roomId : undefined;
+  const activeRoomId = isLoggedIn ? roomId : undefined;
   const { messages, opponent, input, setInput, sendMessage, sendImage, fetchPrevMessages, hasNext, loading } =
     useChatRoom(activeRoomId);
   const headerTitle = opponent?.name ?? '';
   const roleLabel = opponent?.role === 'DESIGNER' ? '디자이너' : undefined;
   const requestChange = useRequestReservationChange();
   const cancelReservation = useCancelReservation();
-  const roleFromStore = useAuthStore((state) => state.user?.role);
-  const roleFromCookie = getUserRole();
-  const userRole = roleFromStore ?? roleFromCookie;
+  const userRole = role;
 
   const containerRef = useRef<HTMLElement | null>(null);
   const isInitialScroll = useRef(true);
@@ -93,7 +90,7 @@ export default function ChatRoom() {
   const { data: fetchedReservationInfo } = useChatReservationSummary({
     roomId: validRoomId ?? null,
     role: userRole,
-    enabled: !queryReservationInfo && isAuthenticated,
+    enabled: !queryReservationInfo && isLoggedIn,
   });
 
   const reservationInfo = queryReservationInfo ?? fetchedReservationInfo ?? null;

--- a/src/app/(common)/chat/page.tsx
+++ b/src/app/(common)/chat/page.tsx
@@ -5,27 +5,24 @@ import ChatCategoryChips from '@/src/components/chat/chatlist/ChatCategoryChips'
 import ChatList from '@/src/components/chat/chatlist/ChatList';
 import { useChatRooms } from '@/src/hooks/queries/chat';
 import { useToast } from '@/src/hooks/common/useToast';
-import { useAuthHydration } from '@/src/hooks/custom';
-import { getUserRole, useAuthStore } from '@/src/stores';
+import { useAuthReady } from '@/src/hooks/custom/mypage';
 import { LoginRequiredModal } from '@/src/components/common';
 import BottomNav from '@/src/components/common/BottomNav';
 
 export default function ChatPage() {
   const { showToast } = useToast();
-  const { isAuthenticated, isHydrated } = useAuthHydration();
-  const roleFromStore = useAuthStore((state) => state.user?.role);
-  const roleFromCookie = getUserRole();
-  const userRole = roleFromCookie ?? roleFromStore;
+  const { isLoggedIn, authReady, role } = useAuthReady();
+  const userRole = role;
   const [modalDismissed, setModalDismissed] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState('ALL');
   const requestCategory = selectedCategory === 'ALL' ? undefined : selectedCategory;
 
   // 비로그인 상태이고 모달을 닫지 않은 경우 표시
-  const showLoginModal = isHydrated && !isAuthenticated && !modalDismissed;
+  const showLoginModal = authReady && !isLoggedIn && !modalDismissed;
 
   // 인증된 경우에만 API 호출 (무한 스크롤)
   const { data, isLoading, isFetching, error, fetchNextPage, hasNextPage, isFetchingNextPage } = useChatRooms({
-    enabled: isAuthenticated,
+    enabled: isLoggedIn,
     category: requestCategory,
   });
 
@@ -42,7 +39,7 @@ export default function ChatPage() {
   }, [allChats]);
   const resolvedRole = userRole ?? inferredRole;
   const isModelUser = resolvedRole === 'model';
-  const isListLoading = !isHydrated || isLoading || (isFetching && allChats.length === 0);
+  const isListLoading = !authReady || isLoading || (isFetching && allChats.length === 0);
 
   // 채팅방은 생성된 채로 메세지가 없는 경우, 채팅방 리스트에 뜨는 것을 방지
   const visibleChats = useMemo(() => {

--- a/src/app/(common)/mypage/likes/page.tsx
+++ b/src/app/(common)/mypage/likes/page.tsx
@@ -84,7 +84,7 @@ export default function LikesPage() {
       <header className="flex items-center justify-between px-4 py-3">
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={() => router.push('/mypage')}
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >

--- a/src/app/(common)/mypage/notification-settings/page.tsx
+++ b/src/app/(common)/mypage/notification-settings/page.tsx
@@ -147,7 +147,7 @@ export default function NotificationSettingsPage() {
         <header className="flex items-center justify-between px-4 py-3">
           <button
             type="button"
-            onClick={() => router.back()}
+            onClick={() => router.push('/mypage')}
             className="flex size-6 cursor-pointer items-center justify-center"
             aria-label="뒤로가기"
           >
@@ -172,7 +172,7 @@ export default function NotificationSettingsPage() {
       <header className="flex items-center justify-between px-4 py-3">
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={() => router.push('/mypage')}
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -72,16 +72,13 @@ export default function MypagePage() {
   const { data: unreadData } = useUnreadNotificationCount(authReady && isLoggedIn);
   const notificationCount = unreadData?.result?.unreadCount ?? 0;
 
-  // 로그아웃 핸들러
+  // 로그아웃 핸들러 (API 실패해도 성공으로 처리 - clearAuth는 finally에서 항상 실행됨)
   const handleLogout = () => {
     if (isLoggingOut) return;
     logout(undefined, {
-      onSuccess: () => {
+      onSettled: () => {
         showToast('로그아웃되었습니다.');
-        router.push('/login');
-      },
-      onError: () => {
-        showToast('로그아웃에 실패했습니다.');
+        router.replace('/login'); // 수동 로그아웃은 callbackUrl 없음
       },
     });
   };

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -83,10 +83,11 @@ export default function MypagePage() {
     });
   };
 
-  // 계정 메뉴 아이템 (onClick 연결)
+  // 계정 메뉴 아이템 (onClick 연결, 비로그인 시 비활성화)
   const accountMenuItems = ACCOUNT_LINKS.map((label) => ({
     label,
     onClick: label === '로그아웃' ? handleLogout : undefined,
+    disabled: !isLoggedIn,
   }));
 
   return (

--- a/src/app/(common)/mypage/profile/edit/page.tsx
+++ b/src/app/(common)/mypage/profile/edit/page.tsx
@@ -49,7 +49,7 @@ export default function ProfileEditPage() {
         <button
           type="button"
           aria-label="이전으로"
-          onClick={() => router.back()}
+          onClick={() => router.push('/mypage')}
           className="flex size-6 cursor-pointer items-center justify-center"
         >
           <ArrowLeftIcon className="text-black" />

--- a/src/app/(common)/mypage/reservations/page.tsx
+++ b/src/app/(common)/mypage/reservations/page.tsx
@@ -141,7 +141,7 @@ export default function MyReservationsPage() {
       <header className="flex items-center justify-between bg-white px-4 py-3">
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={() => router.push('/mypage')}
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >

--- a/src/app/(common)/mypage/reviews/write/[reservationId]/page.tsx
+++ b/src/app/(common)/mypage/reviews/write/[reservationId]/page.tsx
@@ -57,7 +57,7 @@ export default function ReviewWritePage() {
           <h1 className="text-head-4-medium text-center text-black">리뷰 작성하기</h1>
           <button
             type="button"
-            onClick={() => router.back()}
+            onClick={() => router.push('/mypage/reviews')}
             className="flex size-6 cursor-pointer items-center justify-center"
             aria-label="닫기"
           >
@@ -79,7 +79,7 @@ export default function ReviewWritePage() {
         <h1 className="text-head-4-medium text-center text-black">리뷰 작성하기</h1>
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={() => router.push('/mypage/reviews')}
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="닫기"
         >

--- a/src/app/(common)/notification/page.tsx
+++ b/src/app/(common)/notification/page.tsx
@@ -46,7 +46,7 @@ export default function NotificationPage() {
       <header className="flex items-center justify-between px-4 py-3">
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={() => router.push('/')}
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >

--- a/src/app/(designer)/reservations/[reservationId]/page.tsx
+++ b/src/app/(designer)/reservations/[reservationId]/page.tsx
@@ -109,7 +109,7 @@ export default function ReservationDetailPage() {
       <header className="flex items-center justify-between px-4 py-3">
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={() => router.push('/reservations/pending')}
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >

--- a/src/app/(designer)/reservations/pending/page.tsx
+++ b/src/app/(designer)/reservations/pending/page.tsx
@@ -27,7 +27,7 @@ export default function PendingReservationsPage() {
       <header className="flex items-center justify-between px-4 py-3">
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={() => router.push('/designer/home')}
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >

--- a/src/app/auth/callback/[provider]/page.tsx
+++ b/src/app/auth/callback/[provider]/page.tsx
@@ -34,7 +34,7 @@ const SocialCallbackPage = ({ params }: PageProps) => {
       // 프로바이더 검증
       if (!(provider in PROVIDER_NAMES)) {
         showToast('지원하지 않는 로그인 방식입니다.');
-        router.push('/login');
+        router.replace('/login');
         return;
       }
 
@@ -51,13 +51,13 @@ const SocialCallbackPage = ({ params }: PageProps) => {
       // 에러 체크
       if (error) {
         showToast(`${providerName} 로그인 실패: ${errorDescription || error}`);
-        router.push('/login');
+        router.replace('/login');
         return;
       }
 
       if (!code) {
         showToast('다시 로그인해주세요.');
-        router.push('/login');
+        router.replace('/login');
         return;
       }
 
@@ -96,14 +96,14 @@ const SocialCallbackPage = ({ params }: PageProps) => {
             // registered 값에 따라 분기
             if (registered) {
               // 이미 회원가입된 사용자 → 홈으로 이동
-              router.push('/');
+              router.replace('/');
             } else {
               // 회원가입이 필요한 사용자 → 회원가입 페이지로 이동
-              router.push('/signup?social=true');
+              router.replace('/signup?social=true');
             }
           } else {
             showToast(response.message || '로그인 실패');
-            router.push('/login');
+            router.replace('/login');
           }
         },
         onError: (error: Error) => {
@@ -116,13 +116,13 @@ const SocialCallbackPage = ({ params }: PageProps) => {
           // 409 에러: 이미 가입된 사용자
           if (status === 409) {
             showToast('이미 가입된 사용자입니다.');
-            router.push('/login');
+            router.replace('/login');
             return;
           }
 
           const errorMessage = error.message || `${providerName} 로그인 중 오류가 발생했습니다.`;
           showToast(errorMessage);
-          router.push('/login');
+          router.replace('/login');
         },
       });
     };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import '@/src/styles/globals.css';
 import { QueryProvider } from '@/src/providers/QueryProvider';
 import { ToastProvider } from '@/src/providers/ToastProvider';
+import { AuthErrorHandler } from '@/src/providers/AuthErrorHandler';
 import { FCMProvider } from '@/src/providers/FCMProvider';
 
 export const metadata: Metadata = {
@@ -36,9 +37,11 @@ const RootLayout = ({
       <body className="bg-white">
         <QueryProvider>
           <ToastProvider>
-            <FCMProvider>
-              <div className="mx-auto min-h-screen w-full min-w-[375px] overflow-x-hidden sm:w-[375px] sm:shadow-2xl">{children}</div>
-            </FCMProvider>
+            <AuthErrorHandler>
+              <FCMProvider>
+                <div className="mx-auto min-h-screen w-full min-w-[375px] overflow-x-hidden sm:w-[375px] sm:shadow-2xl">{children}</div>
+              </FCMProvider>
+            </AuthErrorHandler>
           </ToastProvider>
         </QueryProvider>
       </body>

--- a/src/components/mypage/MenuList.tsx
+++ b/src/components/mypage/MenuList.tsx
@@ -4,6 +4,7 @@ type MenuListItem = {
   label: string;
   href?: string;
   onClick?: () => void;
+  disabled?: boolean;
 };
 
 type MenuListProps = {
@@ -14,13 +15,17 @@ type MenuListProps = {
 export const MenuList = ({ items }: MenuListProps) => {
   if (items.length === 0) return null;
 
-  const itemStyle = 'text-body-1-medium w-full cursor-pointer py-3 text-left text-gray-900 block';
+  const baseStyle = 'text-body-1-medium w-full py-3 text-left text-gray-900 block';
+  const enabledStyle = 'cursor-pointer';
+  const disabledStyle = 'opacity-50 cursor-not-allowed';
 
   return (
     <section>
       <div>
-        {items.map(({ label, href, onClick }) => {
-          if (href) {
+        {items.map(({ label, href, onClick, disabled }) => {
+          const itemStyle = `${baseStyle} ${disabled ? disabledStyle : enabledStyle}`;
+
+          if (href && !disabled) {
             return (
               <Link key={label} href={href} className={itemStyle}>
                 {label}
@@ -32,7 +37,9 @@ export const MenuList = ({ items }: MenuListProps) => {
             <button
               key={label}
               type="button"
-              onClick={onClick}
+              disabled={disabled}
+              aria-disabled={disabled}
+              onClick={disabled ? undefined : onClick}
               className={itemStyle}
             >
               {label}

--- a/src/components/post/Header/PostHeader.tsx
+++ b/src/components/post/Header/PostHeader.tsx
@@ -14,7 +14,7 @@ export default function PostHeader({ onBack }: PostHeaderProps) {
     if (onBack) {
       onBack();
     } else {
-      router.back();
+      router.push('/explore');
     }
   };
 

--- a/src/providers/AuthErrorHandler.tsx
+++ b/src/providers/AuthErrorHandler.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useCallback, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+import { AUTH_ERROR_EVENT, AUTH_ERROR_MESSAGES, AuthErrorEvent } from '@/src/types/auth/authError';
+import { showToast } from '@/src/utils';
+
+export function AuthErrorHandler({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const redirectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleAuthError = useCallback(
+    (event: CustomEvent<AuthErrorEvent>) => {
+      // 중복 리다이렉트 방지
+      if (redirectTimeoutRef.current) {
+        clearTimeout(redirectTimeoutRef.current);
+      }
+
+      const { type, redirectUrl } = event.detail;
+      showToast(AUTH_ERROR_MESSAGES[type]);
+      queryClient.clear(); // 만료된 데이터 캐시 클리어
+
+      redirectTimeoutRef.current = setTimeout(() => {
+        // 401/TOKEN_EXPIRED: 로그인 페이지로 리다이렉트 (callbackUrl 유지)
+        const callbackUrl = redirectUrl || window.location.pathname;
+        router.replace(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+      }, 100);
+    },
+    [router, queryClient],
+  );
+
+  useEffect(() => {
+    const handler = (e: Event) => handleAuthError(e as CustomEvent<AuthErrorEvent>);
+    window.addEventListener(AUTH_ERROR_EVENT, handler);
+    return () => window.removeEventListener(AUTH_ERROR_EVENT, handler);
+  }, [handleAuthError]);
+
+  return <>{children}</>;
+}

--- a/src/stores/auth/useAuthStore.ts
+++ b/src/stores/auth/useAuthStore.ts
@@ -55,7 +55,7 @@ export const getAccessToken = (): string | null => {
 export const setAccessToken = (token: string) => {
   if (typeof document === 'undefined') return;
 
-  document.cookie = `access_token=${token}; path=/; max-age=3600; SameSite=Lax${
+  document.cookie = `access_token=${token}; path=/; max-age=604800; SameSite=Lax${
     process.env.NODE_ENV === 'production' ? '; Secure' : ''
   }`;
 };
@@ -103,7 +103,7 @@ export const setUserRole = (role: 'model' | 'designer' | string) => {
     return;
   }
 
-  document.cookie = `user_role=${normalizedRole}; path=/; max-age=3600; SameSite=Lax${
+  document.cookie = `user_role=${normalizedRole}; path=/; max-age=604800; SameSite=Lax${
     process.env.NODE_ENV === 'production' ? '; Secure' : ''
   }`;
 };
@@ -141,7 +141,7 @@ export const setUserCategory = (category: Category | string) => {
     return;
   }
 
-  document.cookie = `user_category=${normalizedCategory}; path=/; max-age=3600; SameSite=Lax${
+  document.cookie = `user_category=${normalizedCategory}; path=/; max-age=604800; SameSite=Lax${
     process.env.NODE_ENV === 'production' ? '; Secure' : ''
   }`;
 };

--- a/src/types/auth/authError.ts
+++ b/src/types/auth/authError.ts
@@ -1,0 +1,12 @@
+export type AuthErrorType = 'UNAUTHORIZED' | 'TOKEN_EXPIRED';
+
+export interface AuthErrorEvent {
+  type: AuthErrorType;
+  redirectUrl?: string;
+}
+
+export const AUTH_ERROR_EVENT = 'auth:error';
+export const AUTH_ERROR_MESSAGES: Record<AuthErrorType, string> = {
+  UNAUTHORIZED: '로그인이 필요합니다',
+  TOKEN_EXPIRED: '세션이 만료되었습니다. 다시 로그인해주세요',
+};

--- a/src/utils/auth/authErrorDispatcher.ts
+++ b/src/utils/auth/authErrorDispatcher.ts
@@ -1,0 +1,7 @@
+import { AUTH_ERROR_EVENT, AuthErrorEvent } from '@/src/types/auth/authError';
+
+export function dispatchAuthError(error: AuthErrorEvent): void {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(AUTH_ERROR_EVENT, { detail: error }));
+  }
+}


### PR DESCRIPTION
### 💡 To Reviewers

- 인증(로그인) 관련 `문제 -> 해결 방안`
- 가장 큰 문제는 user_role, user_category의 max_age가 30분이라, accessToken(30분)이 만료되었더라도 refreshToken(7일)으로 갱신하지 못하고, 403(unauthorized)에러를 반환하고 있었습니다.
- 따라서 해당 두 쿠키의 max_age와 accessToken을 안전하게 7일로 늘렸습니다. (accessToken을 정확하게 백엔드와 30분으로 일치시키기 vs 30분보다 약간 긴시간 vs 7일 중 가장 안전한 7일로 통일 하였습니다) 
- 해당 에러를 고치면서 401에러 발생 시 리다이렉트도 추가하였습니다
- 또한 `router.back()` 을 `router.push()` 으로 변경하여 명시적인 라우팅으로 가는 것으로 변경하였습니다. (funnel 구조가 들어간건 여전히 back 사용 중) (다른 많은 웹사이트가 이렇게 구성되어있음. 왜냐하면 예시로 링크를 공유 받아 공고 상세 페이지로 첫 진입시, 뒤로가기를 할 곳을 명시적으로 제시해줘야 하기 때문)
- 채팅 페이지 useAuthHydation -> useAuthReady로 변경 (마이페이지의 useAuthReady로 사용하는것으로 변경) useAuthHydration 훅은 현재 미사용 중. 삭제하지 않은 이유는 현재 작업중인 디자이너 프로필 페이지에 영향이 갈 것을 생각.
- SSR 적용중인 페이지는 인증 관련 어떻게 처리되고 있는지 확인해야됨.

> 백엔드 요청사항
요기 domain: ".moandi.co.kr" 이렇게 추가 가능할까요??

백엔드에서 데이터 양이 많은 것들을 가져올때, 프론트 도메인(moandi.co.kr) 소속 서버에서 api 호출 후 받은 데이터로 렌더링 하는 방식(SSR)이 있는데,
여기서도 똑같이 accessToken이 만료된 경우, refreshToken을 httpOnly로 보내서 갱신을 시켜야됩니당.

근데 지금 받아오는 refreshToken은 도메인이 api.moandi.co.kr 소속이라 브라우저에만 저장되고, 프론트 도메인(moandi.co.kr)은 읽을 수 없습니당. 그래서 accessToken 만료시 SSR 방식으로 데이터를 받아올때, refreshToken을 보낼 수 없어서 accessToken이 자동 갱신되지 못해용

---

### 🔥 작업 내용

#### 문제 1: 401 에러 발생 시 사용자가 깨진 페이지에 머무름

**Before:**
- `axios.ts`에서 401 발생 시 `clearAuth()`만 호출하고 리다이렉트 없음
- 사용자가 깨진 페이지에 머물러 혼란 발생

**After:**
- Pub/Sub 패턴으로 인증 에러 이벤트 시스템 구축
- 401 발생 → 이벤트 발생 → `AuthErrorHandler`에서 Toast + 로그인 페이지 리다이렉트
- `callbackUrl` 유지로 로그인 후 원래 페이지 복귀 가능

---

#### 문제 2: 동시 API 호출 시 토큰 갱신 Race Condition

**Before:**
- 동시에 여러 API가 401을 받으면 각각 refresh 요청을 보냄
- 불필요한 중복 토큰 발급, 서버 부하 증가

**After:**
- 토큰 갱신 동기화 시스템 구현
- 첫 번째 요청만 refresh 실행, 나머지 요청은 대기
- 갱신 완료 후 모든 대기 요청에 새 토큰 전달 후 재시도

```
시간     API 1        API 2        API 3        isRefreshing
────────────────────────────────────────────────────────────
0ms     요청         요청         요청          false
1ms     401          401          401           false
2ms     refresh 시작  대기 등록    대기 등록      true
4ms     토큰 발급     -            -             true
5ms     재요청       토큰 전달    토큰 전달      false
7ms     완료         완료         완료           false
```

---

#### 문제 3: 로그인 후 네비게이션 루프

**Before:**
- `/chat/123` → 401 → `/login?callbackUrl=/chat/123` → 로그인 → `/chat/123`
- 뒤로가기 시 로그인 페이지로 돌아감 (무한 루프)

**After:**
- 인증 관련 리다이렉트에 `router.push()` → `router.replace()` 변경
- 로그인 페이지가 히스토리에 남지 않음

---

#### 문제 4: 토큰 만료 상태에서 로그아웃 시 에러 Toast

**Before:**
- 토큰 만료 상태에서 로그아웃 버튼 클릭
- `POST /auth/logout` → 401 에러 → "로그아웃에 실패했습니다" Toast 표시
- 실제로는 `finally`에서 `clearAuth()` 실행되어 로그아웃 성공

**After:**
- `onError` → `onSettled` 변경
- API 성공/실패 관계없이 "로그아웃되었습니다" Toast 표시
- 수동 로그아웃은 `callbackUrl` 없이 `/login`으로 이동

---

#### 문제 5: `router.back()` 사용 시 예측 불가능한 네비게이션

**Before:**
- 딥링크로 직접 페이지 접근 → 뒤로가기 → 예상치 못한 페이지로 이동

**After:**
- `router.back()` → 명시적 부모 경로로 변경
- 예: `/mypage/likes` 뒤로가기 → `/mypage`
- Funnel 패턴 (회원가입, 예약 단계 등)은 기존 `router.back()` 유지

---

#### 문제 6: 쿠키 만료시간이 refreshToken 유효기간과 불일치

**Before:**
- 쿠키 max-age: 1시간 (3600초)
- accessToken 유효: 30분 (백엔드)
- refreshToken 유효: 7일 (백엔드)
- 쿠키가 먼저 삭제되어 refresh 메커니즘이 동작하지 않는 문제

**After:**
- 쿠키 max-age: 7일 (604800초) - refreshToken과 동기화
- 쿠키 보관 기간 ≠ 토큰 유효 기간 (쿠키는 보관만, 유효성은 백엔드가 검증)
- accessToken 만료 시 axios interceptor가 자동으로 refresh 수행

| 쿠키 | 변경 전 | 변경 후 |
|------|--------|--------|
| `access_token` | 3600초 (1시간) | 604800초 (7일) |
| `user_role` | 3600초 (1시간) | 604800초 (7일) |
| `user_category` | 3600초 (1시간) | 604800초 (7일) |

---

#### 문제 7: 비로그인 사용자가 계정 메뉴 클릭 가능

**Before:**
- 비로그인 상태에서 마이페이지 접속 시 "계정 추가하기", "로그아웃", "탈퇴하기" 버튼이 활성화 상태
- 클릭 시 아무 동작 없거나 에러 발생 가능

**After:**
- 비로그인 시 계정 메뉴 `opacity-50` + `disabled` 처리
- `aria-disabled` 속성으로 접근성 지원
- 클릭 불가능하게 처리

---

### 📁 수정 파일 목록

| 파일 | 작업 |
|------|------|
| `src/types/auth/authError.ts` | 새로 생성 - 인증 에러 타입/상수 정의 |
| `src/utils/auth/authErrorDispatcher.ts` | 새로 생성 - 이벤트 디스패처 |
| `src/providers/AuthErrorHandler.tsx` | 새로 생성 - 인증 에러 UI 처리 Provider |
| `src/apis/axios.ts` | 토큰 갱신 동기화 + 401 이벤트 dispatch |
| `src/stores/auth/useAuthStore.ts` | 쿠키 max-age 7일로 변경 |
| `src/app/layout.tsx` | AuthErrorHandler 추가 |
| `src/app/(common)/mypage/page.tsx` | 로그아웃 onSettled 변경 + replace |
| `src/app/(auth)/login/page.tsx` | push → replace |
| `src/app/auth/callback/[provider]/page.tsx` | push → replace (8개소) |
| `src/app/(common)/mypage/profile/edit/page.tsx` | back → push('/mypage') |
| `src/app/(common)/mypage/notification-settings/page.tsx` | back → push('/mypage') |
| `src/app/(common)/mypage/likes/page.tsx` | back → push('/mypage') |
| `src/app/(common)/mypage/reservations/page.tsx` | back → push('/mypage') |
| `src/app/(common)/mypage/reviews/write/[reservationId]/page.tsx` | back → push('/mypage/reviews') |
| `src/app/(common)/notification/page.tsx` | back → push('/') |
| `src/app/(designer)/reservations/pending/page.tsx` | back → push('/designer/home') |
| `src/app/(designer)/reservations/[reservationId]/page.tsx` | back → push('/reservations/pending') |
| `src/components/post/Header/PostHeader.tsx` | back → push('/explore') |

---

### 🤔 추후 작업 예정

- 없음 (완료)

---

### 📸 작업 결과 (스크린샷) - 테스트 내역으로 대체합니다

| 테스트 | 시나리오 | 기대 결과 |
|--------|---------|----------|
| 토큰 갱신 | access_token 쿠키만 삭제 → API 호출 | 자동 갱신 후 정상 응답 |
| 동시 API 호출 | 3개 API 동시 401 | 첫 번째만 refresh, 나머지 대기 후 재시도 |
| Refresh 실패 | 모든 토큰 삭제 → API 호출 | Toast + 로그인 페이지 이동 (callbackUrl 포함) |
| 로그아웃 | 토큰 만료 상태에서 로그아웃 클릭 | "로그아웃되었습니다" Toast + `/login` 이동 |
| 네비게이션 루프 | 로그인 → callbackUrl → 뒤로가기 | 로그인 페이지 아님 확인 |
| Back 버튼 | 딥링크로 직접 접근 → 뒤로가기 | 부모 경로로 이동 |
| 쿠키 유지 | 로그인 후 30분 경과 → API 호출 | 쿠키 유지, 자동 refresh 후 정상 응답 |

---

### 🔗 관련 이슈

- #57



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 인증 만료 시 안정적인 토큰 재발급 및 동시 요청 처리 개선, 실패 시 자동 로그아웃/리다이렉트 보장

* **새로운 기능**
  * 클라이언트 인증 에러 중앙 처리기 및 에러 이벤트/발송 추가
  * 메뉴 항목에 비활성화(disabled) 상태 지원

* **개선 사항**
  * 내비게이션을 replace/push로 일관화해 뒤로가기 이슈 해소
  * 세션 유지 기간 연장(1시간 → 7일)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->