### PR TITLE
[FIX] iOS PWA 알림 권한 상태 동기화 버그 수정

### DIFF
--- a/src/hooks/custom/notification/useFCM.ts
+++ b/src/hooks/custom/notification/useFCM.ts
@@ -47,6 +47,27 @@ export function useFCM(onMessageReceived?: (payload: MessagePayload) => void): U
   const [permission, setPermission] = useState<NotificationPermission>(getInitialPermission);
   const unsubscribeRef = useRef<(() => void) | null>(null);
 
+  // iOS 대응: 앱이 포그라운드로 돌아올 때 권한 상태 동기화
+  useEffect(() => {
+    const syncPermission = () => {
+      if (typeof window !== 'undefined' && 'Notification' in window) {
+        const actualPermission = Notification.permission;
+        setPermission((prev) => (prev !== actualPermission ? actualPermission : prev));
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        syncPermission();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
   /**
    * 알림 권한 요청 및 FCM 토큰 발급
    * @returns FCM 토큰 또는 null (권한 거부/오류 시)
@@ -58,9 +79,13 @@ export function useFCM(onMessageReceived?: (payload: MessagePayload) => void): U
 
     try {
       // 1. 브라우저 알림 권한 요청
-      const result = await Notification.requestPermission();
-      setPermission(result);
-      if (result !== 'granted') return null;
+      await Notification.requestPermission();
+
+      // iOS 대응: 반환값 대신 실제 권한 상태 사용
+      const actualPermission = Notification.permission;
+      setPermission(actualPermission);
+
+      if (actualPermission !== 'granted') return null;
 
       // 2. Firebase Messaging 인스턴스 획득
       const messaging = await getFirebaseMessaging();
@@ -79,6 +104,9 @@ export function useFCM(onMessageReceived?: (payload: MessagePayload) => void): U
       setToken(fcmToken);
       return fcmToken;
     } catch {
+      // 에러 시에도 실제 권한 상태 동기화
+      const actualPermission = Notification.permission;
+      setPermission(actualPermission);
       return null;
     }
   }, []);


### PR DESCRIPTION
### 💡 To Reviewers

- iOS PWA 알림 권한 상태 동기화 버그 수정
- Notification permission을 직접 읽도록 수정 -> 리스너를 통해 Toggle 버튼 상태 동기화

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

## visibilitychange 리스너 추가

- 앱이 포그라운드로 돌아올 때 Notification.permission을 다시 읽어 상태 동기화
- IOS에서 시스템 설정 앱 갔다 돌아올 때 권한 상태 갱신

## requestPermission 로직 수정

- 기존: await Notification.requestPermission() 반환값 사용
- 수정: 반환값 무시, Notification.permission 직접 읽기

### 🤔 추후 작업 예정

- ios pwa 앱 확인

### 📸 작업 결과 (스크린샷)

없음

### 🔗 관련 이슈

- #102 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **알림 권한 상태 동기화**: 앱이 백그라운드에서 포그라운드로 전환될 때 알림 권한 상태를 정확하게 감지하고 업데이트합니다.
* **권한 요청 신뢰성 향상**: 알림 권한 요청 후 실제 권한 상태를 확인하여 권한 상태 추적의 안정성을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->