### PR TITLE
[FIX] 마이페이지, 채팅 페이지 하위 페이지 iOS Safe Area 레이아웃 레벨에서 일괄 처리

### DIFF
--- a/src/app/(common)/chat/[roomId]/page.tsx
+++ b/src/app/(common)/chat/[roomId]/page.tsx
@@ -202,7 +202,7 @@ export default function ChatRoom() {
   return (
     <div className="relative flex h-screen flex-col bg-gray-200">
       {isReservationOpen && (
-        <div className="safe-area-top absolute inset-x-0 top-0 z-20 rounded-b-[20px] bg-white pt-[15.5px] pb-5">
+        <div className="absolute inset-x-0 top-0 z-20 rounded-b-[20px] bg-white pt-[calc(env(safe-area-inset-top)+15.5px)] pb-5">
           <div className="flex justify-end px-4 pb-[15.5px]">
             <button
               type="button"

--- a/src/app/(common)/chat/page.tsx
+++ b/src/app/(common)/chat/page.tsx
@@ -7,7 +7,6 @@ import { useChatRooms } from '@/src/hooks/queries/chat';
 import { useToast } from '@/src/hooks/common/useToast';
 import { useAuthReady } from '@/src/hooks/custom/mypage';
 import { LoginRequiredModal } from '@/src/components/common';
-import BottomNav from '@/src/components/common/BottomNav';
 
 export default function ChatPage() {
   const { showToast } = useToast();
@@ -56,7 +55,7 @@ export default function ChatPage() {
   }, [error, showToast]);
 
   return (
-    <div className="min-h-screen bg-white pt-[env(safe-area-inset-top)] pb-20">
+    <div className="min-h-screen bg-white">
       <h1 className="text-head-3-semibold px-5 py-3">채팅</h1>
       {isModelUser && <ChatCategoryChips selectedCategory={selectedCategory} onChange={setSelectedCategory} />}
       <ChatList
@@ -66,7 +65,6 @@ export default function ChatPage() {
         isFetchingNextPage={isFetchingNextPage}
         onLoadMore={fetchNextPage}
       />
-      <BottomNav />
       <LoginRequiredModal isOpen={showLoginModal} onClose={() => setModalDismissed(true)} callbackUrl="/chat" />
     </div>
   );

--- a/src/app/(common)/layout.tsx
+++ b/src/app/(common)/layout.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import BottomNav from '@/src/components/common/BottomNav';
+
+export default function CommonLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  // 채팅방 상세: /chat/[roomId] (모든 roomId 형식 지원)
+  const isChatRoom = pathname.startsWith('/chat/') && pathname !== '/chat';
+
+  const hideBottomNav =
+    pathname.startsWith('/mypage/likes') ||
+    pathname.startsWith('/mypage/reservations') ||
+    pathname.startsWith('/mypage/reviews') ||
+    pathname.startsWith('/mypage/notification-settings') ||
+    pathname.startsWith('/mypage/profile') ||
+    pathname.startsWith('/notification') ||
+    isChatRoom;
+
+  // chat/[roomId]는 h-screen 레이아웃이므로 safe-area 제외 (페이지 내부에서 처리)
+  const excludeSafeArea = isChatRoom;
+
+  const mainClassName = excludeSafeArea
+    ? ''
+    : hideBottomNav
+      ? 'pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]'
+      : 'pt-[env(safe-area-inset-top)] pb-[calc(76px+env(safe-area-inset-bottom))]';
+
+  return (
+    <>
+      <main className={mainClassName}>{children}</main>
+      {!hideBottomNav && <BottomNav />}
+    </>
+  );
+}

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import ArrowRightIcon from '@/public/icons/common/arrow-right.svg';
-import { BottomNav } from '@/src/components/common';
 import { MenuList, MyMenuCard, ProfileCard } from '@/src/components/mypage';
 import { useAuthReady, useSimpleProfile } from '@/src/hooks/custom/mypage';
 import { useLogout } from '@/src/hooks/queries/auth';
@@ -91,7 +90,7 @@ export default function MypagePage() {
   }));
 
   return (
-    <div className="min-h-screen bg-white pt-[env(safe-area-inset-top)]">
+    <div className="min-h-screen bg-white">
       <div className="flex flex-col">
         {/* 헤더 */}
         <header className="flex h-[52px] items-center justify-between py-3 pr-3 pl-5">
@@ -129,7 +128,6 @@ export default function MypagePage() {
           <MenuList items={accountMenuItems} />
         </div>
       </div>
-      <BottomNav />
     </div>
   );
 }

--- a/src/app/(common)/mypage/profile/edit/page.tsx
+++ b/src/app/(common)/mypage/profile/edit/page.tsx
@@ -43,7 +43,7 @@ export default function ProfileEditPage() {
   const isButtonLoading = isUploading || isLoading;
 
   return (
-    <div className="flex min-h-screen flex-col bg-white pt-[env(safe-area-inset-top)]">
+    <div className="flex min-h-screen flex-col bg-white">
       {/* 헤더 */}
       <header className="flex items-center justify-between px-4 py-3">
         <button

--- a/src/components/chat/chatroom/ChatHeader.tsx
+++ b/src/components/chat/chatroom/ChatHeader.tsx
@@ -25,7 +25,7 @@ export default function ChatHeader({
   const canShowReservation = showReservation && !!onReservationClick;
 
   return (
-    <header className="safe-area-top relative flex h-13 items-center px-4 py-3">
+    <header className="relative flex h-13 items-center px-4 pt-[calc(env(safe-area-inset-top)+12px)] pb-3">
       <button
         type="button"
         onClick={() => router.push('/chat')}

--- a/src/components/chat/chatroom/ChatHeader.tsx
+++ b/src/components/chat/chatroom/ChatHeader.tsx
@@ -25,7 +25,7 @@ export default function ChatHeader({
   const canShowReservation = showReservation && !!onReservationClick;
 
   return (
-    <header className="relative flex h-13 items-center px-4 pt-[calc(env(safe-area-inset-top)+12px)] pb-3">
+    <header className="relative flex min-h-13 items-center px-4 pt-[calc(env(safe-area-inset-top)+12px)] pb-3">
       <button
         type="button"
         onClick={() => router.push('/chat')}

--- a/src/components/chat/chatroom/ChatInput.tsx
+++ b/src/components/chat/chatroom/ChatInput.tsx
@@ -37,7 +37,7 @@ export default function ChatInput({
   };
 
   return (
-    <div className="bg-transparent px-4 py-3">
+    <div className="bg-transparent px-4 py-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
       <div className="flex items-center gap-2">
         <button
           type="button"

--- a/src/components/common/Modal/LoginRequiredModal.tsx
+++ b/src/components/common/Modal/LoginRequiredModal.tsx
@@ -25,7 +25,7 @@ export default function LoginRequiredModal({ isOpen, onClose, callbackUrl }: Log
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(28,28,30,0.4)]">
+    <div className="fixed inset-0 z-60 flex items-center justify-center bg-[rgba(28,28,30,0.4)]">
       <div className="relative w-[311px] rounded-[20px] bg-white px-5 py-6">
         {/* 안내 텍스트 */}
         <div className="mb-6 text-center">


### PR DESCRIPTION
### 💡 To Reviewers

- myPage 하위 페이지에서 뒤로가기 버튼이 보이지 않는 버그 발생
- (common) 폴더 아래 공통 layout 추가 및 하위페이지 bottomNav, safe area 일괄처리하였습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 각 페이지 별로 적절한 padding 추가 및 iOS Safe Area 처리 하였습니다.

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 배포 후 확인 필요

### 🔗 관련 이슈

- #102 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 공통 레이아웃 도입으로 경로에 따른 하단 네비게이션 표시 제어 및 화면 안전영역 처리 적용

* **버그 수정**
  * 노치·안전영역(env(safe-area-inset-* ))을 반영한 헤더·예약패널·채팅입력의 상하 여백 조정
  * 채팅 페이지 및 마이페이지에서 하단 네비게이션 사용성 개선(불필요한 표시 제거)
  * 로그인 모달의 표시 우선순위(z-index) 상향 조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->