### PR TITLE
[FIX] iOS Safari, PWA 앱 UI 버그 수정

### DIFF
--- a/public/icons/common/arrow-left.svg
+++ b/public/icons/common/arrow-left.svg
@@ -1,3 +1,3 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M15.5 19L8.5 12L15.5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.5 19L8.5 12L15.5 5" stroke="#222222" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/public/icons/common/arrow-left.svg
+++ b/public/icons/common/arrow-left.svg
@@ -1,3 +1,3 @@
-<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M15.5 19L8.5 12L15.5 5" stroke="#222222" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/app/(common)/chat/[roomId]/page.tsx
+++ b/src/app/(common)/chat/[roomId]/page.tsx
@@ -200,9 +200,9 @@ export default function ChatRoom() {
   };
 
   return (
-    <div className="relative flex h-screen flex-col bg-gray-200">
+    <div className="relative flex h-screen h-dvh flex-col overflow-hidden bg-gray-200">
       {isReservationOpen && (
-        <div className="safe-area-top absolute inset-x-0 top-0 z-20 rounded-b-[20px] bg-white pt-[15.5px] pb-5">
+        <div className="absolute inset-x-0 top-0 z-20 rounded-b-[20px] bg-white pt-[calc(env(safe-area-inset-top)+15.5px)] pb-5">
           <div className="flex justify-end px-4 pb-[15.5px]">
             <button
               type="button"

--- a/src/app/(common)/chat/[roomId]/page.tsx
+++ b/src/app/(common)/chat/[roomId]/page.tsx
@@ -200,7 +200,7 @@ export default function ChatRoom() {
   };
 
   return (
-    <div className="relative flex h-screen h-dvh flex-col overflow-hidden bg-gray-200">
+    <div className="fixed inset-0 flex flex-col overflow-hidden bg-gray-200">
       {isReservationOpen && (
         <div className="absolute inset-x-0 top-0 z-20 rounded-b-[20px] bg-white pt-[calc(env(safe-area-inset-top)+15.5px)] pb-5">
           <div className="flex justify-end px-4 pb-[15.5px]">

--- a/src/app/(common)/chat/[roomId]/page.tsx
+++ b/src/app/(common)/chat/[roomId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useParams, usePathname, useSearchParams } from 'next/navigation';
 import ChatHeader from '@/src/components/chat/chatroom/ChatHeader';
 import MessageItem from '@/src/components/chat/chatroom/MessageItem';
@@ -56,6 +56,15 @@ export default function ChatRoom() {
   const [successMessage, setSuccessMessage] = useState('');
   const [pendingCancelChangeId, setPendingCancelChangeId] = useState<number | null>(null);
   const [isReservationOpen, setIsReservationOpen] = useState(false);
+
+  // iOS body 스크롤 잠금
+  useEffect(() => {
+    const originalStyle = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = originalStyle;
+    };
+  }, []);
 
   const queryReservationInfo = useMemo<ReservationInfo | null>(() => {
     const reservationIdParam = searchParams.get('reservationId');
@@ -244,7 +253,7 @@ export default function ChatRoom() {
           setIsReservationOpen((prev) => !prev);
         }}
       />
-      <main ref={containerRef} className="scrollbar-hide flex-1 overflow-auto px-4 py-3" onScroll={handleScroll}>
+      <main ref={containerRef} className="scrollbar-hide flex-1 overflow-auto overscroll-y-contain px-4 py-3" onScroll={handleScroll}>
         <ul className="space-y-3">
           {messages.map((m, idx) => {
             const next = messages[idx + 1];

--- a/src/app/(common)/mypage/likes/page.tsx
+++ b/src/app/(common)/mypage/likes/page.tsx
@@ -88,7 +88,7 @@ export default function LikesPage() {
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >
-          <ArrowLeftIcon className="text-black" />
+          <ArrowLeftIcon className="size-6" />
         </button>
         <h1 className="text-head-4-medium text-center text-black">찜</h1>
         {/* 균형을 위한 빈 공간 */}

--- a/src/app/(common)/mypage/notification-settings/page.tsx
+++ b/src/app/(common)/mypage/notification-settings/page.tsx
@@ -151,7 +151,7 @@ export default function NotificationSettingsPage() {
             className="flex size-6 cursor-pointer items-center justify-center"
             aria-label="뒤로가기"
           >
-            <ArrowLeftIcon className="text-black" />
+            <ArrowLeftIcon className="size-6" />
           </button>
           <h1 className="text-head-4-medium text-center text-black">알림 설정</h1>
           <div className="size-6" />
@@ -176,7 +176,7 @@ export default function NotificationSettingsPage() {
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >
-          <ArrowLeftIcon className="text-black" />
+          <ArrowLeftIcon className="size-6" />
         </button>
         <h1 className="text-head-4-medium text-center text-black">알림 설정</h1>
         <div className="size-6" />

--- a/src/app/(common)/mypage/profile/edit/page.tsx
+++ b/src/app/(common)/mypage/profile/edit/page.tsx
@@ -52,7 +52,7 @@ export default function ProfileEditPage() {
           onClick={() => router.push('/mypage')}
           className="flex size-6 cursor-pointer items-center justify-center"
         >
-          <ArrowLeftIcon className="text-black" />
+          <ArrowLeftIcon className="size-6" />
         </button>
         <h1 className="text-head-4-medium text-black">프로필 수정</h1>
         {/* 균형을 위한 빈 공간 */}

--- a/src/app/(common)/mypage/reservations/page.tsx
+++ b/src/app/(common)/mypage/reservations/page.tsx
@@ -145,7 +145,7 @@ export default function MyReservationsPage() {
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >
-          <ArrowLeftIcon className="text-black" />
+          <ArrowLeftIcon className="size-6" />
         </button>
         <h1 className="text-head-4-medium text-center text-black">예약 목록</h1>
         {/* 균형을 위한 빈 공간 */}

--- a/src/app/(common)/mypage/reviews/_components/DesignerReviewsPage.tsx
+++ b/src/app/(common)/mypage/reviews/_components/DesignerReviewsPage.tsx
@@ -97,7 +97,7 @@ export default function DesignerReviewsPage() {
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >
-          <ArrowLeftIcon className="text-black" />
+          <ArrowLeftIcon className="size-6" />
         </button>
         <h1 className="text-head-4-medium text-center text-black">리뷰 관리</h1>
         <div className="size-6" />

--- a/src/app/(common)/mypage/reviews/_components/ModelReviewsPage.tsx
+++ b/src/app/(common)/mypage/reviews/_components/ModelReviewsPage.tsx
@@ -87,7 +87,7 @@ export default function ModelReviewsPage() {
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >
-          <ArrowLeftIcon className="text-black" />
+          <ArrowLeftIcon className="size-6" />
         </button>
         <h1 className="text-head-4-medium text-center text-black">나의 리뷰</h1>
         <div className="size-6" />

--- a/src/components/chat/chatroom/ChatHeader.tsx
+++ b/src/components/chat/chatroom/ChatHeader.tsx
@@ -25,7 +25,7 @@ export default function ChatHeader({
   const canShowReservation = showReservation && !!onReservationClick;
 
   return (
-    <header className="safe-area-top relative flex h-13 items-center px-4 py-3">
+    <header className="relative flex min-h-13 items-center bg-white px-4 pt-[calc(env(safe-area-inset-top)+12px)] pb-3">
       <button
         type="button"
         onClick={() => router.push('/chat')}

--- a/src/components/chat/chatroom/ChatHeader.tsx
+++ b/src/components/chat/chatroom/ChatHeader.tsx
@@ -25,7 +25,7 @@ export default function ChatHeader({
   const canShowReservation = showReservation && !!onReservationClick;
 
   return (
-    <header className="relative flex min-h-13 items-center bg-white px-4 pt-[calc(env(safe-area-inset-top)+12px)] pb-3">
+    <header className="relative flex min-h-13 items-center px-4 pt-[calc(env(safe-area-inset-top)+12px)] pb-3">
       <button
         type="button"
         onClick={() => router.push('/chat')}

--- a/src/components/chat/chatroom/ChatInput.tsx
+++ b/src/components/chat/chatroom/ChatInput.tsx
@@ -37,7 +37,7 @@ export default function ChatInput({
   };
 
   return (
-    <div className="bg-transparent px-4 py-3">
+    <div className="bg-transparent px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
       <div className="flex items-center gap-2">
         <button
           type="button"


### PR DESCRIPTION
### 💡 To Reviewers

- 이전 PR과는 다르게 soft하게 변경하였습니다.
- 1. 마이페이지 하위 페이지들에서 뒤로가기 버튼이 나오지 않는 문제
- 2. iOS Safari, iOS PWA 앱에서만 채팅방 헤더, input 창이 스크롤 되어야 보이는 문제를 해결했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

## 이슈 1: 마이페이지 하위페이지 뒤로가기 버튼 미표시
### 증상: iOS PWA에서만 뒤로가기 아이콘이 보이지 않음 (클릭은 됨)

### 원인: ArrowLeftIcon에 크기 클래스가 누락되어 SVGR 컴포넌트가 0x0으로 렌더링됨

### 해결:


```
// Before
<ArrowLeftIcon className="text-black" />

// After
<ArrowLeftIcon className="size-6" />
수정 파일 (6개):

likes/page.tsx
reservations/page.tsx
profile/edit/page.tsx
notification-settings/page.tsx
reviews/_components/ModelReviewsPage.tsx
reviews/_components/DesignerReviewsPage.tsx
```

## 이슈 2: 채팅방 헤더/입력창 스크롤 문제
### 증상: iOS에서 페이지 전체가 스크롤되어 헤더와 입력창이 화면 밖으로 밀림 + 스크롤 체이닝 현상

### 원인: Root layout의 min-h-screen wrapper로 인해 body 레벨 스크롤 발생

### 해결:


```
// Before
<div className="relative flex h-screen h-dvh flex-col overflow-hidden ...">

// After
<div className="fixed inset-0 flex flex-col overflow-hidden ...">
fixed inset-0으로 뷰포트에 완전 고정 → body 스크롤 완전 차단

추가 수정:

ChatHeader: pt-[calc(env(safe-area-inset-top)+12px)] 적용
ChatInput: pb-[calc(12px+env(safe-area-inset-bottom))] 적용
예약카드: pt-[calc(env(safe-area-inset-top)+15.5px)] 적용
```

```
overscroll-y-contain 추가 - 내부 스크롤이 끝나도 부모로 전파 방지

<main className="... overscroll-y-contain ...">
body 스크롤 잠금 useEffect 추가

useEffect(() => {
  const originalStyle = document.body.style.overflow;
  document.body.style.overflow = 'hidden';
  return () => {
    document.body.style.overflow = originalStyle;
  };
}, []);
```

### 🤔 추후 작업 예정

- (common) 폴더에 속하는 page를 layout아래 두려고 했는데, 추후에 작업하는게 좋을듯 합니다.
- vercel preview를 통한 ui 반영 사항을 확인하여야 합니다.

### 📸 작업 결과 (스크린샷)

- vercel preview를  통한 ui 반영 확인

### 🔗 관련 이슈

- #106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * 채팅 화면에 iOS용 바디 스크롤 잠금 적용으로 모달/채팅에서 스크롤 충돌 완화
  * 채팅 룸 레이아웃을 전체 고정(inset-0) 및 오버플로우 관리로 표시 안정성 향상(overscroll-y-contain 포함)
  * 헤더·입력 필드의 상하 패딩을 기기 안전 영역(env(safe-area-inset-*))을 반영해 동적으로 조정
  * 여러 페이지의 뒤로가기 아이콘 스타일을 통일하여 UI 일관성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->