### PR TITLE
[FIX] 찜한 공고/디자이너 목록 API 수정

### DIFF
--- a/src/components/mypage/likes/Designer/LikedDesignerCard.tsx
+++ b/src/components/mypage/likes/Designer/LikedDesignerCard.tsx
@@ -7,6 +7,7 @@ import { formatDistrict } from '@/src/utils/common';
 import { useToggleDesignerLike } from '@/src/hooks/queries/likes';
 import LocationIcon from '@/public/icons/explore/location.svg';
 import ProfileIcon from '@/public/icons/myRecruitment/mypage-active.svg';
+import StarIcon from '@/public/icons/common/star.svg';
 
 interface LikedDesignerCardProps {
   designer: LikedDesignerItem;
@@ -56,6 +57,16 @@ export default function LikedDesignerCard({ designer }: LikedDesignerCardProps) 
               <span>·</span>
               <span className="truncate">{designer.shopName}</span>
             </div>
+
+            {/* 별점 */}
+            {designer.averageRating != null && (
+              <div className="flex items-center gap-1">
+                <StarIcon className="size-3.5 text-star" />
+                <span className="text-caption-1-medium text-gray-800">
+                  {designer.averageRating.toFixed(1)} ({designer.reviewCount?.toLocaleString() ?? 0})
+                </span>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/mypage/likes/Recruitment/LikedRecruitmentCard.tsx
+++ b/src/components/mypage/likes/Recruitment/LikedRecruitmentCard.tsx
@@ -3,11 +3,9 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import type { LikedRecruitmentItem } from '@/src/types';
-import { useRecruitmentDetail } from '@/src/hooks/queries/explore/useRecruitmentDetail';
 import { useToggleRecruitmentLike } from '@/src/hooks/queries/likes';
 import { formatDistrict } from '@/src/utils/common';
 import CategoryBadge from '@/src/components/common/CategoryBadge';
-import { Skeleton } from '@/src/components/common/Skeleton';
 import LocationIcon from '@/public/icons/explore/location.svg';
 import StarIcon from '@/public/icons/common/star.svg';
 
@@ -22,12 +20,6 @@ export default function LikedRecruitmentCard({
 }: LikedRecruitmentCardProps) {
   const { mutate: toggleLike, isPending } = useToggleRecruitmentLike();
 
-  // 공고 상세 정보 조회
-  const { data: detailResponse, isLoading: isDetailLoading } = useRecruitmentDetail(
-    recruitment.recruitmentId
-  );
-  const detail = detailResponse?.result;
-
   const handleLikeClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -36,17 +28,14 @@ export default function LikedRecruitmentCard({
     }
   };
 
-  // 썸네일 (찜 목록 API 또는 상세 API에서)
-  const thumbnailSrc = recruitment.thumbnail || detail?.imageUrls?.[0];
-
   return (
     <Link href={`/post/${recruitment.recruitmentId}`} className="flex flex-col gap-2.5">
       {/* 이미지 */}
       <div className="relative h-[210px] w-full overflow-hidden bg-gray-200">
-        {thumbnailSrc ? (
+        {recruitment.recruitmentThumbnail ? (
           <Image
-            src={thumbnailSrc}
-            alt={detail?.title ?? '공고 이미지'}
+            src={recruitment.recruitmentThumbnail}
+            alt={recruitment.title}
             fill
             sizes="50vw"
             className="object-cover"
@@ -75,57 +64,40 @@ export default function LikedRecruitmentCard({
 
       {/* 정보 */}
       <div className={`flex flex-col gap-2 ${isLeftColumn ? 'pr-[9px] pl-4' : 'pr-4 pl-[10px]'}`}>
-        {isDetailLoading ? (
-          // 로딩 상태
-          <div className="flex flex-col gap-1">
-            <Skeleton className="h-5 w-3/4" />
-            <div className="flex flex-col gap-0.5">
-              <Skeleton className="h-4 w-2/3" />
-              <Skeleton className="h-4 w-1/2" />
+        <div className="flex flex-col gap-1">
+          {/* 제목 */}
+          <h3 className="text-body-1-semibold truncate text-black">{recruitment.title}</h3>
+
+          {/* 디자이너 정보 */}
+          <div className="flex flex-col gap-0.5">
+            <p className="text-caption-1-medium text-gray-800">
+              {recruitment.designerName} · {recruitment.shop}
+            </p>
+
+            {/* 위치 */}
+            <div className="flex items-center gap-1 px-px">
+              <LocationIcon className="shrink-0" />
+              <span className="text-caption-1-medium text-gray-800">
+                {formatDistrict(recruitment.shopAddress)}
+              </span>
             </div>
-          </div>
-        ) : detail ? (
-          // 상세 정보 표시
-          <div className="flex flex-col gap-1">
-            {/* 제목 */}
-            <h3 className="text-body-1-semibold truncate text-black">{detail.title}</h3>
 
-            {/* 디자이너 정보 */}
-            <div className="flex flex-col gap-0.5">
-              <p className="text-caption-1-medium text-gray-800">
-                {detail.designerProfile.designerName} · {detail.designerProfile.shop}
-              </p>
-
-              {/* 위치 */}
-              <div className="flex items-center gap-1 px-px">
-                <LocationIcon className="shrink-0" />
+            {/* 별점 */}
+            {recruitment.averageRating != null && (
+              <div className="flex items-center gap-1">
+                <StarIcon className="size-3.5 text-star" />
                 <span className="text-caption-1-medium text-gray-800">
-                  {formatDistrict(detail.designerProfile.shopAddress)}
+                  {recruitment.averageRating.toFixed(1)} ({recruitment.reviewCount?.toLocaleString() ?? 0})
                 </span>
               </div>
-
-              {/* 별점 */}
-              {detail.averageRating != null && (
-                <div className="flex items-center gap-1">
-                  <StarIcon className="size-3.5 text-star" />
-                  <span className="text-caption-1-medium text-gray-800">
-                    {detail.averageRating.toFixed(1)} ({detail.reviewCount?.toLocaleString() ?? 0})
-                  </span>
-                </div>
-              )}
-            </div>
+            )}
           </div>
-        ) : (
-          // 정보 없음
-          <div className="flex flex-col gap-1">
-            <span className="text-caption-1-medium text-gray-500">정보를 불러올 수 없습니다</span>
-          </div>
-        )}
+        </div>
 
         {/* 서비스 태그 */}
-        {detail?.subCategories && detail.subCategories.length > 0 && (
+        {recruitment.subCategories && recruitment.subCategories.length > 0 && (
           <div className="flex flex-wrap gap-1">
-            {detail.subCategories.slice(0, 2).map((subCategory) => (
+            {recruitment.subCategories.slice(0, 2).map((subCategory) => (
               <CategoryBadge key={subCategory} category={subCategory} />
             ))}
           </div>

--- a/src/types/likes/likes.ts
+++ b/src/types/likes/likes.ts
@@ -11,16 +11,28 @@ export interface LikedDesignerItem {
   designerId: number;
   designerName: string;
   designerProfileImage?: string;
-  designerCategory: string; // "헤어", "네일" 등 한글
+  designerCategory: Category;
   shopName: string;
   shopAddress: string;
+  reviewCount: number;
+  averageRating: number;
 }
 
 // ===== 찜한 공고 아이템 =====
 export interface LikedRecruitmentItem {
   recruitmentLikeId: number;
   recruitmentId: number;
-  thumbnail?: string;
+  title: string;
+  designerImage?: string;
+  designerName: string;
+  recruitmentThumbnail?: string;
+  shop: string;
+  shopAddress: string;
+  category: Category;
+  subCategories: string[];
+  reviewCount: number;
+  averageRating: number;
+  createdAt: string;
 }
 
 // ===== 찜 목록 조회 파라미터 =====
@@ -35,10 +47,12 @@ export interface LikedDesignersResponse {
   items: LikedDesignerItem[];
   hasNext: boolean;
   nextCursor: number | null;
+  totalCount: number;
 }
 
 export interface LikedRecruitmentsResponse {
   items: LikedRecruitmentItem[];
   hasNext: boolean;
   nextCursor: number | null;
+  totalCount: number;
 }

--- a/src/types/likes/likes.ts
+++ b/src/types/likes/likes.ts
@@ -14,8 +14,8 @@ export interface LikedDesignerItem {
   designerCategory: Category;
   shopName: string;
   shopAddress: string;
-  reviewCount: number;
-  averageRating: number;
+  reviewCount?: number;
+  averageRating?: number;
 }
 
 // ===== 찜한 공고 아이템 =====
@@ -30,8 +30,8 @@ export interface LikedRecruitmentItem {
   shopAddress: string;
   category: Category;
   subCategories: string[];
-  reviewCount: number;
-  averageRating: number;
+  reviewCount?: number;
+  averageRating?: number;
   createdAt: string;
 }
 


### PR DESCRIPTION
### 💡 To Reviewers

- 찜한 공고/디자이너 목록 API에서 이미 필요한 데이터를 모두 반환하므로, 타입을 확장하여 추가 API 호출 없이 데이터를 직접 사용하도록 변경했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- **중복 API 호출 문제 해결**
  - 기존: 찜 목록 1회 + 각 카드별 상세 조회 N회 
  - 변경: 찜 목록 1회만 호출

- **타입 확장** (`src/types/likes/likes.ts`)
  - `LikedRecruitmentItem`: title, designerName, shop, shopAddress, category, subCategories, reviewCount, averageRating, createdAt 추가
  - `LikedDesignerItem`: reviewCount, averageRating 추가, designerCategory 타입을 string → Category로 변경
  - Response 타입에 totalCount 추가

- **LikedRecruitmentCard 리팩토링** (`src/components/mypage/likes/Recruitment/LikedRecruitmentCard.tsx`)
  - `useRecruitmentDetail` 훅 제거
  - API 응답 데이터 직접 사용

- **LikedDesignerCard UI 개선** (`src/components/mypage/likes/Designer/LikedDesignerCard.tsx`)
  - 별점/리뷰 수 표시 추가 (⭐ 4.9 (128) 형식)

### 🤔 추후 작업 예정

- 거리 표시는 백엔드와 합의 후 하지 않기로 했습니다.

### 📸 작업 결과 (스크린샷)

<img width="430" height="908" alt="image" src="https://github.com/user-attachments/assets/37284e6a-b4ec-41c8-ad14-e543bb5633f2" />

<img width="426" height="907" alt="image" src="https://github.com/user-attachments/assets/33061dfe-c681-496a-929d-ab37f68036a9" />


### 🔗 관련 이슈

- #108


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 찜한 디자이너 카드에 평점(소수 첫째자리) 및 리뷰 수 표시 추가

* **개선 사항**
  * 찜한 채용공고 카드의 데이터 표시 로직 단순화로 로딩 스켈레톤 제거 및 썸네일 처리 일원화
  * 찜 목록 응답에 총계 필드 추가로 페이지 내 전체 개수 표시 가능해짐

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->