### PR TITLE
[FIX] 무한스크롤 totalCount 필드 반영 

### DIFF
--- a/src/apis/designer/recruitments.ts
+++ b/src/apis/designer/recruitments.ts
@@ -172,6 +172,7 @@ function getMockDesignerRecruitments(
       items,
       hasNext,
       nextCursor,
+      totalCount: filteredItems.length,
     },
   });
 }

--- a/src/apis/explore/designers.ts
+++ b/src/apis/explore/designers.ts
@@ -76,6 +76,7 @@ function getMockDesigners(
       items,
       hasNext,
       nextCursor,
+      totalCount: filtered.length,
     },
   });
 }

--- a/src/apis/explore/recruitments.ts
+++ b/src/apis/explore/recruitments.ts
@@ -122,6 +122,7 @@ function getMockRecruitments(
       items,
       hasNext,
       nextCursor,
+      totalCount: filtered.length,
     },
   });
 }

--- a/src/app/(common)/mypage/reviews/_components/DesignerReviewsPage.tsx
+++ b/src/app/(common)/mypage/reviews/_components/DesignerReviewsPage.tsx
@@ -34,8 +34,8 @@ export default function DesignerReviewsPage() {
     return designerReviewsQuery.data?.pages.flatMap((page) => page.result?.items ?? []) ?? [];
   }, [designerReviewsQuery.data?.pages]);
 
-  // 전체 개수
-  const totalCount = reviews.length;
+  // 전체 개수 (API 응답의 totalCount 사용)
+  const totalCount = designerReviewsQuery.data?.pages[0]?.result?.totalCount ?? 0;
 
   // 답글 달기 클릭
   const handleReplyClick = (reviewId: number) => {

--- a/src/app/(common)/mypage/reviews/_components/ModelReviewsPage.tsx
+++ b/src/app/(common)/mypage/reviews/_components/ModelReviewsPage.tsx
@@ -54,16 +54,17 @@ export default function ModelReviewsPage() {
     return unreviewedQuery.data?.pages.flatMap((page) => page.result?.items ?? []) ?? [];
   }, [unreviewedQuery.data?.pages]);
 
-  // 리뷰 미작성 개수
-  const unreviewedCount = unreviewedReservations.length;
+  // 리뷰 미작성 개수 (API 응답의 totalCount 사용)
+  const unreviewedCount = unreviewedQuery.data?.pages[0]?.result?.totalCount ?? 0;
 
   // 작성한 리뷰 목록 데이터 가공
   const writtenReviews = useMemo(() => {
     return writtenQuery.data?.pages.flatMap((page) => page.result?.items ?? []) ?? [];
   }, [writtenQuery.data?.pages]);
 
-  // 현재 탭에 따른 총 개수
-  const totalCount = activeTab === 'unreviewed' ? unreviewedCount : writtenReviews.length;
+  // 현재 탭에 따른 총 개수 (API 응답의 totalCount 사용)
+  const writtenCount = writtenQuery.data?.pages[0]?.result?.totalCount ?? 0;
+  const totalCount = activeTab === 'unreviewed' ? unreviewedCount : writtenCount;
 
   // 리뷰 수정 핸들러
   const handleEditReview = (reviewId: number) => {

--- a/src/app/(designer)/myRecruitment/page.tsx
+++ b/src/app/(designer)/myRecruitment/page.tsx
@@ -77,6 +77,10 @@ export default function MyRecruitmentPage() {
     });
   }, [closedData]);
 
+  // totalCount 추출 (첫 페이지에서 가져옴)
+  const activeTotalCount = activeData?.pages[0]?.result?.totalCount ?? 0;
+  const closedTotalCount = closedData?.pages[0]?.result?.totalCount ?? 0;
+
   // 카드 클릭 핸들러
   const handleCardClick = (id: number) => {
     router.push(`/myRecruitment/${id}`);
@@ -110,7 +114,7 @@ export default function MyRecruitmentPage() {
       <RecruitmentTabs
         activeTab={activeTab}
         onTabChange={setActiveTab}
-        activeCount={activeRecruitments.length}
+        activeCount={activeTotalCount}
       />
 
       {/* 모집중 탭 */}
@@ -151,7 +155,7 @@ export default function MyRecruitmentPage() {
         ) : (
           <ClosedRecruitmentList
             recruitments={closedRecruitments}
-            totalCount={closedRecruitments.length}
+            totalCount={closedTotalCount}
             onClick={handleCardClick}
             onLoadMore={fetchClosedNextPage}
             hasMore={hasClosedNextPage}

--- a/src/components/explore/ExploreContent.tsx
+++ b/src/components/explore/ExploreContent.tsx
@@ -28,6 +28,8 @@ export default function ExploreContent() {
   const {
     recruitments,
     designers,
+    recruitmentTotalCount,
+    designerTotalCount,
     isLoading,
     isFetchingNext,
     infiniteScrollProps,
@@ -46,8 +48,8 @@ export default function ExploreContent() {
   // Infinite scroll
   const { loadMoreRef } = useInfiniteScroll(infiniteScrollProps);
 
-  // Total count
-  const totalCount = filters.view === 'recruitment' ? recruitments.length : designers.length;
+  // Total count (API 응답의 totalCount 사용)
+  const totalCount = filters.view === 'recruitment' ? recruitmentTotalCount : designerTotalCount;
 
   return (
     <div className="flex min-h-screen flex-col bg-white">

--- a/src/hooks/custom/explore/useExploreData.ts
+++ b/src/hooks/custom/explore/useExploreData.ts
@@ -71,6 +71,10 @@ export function useExploreData({
     });
   }, [designerData]);
 
+  // totalCount 추출 (첫 페이지에서 가져옴)
+  const recruitmentTotalCount = recruitmentData?.pages[0]?.result?.totalCount ?? 0;
+  const designerTotalCount = designerData?.pages[0]?.result?.totalCount ?? 0;
+
   // Loading states
   const isWaitingForLocation = needsLocation && !hasLocation && isLocationLoading;
   const isLoading = isWaitingForLocation || (view === 'recruitment' ? isLoadingRecruitments : isLoadingDesigners);
@@ -86,6 +90,8 @@ export function useExploreData({
   return {
     recruitments,
     designers,
+    recruitmentTotalCount,
+    designerTotalCount,
     isLoading,
     isFetchingNext,
     infiniteScrollProps,

--- a/src/mocks/explore/designers.ts
+++ b/src/mocks/explore/designers.ts
@@ -115,6 +115,7 @@ export const mockDesignerListResponse: DesignerListResponse = {
   items: mockDesignerItems.slice(0, 6),
   hasNext: true,
   nextCursor: 6,
+  totalCount: mockDesignerItems.length,
 };
 
 // Mock 디자이너 리스트 응답 (두 번째 페이지)
@@ -122,4 +123,5 @@ export const mockDesignerListResponse2: DesignerListResponse = {
   items: mockDesignerItems.slice(6, 8),
   hasNext: false,
   nextCursor: 8,
+  totalCount: mockDesignerItems.length,
 };

--- a/src/mocks/explore/recruitments.ts
+++ b/src/mocks/explore/recruitments.ts
@@ -238,6 +238,7 @@ export const mockRecruitmentListResponse: RecruitmentListResponse = {
   items: mockRecruitmentItems.slice(0, 6),
   hasNext: true,
   nextCursor: 6,
+  totalCount: mockRecruitmentItems.length,
 };
 
 // Mock 공고 리스트 응답 (두 번째 페이지)
@@ -245,4 +246,5 @@ export const mockRecruitmentListResponse2: RecruitmentListResponse = {
   items: mockRecruitmentItems.slice(6, 8),
   hasNext: false,
   nextCursor: 8,
+  totalCount: mockRecruitmentItems.length,
 };

--- a/src/types/myRecruitment/recruitment.ts
+++ b/src/types/myRecruitment/recruitment.ts
@@ -54,6 +54,7 @@ export interface MyRecruitmentListResponse {
   items: MyRecruitmentListItem[];
   hasNext: boolean;
   nextCursor: number;
+  totalCount: number;
 }
 
 // ===== 공고 생성/수정 =====

--- a/src/types/recruitment/recruitment.ts
+++ b/src/types/recruitment/recruitment.ts
@@ -57,6 +57,7 @@ export interface CursorPaginationResponse<T> {
   items: T[];
   hasNext: boolean;
   nextCursor: number;
+  totalCount: number;
 }
 
 // ===== 공고 리스트 응답 =====

--- a/src/types/review/designer.ts
+++ b/src/types/review/designer.ts
@@ -27,6 +27,7 @@ export interface DesignerReviewsResponse {
   items: DesignerReviewItem[];
   hasNext: boolean;
   nextCursor?: number | null;
+  totalCount: number;
 }
 
 // ===== 답글 작성 요청 =====

--- a/src/types/review/model.ts
+++ b/src/types/review/model.ts
@@ -56,6 +56,7 @@ export interface WrittenReviewsResponse {
   items: WrittenReviewItem[];
   hasNext: boolean;
   nextCursor: number | null;
+  totalCount: number;
 }
 
 // ===== 리뷰 작성 요청 =====


### PR DESCRIPTION
### 💡 To Reviewers

- 백엔드 API 응답에 추가된 `totalCount` 필드를 프론트엔드에서 활용하도록 수정.
- 무한스크롤로 로드된 배열의 `.length`를 사용하여 전체 개수를 표시 ->  API 응답의 `totalCount`를 사용

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

**타입 정의 수정 (4개 파일)**
- `CursorPaginationResponse<T>`에 `totalCount` 필드 추가
- `DesignerReviewsResponse`에 `totalCount` 필드 추가
- `WrittenReviewsResponse`에 `totalCount` 필드 추가
- `MyRecruitmentListResponse`에 `totalCount` 필드 추가

**탐색 페이지 (Explore)**
- `useExploreData` 훅에서 `recruitmentTotalCount`, `designerTotalCount` 추출 및 반환
- `ExploreContent`에서 배열 길이 대신 API `totalCount` 사용

**디자이너 리뷰 관리 페이지**
- `DesignerReviewsPage`에서 `reviews.length` 대신 API `totalCount` 사용

**모델 나의 리뷰 페이지**
- `ModelReviewsPage`에서 `unreviewedReservations.length`, `writtenReviews.length` 대신 API `totalCount` 사용

**내 공고 페이지 (디자이너)**
- `myRecruitment/page.tsx`에서 모집중/마감 공고 개수를 API `totalCount`로 변경

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 무한스크롤 시 전체 개수가 변하지 않고 API 응답값으로 고정됨

### 🔗 관련 이슈

- #97


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 디자이너 리뷰, 모델 리뷰, 내 채용공고, 탐색 페이지의 항목 개수를 로컬 계산에서 API가 제공하는 totalCount로 변경해 UI 총계가 더 정확해졌습니다.
  * 무한 스크롤·페이징 동작에는 영향이 없습니다.

* **문서·API 노출**
  * 목록 응답 및 탐색 훅의 반환값에 totalCount가 포함되어 UI에서 전체 개수 표시가 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->