### PR TITLE
[FIX] 채팅방 페이지 데스크톱 너비 375px 제한 적용

### DIFF
--- a/src/app/(common)/chat/[roomId]/page.tsx
+++ b/src/app/(common)/chat/[roomId]/page.tsx
@@ -209,7 +209,7 @@ export default function ChatRoom() {
   };
 
   return (
-    <div className="fixed inset-0 flex flex-col overflow-hidden bg-gray-200">
+    <div className="fixed inset-0 mx-auto flex w-full min-w-[375px] flex-col overflow-hidden bg-gray-200 sm:w-[375px]">
       {isReservationOpen && (
         <div className="absolute inset-x-0 top-0 z-20 rounded-b-[20px] bg-white pt-[calc(env(safe-area-inset-top)+15.5px)] pb-5">
           <div className="flex justify-end px-4 pb-[15.5px]">


### PR DESCRIPTION
### 💡 To Reviewers

- 채팅방 페이지 데스크톱 너비 375px 제한 적용했습니다
- (common) 라우트 경로에도 추후 layout.tsx가 필요합니다. 다만 현재는 제외하고 개별 적용하겠습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

## 문제 상황
- `fixed inset-0`은 viewport 기준이므로 레이아웃의 375px 제한을 무시하고 화면 전체를 차지함.

## 해결
- sm:w-[375px] 
- mx-auto 
- min-w-[375px]
해당 클래스 추가

### 🤔 추후 작업 예정

없음

### 📸 작업 결과 (스크린샷)

<img width="435" height="905" alt="image" src="https://github.com/user-attachments/assets/f928be87-2b91-42bb-8eaa-2375a5377cf1" />

### 🔗 관련 이슈

- #111 
