### PR TITLE
[FIX] 공고 이미지 수정 오류 수정

### DIFF
--- a/src/app/(designer)/myRecruitment/page.tsx
+++ b/src/app/(designer)/myRecruitment/page.tsx
@@ -35,6 +35,8 @@ export default function MyRecruitmentPage() {
     status: 'OPEN',
     month: monthString,
     enabled: activeTab === 'active',
+    retry: 2,
+    retryDelay: 3000, // 3초 간격으로 재시도
   });
 
   // API Hooks - 마감 공고
@@ -49,6 +51,8 @@ export default function MyRecruitmentPage() {
     status: 'CLOSED',
     month: monthString, // 임시: 백엔드에서 month 필수로 요구
     enabled: activeTab === 'closed',
+    retry: 2,
+    retryDelay: 3000, // 3초 간격으로 재시도
   });
 
   const { mutate: deleteRecruitment, isPending: isDeleting } = useDeleteRecruitment();

--- a/src/app/(designer)/myRecruitment/page.tsx
+++ b/src/app/(designer)/myRecruitment/page.tsx
@@ -36,7 +36,7 @@ export default function MyRecruitmentPage() {
     month: monthString,
     enabled: activeTab === 'active',
     retry: 2,
-    retryDelay: 3000, // 3초 간격으로 재시도
+    retryDelay: 4000, // 4초 간격으로 재시도
   });
 
   // API Hooks - 마감 공고

--- a/src/components/post/Header/PostHeader.tsx
+++ b/src/components/post/Header/PostHeader.tsx
@@ -14,7 +14,7 @@ export default function PostHeader({ onBack }: PostHeaderProps) {
     if (onBack) {
       onBack();
     } else {
-      router.push('/explore');
+      router.push('/myRecruitment');
     }
   };
 

--- a/src/hooks/custom/myRecruitment/useCreateRecruitmentSubmit.ts
+++ b/src/hooks/custom/myRecruitment/useCreateRecruitmentSubmit.ts
@@ -35,9 +35,15 @@ export function useCreateRecruitmentSubmit() {
 
       // 3. API 호출
       createRecruitment(request, {
-        onSuccess: () => {
+        onSuccess: (response) => {
           reset();
-          router.push('/myRecruitment');
+          // 상세 페이지로 이동 (썸네일 생성 지연 대응 + 생성 결과 확인)
+          const newRecruitmentId = response.result?.recruitmentId;
+          if (newRecruitmentId) {
+            router.push(`/myRecruitment/${newRecruitmentId}`);
+          } else {
+            router.push('/myRecruitment');
+          }
         },
         onError: () => {
           setIsSubmitting(false);

--- a/src/hooks/custom/myRecruitment/useImagePreview.ts
+++ b/src/hooks/custom/myRecruitment/useImagePreview.ts
@@ -35,13 +35,14 @@ export function useImagePreview({ imageFiles, existingUrls, onUrlsChange }: UseI
       }
     });
 
-    // 새 blob URL 생성
-    const newUrls = imageFiles.map((file) => URL.createObjectURL(file));
-    onUrlsChange(newUrls);
+    // 기존 서버 URL 유지 + 새 blob URL 추가
+    const serverUrls = existingUrls.filter((url) => !url.startsWith('blob:'));
+    const newBlobUrls = imageFiles.map((file) => URL.createObjectURL(file));
+    onUrlsChange([...serverUrls, ...newBlobUrls]);
 
     // cleanup: 컴포넌트 언마운트 시 URL revoke
     return () => {
-      newUrls.forEach((url) => URL.revokeObjectURL(url));
+      newBlobUrls.forEach((url) => URL.revokeObjectURL(url));
     };
     // imageFilesKey를 의존성으로 사용하여 파일 교체도 감지
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/custom/myRecruitment/useUpdateRecruitmentSubmit.ts
+++ b/src/hooks/custom/myRecruitment/useUpdateRecruitmentSubmit.ts
@@ -5,10 +5,11 @@ import { useUpdateRecruitment } from '@/src/hooks/queries/myRecruitment';
 import { uploadRecruitmentImages } from '@/src/apis/designer/recruitments';
 import { transformFormToRequest } from '@/src/utils/myRecruitment';
 import { useToast } from '@/src/hooks/common/useToast';
+import type { ImageUploadResult } from '@/src/types/myRecruitment';
 
 /**
  * 공고 수정 제출 로직을 관리하는 커스텀 훅
- * - 이미지 업로드 (새 이미지가 있는 경우)
+ * - 기존 이미지 URL 유지 + 새 이미지만 업로드
  * - 폼 데이터 변환
  * - 수정 API 호출
  * - 에러 처리
@@ -27,21 +28,37 @@ export function useUpdateRecruitmentSubmit(recruitmentId: number) {
 
     setIsSubmitting(true);
     try {
-      let uploadResult = {
-        thumbnail: formState.thumbnail,
-        imageUrls: formState.imageUrls,
-        imageFolderId: formState.imageFolderId,
-      };
+      // 1. 기존 이미지 URL과 새 이미지 파일 분리
+      const { existingUrls, newFiles } = separateImages(
+        formState.imagePreviewUrls,
+        formState.imageFiles
+      );
 
-      // 새 이미지 파일이 있으면 업로드
-      if (formState.imageFiles.length > 0) {
-        uploadResult = await uploadRecruitmentImages(formState.imageFiles);
+      let uploadResult: ImageUploadResult;
+
+      if (newFiles.length > 0) {
+        // 2. 새 이미지가 있으면 업로드
+        const newUpload = await uploadRecruitmentImages(newFiles);
+
+        // 3. 기존 URL + 새 URL 합치기
+        uploadResult = {
+          thumbnail: existingUrls[0] || newUpload.thumbnail,
+          imageUrls: [...existingUrls, ...newUpload.imageUrls],
+          imageFolderId: newUpload.imageFolderId,
+        };
+      } else {
+        // 4. 이미지 변경 없음 → 기존 URL 유지
+        uploadResult = {
+          thumbnail: existingUrls[0] || formState.thumbnail,
+          imageUrls: existingUrls,
+          imageFolderId: '', // 백엔드가 정상 처리 (API 테스트 확인됨)
+        };
       }
 
-      // 폼 데이터 -> API Request 변환
+      // 5. 폼 데이터 -> API Request 변환
       const request = transformFormToRequest(formState, uploadResult);
 
-      // 수정 API 호출
+      // 6. 수정 API 호출
       updateRecruitment(
         { recruitmentId, request },
         {
@@ -65,4 +82,37 @@ export function useUpdateRecruitmentSubmit(recruitmentId: number) {
     handleSubmit,
     reset,
   };
+}
+
+/**
+ * imagePreviewUrls에서 기존 URL과 새 파일 분리
+ * - https:// 또는 http:// URL → 기존 이미지 (서버에 이미 있음)
+ * - blob: URL → 새 이미지 (업로드 필요)
+ *
+ * @param previewUrls - 미리보기 URL 배열 (기존 https + 새 blob 혼합)
+ * @param imageFiles - 새로 추가된 이미지 File 배열 (blob URL과 1:1 매칭)
+ * @returns { existingUrls: 기존 이미지 URL[], newFiles: 업로드할 File[] }
+ */
+function separateImages(
+  previewUrls: string[],
+  imageFiles: File[]
+): { existingUrls: string[]; newFiles: File[] } {
+  const existingUrls: string[] = [];
+  const newFiles: File[] = [];
+
+  let blobIndex = 0;
+  for (const url of previewUrls) {
+    if (url.startsWith('blob:')) {
+      // 새 이미지 - File 객체 추가
+      if (blobIndex < imageFiles.length) {
+        newFiles.push(imageFiles[blobIndex]);
+        blobIndex++;
+      }
+    } else {
+      // 기존 이미지 (https://, http://) - URL 유지
+      existingUrls.push(url);
+    }
+  }
+
+  return { existingUrls, newFiles };
 }

--- a/src/hooks/custom/myRecruitment/useUpdateRecruitmentSubmit.ts
+++ b/src/hooks/custom/myRecruitment/useUpdateRecruitmentSubmit.ts
@@ -64,7 +64,8 @@ export function useUpdateRecruitmentSubmit(recruitmentId: number) {
         {
           onSuccess: () => {
             reset();
-            router.push('/myRecruitment');
+            // 상세 페이지로 이동 (백엔드 처리 지연 대응 + 수정 결과 확인)
+            router.push(`/myRecruitment/${recruitmentId}`);
           },
           onError: () => {
             setIsSubmitting(false);

--- a/src/hooks/queries/explore/useRecruitmentDetail.ts
+++ b/src/hooks/queries/explore/useRecruitmentDetail.ts
@@ -5,6 +5,10 @@ import type { RecruitmentDetail, ApiResponse } from '@/src/types';
 
 interface UseRecruitmentDetailOptions {
   enabled?: boolean;
+  /** 재시도 횟수 (기본값: 글로벌 설정 사용) */
+  retry?: number;
+  /** 재시도 간격 ms (기본값: 글로벌 설정 사용) */
+  retryDelay?: number;
 }
 
 /**
@@ -14,12 +18,14 @@ export function useRecruitmentDetail(
   recruitmentId: number,
   options: UseRecruitmentDetailOptions = {}
 ) {
-  const { enabled = true } = options;
+  const { enabled = true, retry, retryDelay } = options;
 
   return useQuery<ApiResponse<RecruitmentDetail>, Error>({
     queryKey: recruitmentKeys.detail(recruitmentId),
     queryFn: () => getRecruitmentDetail(recruitmentId),
     enabled: enabled && recruitmentId > 0,
     staleTime: 1000 * 60 * 5, // 5분
+    ...(retry !== undefined && { retry }),
+    ...(retryDelay !== undefined && { retryDelay }),
   });
 }

--- a/src/hooks/queries/myRecruitment/useDesignerRecruitments.ts
+++ b/src/hooks/queries/myRecruitment/useDesignerRecruitments.ts
@@ -14,6 +14,10 @@ interface UseDesignerRecruitmentsParams {
   month?: string; // OPEN일 때만 필요
   size?: number;
   enabled?: boolean;
+  /** 재시도 횟수 (기본값: 글로벌 설정 사용) */
+  retry?: number;
+  /** 재시도 간격 ms (기본값: 글로벌 설정 사용) */
+  retryDelay?: number;
 }
 
 /**
@@ -21,7 +25,7 @@ interface UseDesignerRecruitmentsParams {
  * useInfiniteQuery를 사용하여 커서 기반 페이징 지원
  */
 export function useDesignerRecruitments(params: UseDesignerRecruitmentsParams) {
-  const { status, month, size = 10, enabled = true } = params;
+  const { status, month, size = 10, enabled = true, retry, retryDelay } = params;
 
   type CursorParam = { cursorId?: number; cursorEarliestDate?: string } | undefined;
 
@@ -66,5 +70,7 @@ export function useDesignerRecruitments(params: UseDesignerRecruitmentsParams) {
     },
     enabled,
     staleTime: 1000 * 60 * 5, // 5분
+    ...(retry !== undefined && { retry }),
+    ...(retryDelay !== undefined && { retryDelay }),
   });
 }

--- a/src/hooks/queries/myRecruitment/useUpdateRecruitment.ts
+++ b/src/hooks/queries/myRecruitment/useUpdateRecruitment.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateRecruitment } from '@/src/apis';
 import { useToast } from '@/src/hooks/common/useToast';
 import { myRecruitmentKeys } from './useDesignerRecruitments';
+import { recruitmentKeys } from '../explore/useRecruitments';
 import type { ApiResponse, UpdateRecruitmentRequest, RecruitmentMutationResponse } from '@/src/types';
 
 interface UpdateRecruitmentParams {
@@ -24,9 +25,13 @@ export function useUpdateRecruitment() {
     mutationFn: ({ recruitmentId, request }: UpdateRecruitmentParams) => {
       return updateRecruitment(recruitmentId, request);
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       // 내 공고 목록 쿼리 갱신
       queryClient.invalidateQueries({ queryKey: myRecruitmentKeys.lists() });
+      // 공고 상세 쿼리 갱신
+      queryClient.invalidateQueries({
+        queryKey: recruitmentKeys.detail(variables.recruitmentId),
+      });
       showToast('공고가 수정되었습니다.');
     },
     onError: () => {

--- a/src/stores/myRecruitment/useRecruitmentFormStore.ts
+++ b/src/stores/myRecruitment/useRecruitmentFormStore.ts
@@ -185,10 +185,24 @@ export const useRecruitmentFormStore = create<RecruitmentFormStore>((set) => ({
     })),
 
   removeImageFile: (index) =>
-    set((state) => ({
-      imageFiles: state.imageFiles.filter((_, i) => i !== index),
-      imagePreviewUrls: state.imagePreviewUrls.filter((_, i) => i !== index),
-    })),
+    set((state) => {
+      const urlToRemove = state.imagePreviewUrls[index];
+
+      // blob URL 삭제 시에만 imageFiles에서도 제거
+      let newImageFiles = state.imageFiles;
+      if (urlToRemove?.startsWith('blob:')) {
+        // 해당 index 이전의 blob URL 개수 = imageFiles에서의 실제 인덱스
+        const blobIndexInFiles = state.imagePreviewUrls
+          .slice(0, index)
+          .filter((url) => url.startsWith('blob:')).length;
+        newImageFiles = state.imageFiles.filter((_, i) => i !== blobIndexInFiles);
+      }
+
+      return {
+        imageFiles: newImageFiles,
+        imagePreviewUrls: state.imagePreviewUrls.filter((_, i) => i !== index),
+      };
+    }),
 
   setImagePreviewUrls: (urls) => set({ imagePreviewUrls: urls }),
 

--- a/src/stores/myRecruitment/useRecruitmentFormStore.ts
+++ b/src/stores/myRecruitment/useRecruitmentFormStore.ts
@@ -198,9 +198,16 @@ export const useRecruitmentFormStore = create<RecruitmentFormStore>((set) => ({
         newImageFiles = state.imageFiles.filter((_, i) => i !== blobIndexInFiles);
       }
 
+      // 새 이미지 목록
+      const newPreviewUrls = state.imagePreviewUrls.filter((_, i) => i !== index);
+
+      // 첫 번째 이미지 삭제 시 thumbnail 동기화
+      const newThumbnail = index === 0 ? (newPreviewUrls[0] || '') : state.thumbnail;
+
       return {
         imageFiles: newImageFiles,
-        imagePreviewUrls: state.imagePreviewUrls.filter((_, i) => i !== index),
+        imagePreviewUrls: newPreviewUrls,
+        thumbnail: newThumbnail,
       };
     }),
 


### PR DESCRIPTION
## 💡 To Reviewers

- `imageFolderId: ''` 전송 시 S3 폴더가 삭제되는 문제가 있습니다. `RecruitmentResponseDto`에 `imageFolderId` 필드 추가가 필요합니다.
- 현재는 우회책으로 생성/수정 후 상세 페이지로 이동하여 시간을 확보하는 방식을 적용.
- 공고 수정, 업로드시 내 공고글 상세 페이지로 이동하도록 변경하였습니다.

---

## 🔥 작업 내용

### 1. 공고 수정 시 이미지 처리 로직 수정 (`useUpdateRecruitmentSubmit.ts`)
- 기존 이미지 URL(`https://`)과 새 이미지(`blob:`)를 분리하는 `separateImages` 함수 추가
- 새 이미지만 업로드하고 기존 이미지 URL은 그대로 유지
- 기존 + 새 이미지 조합 가능하도록 개선

### 2. 이미지 미리보기 URL 관리 수정 (`useImagePreview.ts`)
- 기존 서버 URL 유지 + 새 blob URL 추가 방식으로 변경
- 기존 URL이 새 이미지 추가 시 덮어씌워지는 버그 수정

### 3. 이미지 삭제 시 인덱스 매핑 수정 (`useRecruitmentFormStore.ts`)
- `imagePreviewUrls`와 `imageFiles` 배열 간 인덱스 불일치 버그 수정
- blob URL 삭제 시에만 `imageFiles`에서 올바른 인덱스로 삭제
- **첫 번째 이미지 삭제 시 thumbnail 동기화 추가**

### 4. 공고 수정 시 상세 쿼리 무효화 추가 (`useUpdateRecruitment.ts`)
- 수정 후 상세 페이지에서 최신 데이터를 보여주기 위해 `recruitmentKeys.detail` 쿼리 무효화 추가

### 5. myRecruitment 목록 쿼리 재시도 설정 추가
- `useDesignerRecruitments`: `retry: 2`, `retryDelay: 4000`
- `useRecruitmentDetail`: `retry: 2`, `retryDelay: 4000`
- 403 에러 발생 시 재시도하여 사용자 경험 개선

### 6. PostHeader 기본 뒤로가기 경로 변경
- 기본값을 `/myRecruitment`로 변경

### 7. 공고 수정/생성 후 상세 페이지로 이동
- **수정 후**: `/myRecruitment/${recruitmentId}`로 이동
- **생성 후**: `/myRecruitment/${newRecruitmentId}`로 이동
- 썸네일 생성 지연 및 S3 처리 지연으로 인한 403 에러 우회

---

## 🤔 추후 작업 예정

### 더 근본적인 해결 방안
현재 프론트엔드에서 `imageFolderId: ''`를 전송하면 백엔드가 기존 S3 폴더를 삭제합니다.

**해결 방안 (택 1)**:
1. `RecruitmentResponseDto`에 `imageFolderId` 필드 추가
   - 프론트엔드가 기존 folderId를 보존하여 전송 가능
2. 백엔드에서 `imageFolderId: ""`일 때 삭제 로직 스킵
   - 빈 문자열이면 기존 폴더 유지

### 문제 시나리오
```
[기존 상태]
- imageFolderId: "abc-123"
- imageUrls: ["s3://.../abc-123/img1.jpg", "s3://.../abc-123/img2.jpg"]

[사용자 행동]
- 이미지 1개 삭제 (새 이미지 업로드 없음)

[프론트엔드 전송]
- imageFolderId: ""  ← API 응답에 없어서 빈 문자열
- imageUrls: ["s3://.../abc-123/img2.jpg"]

[백엔드 처리]
- "" != "abc-123" → 조건 참 → S3 폴더 삭제!
- imageUrls는 DB에 저장되지만 실제 파일은 삭제됨 → 403 에러
```

---

## 📸 작업 결과 (스크린샷) - 테스트가 필요한 경우의 수 5가지로 대체합니다.

- 이미지 변경 없이 수정 → 기존 이미지 유지
- 기존 이미지 일부 삭제 → 남은 이미지만 저장
- 기존 + 새 이미지 추가 → 합쳐진 이미지 저장
- 전체 교체 → 새 이미지만 저장
- 새 공고 작성 → 정상 동작

---

## 🔗 관련 이슈

- #91

---

## 📁 변경된 파일 (9개)

| 파일 | 변경 내용 |
|------|----------|
| `src/hooks/custom/myRecruitment/useUpdateRecruitmentSubmit.ts` | 이미지 처리 로직 전면 수정 |
| `src/hooks/custom/myRecruitment/useCreateRecruitmentSubmit.ts` | 생성 후 상세 페이지로 이동 |
| `src/hooks/custom/myRecruitment/useImagePreview.ts` | 기존 서버 URL 유지 로직 |
| `src/stores/myRecruitment/useRecruitmentFormStore.ts` | 이미지 삭제 인덱스 매핑 + thumbnail 동기화 |
| `src/hooks/queries/myRecruitment/useUpdateRecruitment.ts` | 상세 쿼리 무효화 추가 |
| `src/hooks/queries/myRecruitment/useDesignerRecruitments.ts` | 재시도 설정 추가 |
| `src/hooks/queries/explore/useRecruitmentDetail.ts` | 재시도 설정 추가 |
| `src/app/(designer)/myRecruitment/page.tsx` | 재시도 옵션 활성화 |
| `src/components/post/Header/PostHeader.tsx` | 기본 뒤로가기 경로 변경 |
