### PR TITLE
[FIX] 공고 상세 뒤로가기 시 디자이너는 myRecruitment, 그 외는 explore로 이동

### DIFF
--- a/src/components/post/Header/PostHeader.tsx
+++ b/src/components/post/Header/PostHeader.tsx
@@ -3,6 +3,8 @@
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
+import { getUserRole } from '@/src/stores/auth/useAuthStore';
+
 interface PostHeaderProps {
   onBack?: () => void;
 }
@@ -14,7 +16,8 @@ export default function PostHeader({ onBack }: PostHeaderProps) {
     if (onBack) {
       onBack();
     } else {
-      router.push('/myRecruitment');
+      const role = getUserRole();
+      router.push(role === 'designer' ? '/myRecruitment' : '/explore');
     }
   };
 


### PR DESCRIPTION
### 💡 To Reviewers

- 기존에 모델/비로그인도 myRecruitment 로 이동하는 버그 수정

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- getUserRole을 통해서 쿠키에 있는 role 읽어와서 desinger 일시, myRecruiment, 그 외는 explore로 이동하게 변경

### 🔗 관련 이슈

- #122 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자 역할에 따라 뒤로 가기 버튼의 이동 경로가 다르게 작동하도록 개선했습니다. 디자이너 사용자는 내 채용 페이지로, 다른 사용자는 탐색 페이지로 이동합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->