### PR TITLE
[FIX] iOS 상태바 themeColor 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 5,
   userScalable: true,
-  themeColor: '#00000000',
+  themeColor: '#ffffff',
   viewportFit: 'cover',
 };
 

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -14,7 +14,7 @@ export default function manifest(): MetadataRoute.Manifest {
     // 배경색 (theme.css의 white)
     background_color: '#ffffff',
     // 테마 컬러 (theme.css의 white)
-    theme_color: '#00000000',
+    theme_color: '#ffffff',
     // PWA 아이콘 설정
     icons: [
       {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,6 +25,11 @@
     font-size: 16px !important;
   }
 
+  /* Windows 스크롤바 레이아웃 시프트 방지 */
+  html {
+    scrollbar-gutter: stable;
+  }
+
   html,
   body {
     width: 100%;
@@ -37,6 +42,8 @@
       'liga' off,
       'clig' off;
     letter-spacing: var(--tracking-tight);
+    /* Mac/모바일 오버스크롤 바운스 방지 */
+    overscroll-behavior: none;
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -18,6 +18,13 @@
 
 /* Base Styles */
 @layer base {
+  /* iOS Safari input 자동 확대 방지 - !important로 유틸리티 클래스 오버라이드 */
+  input,
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+
   html,
   body {
     width: 100%;


### PR DESCRIPTION
### 💡 To Reviewers

**iOS PWA 상태바 스타일**
- `default`: 흰색 배경 + 검정 텍스트
- `black`: 검정 배경 + 검정 텍스트
- `black-translucent`: 투명 (콘텐츠가 상태바 뒤로 감) + 흰색 텍스트

현재 프로젝트는 `black-translucent` 사용 중 (fullscreen 경험 위해).
투명(`#00000000`) themeColor는 iOS에서 검정으로 폴백되는 문제가 있어 흰색으로 변경.

**iOS input 자동 확대**
- iOS Safari는 font-size 16px 미만 input 포커스 시 자동 확대됨
- 기존 input들이 `text-body-2-medium` (14px) 사용 중이라 유틸리티 클래스에 오버라이드됨
- `!important`로 강제 16px 적용하여 해결

### 🔥 작업 내용

- `themeColor` 투명(`#00000000`) → 흰색(`#ffffff`) 변경
- iOS Safari input 포커스 시 자동 확대 방지 (`font-size: 16px !important`)

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과

- iOS 기기에서 테스트 필요

### 🔗 관련 이슈

- #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * iOS Safari 자동 확대 방지 기능 추가
  * 스크롤바 레이아웃 안정성 개선
  * 오버스크롤 바운스 효과 비활성화

* **Chores**
  * 앱 테마 색상을 흰색으로 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->