### PR TITLE
[FIX] 찜 기능 로그인 인증 체크 오류 수정

### DIFF
--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -19,6 +19,7 @@ import type { DesignerReviewSummaryData } from '@/src/components/designerProfile
 import { useRecruitmentDetail } from '@/src/hooks/queries/explore';
 import { useToggleRecruitmentLike } from '@/src/hooks/queries/likes';
 import { useAuthReady } from '@/src/hooks/custom/mypage';
+import { getAccessToken } from '@/src/stores';
 import { useMyDesignerProfile } from '@/src/hooks/queries/profile';
 import {
   useDesignerReviews,
@@ -180,6 +181,11 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
   const isLiked = toggleCount % 2 === 0 ? detail.isLiked : !detail.isLiked;
 
   const handleFavoriteClick = () => {
+    // 비로그인 시: UI 토글 없이 mutation만 호출 (Toast 표시용)
+    if (!getAccessToken()) {
+      toggleLike(recruitmentId);
+      return;
+    }
     setToggleCount((prev) => prev + 1); // Optimistic update
     toggleLike(recruitmentId);
   };

--- a/src/hooks/custom/explore/useLikeToggle.ts
+++ b/src/hooks/custom/explore/useLikeToggle.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { useAuthStore } from '@/src/stores';
+import { getAccessToken } from '@/src/stores';
 
 interface UseLikeToggleOptions {
   serverValue: boolean;
@@ -21,8 +21,6 @@ interface UseLikeToggleReturn {
  * optimistic update와 서버 동기화를 모두 지원
  */
 export function useLikeToggle({ serverValue, onToggle }: UseLikeToggleOptions): UseLikeToggleReturn {
-  const { isAuthenticated } = useAuthStore();
-
   // 토글 카운트: 홀수면 서버 값 반전
   const [toggleCount, setToggleCount] = useState(0);
   const [trackedServerValue, setTrackedServerValue] = useState(serverValue);
@@ -42,7 +40,7 @@ export function useLikeToggle({ serverValue, onToggle }: UseLikeToggleOptions): 
       e.stopPropagation();
 
       // 로그인하지 않은 경우: UI 토글 없이 콜백만 실행 (Toast 표시용)
-      if (!isAuthenticated) {
+      if (!getAccessToken()) {
         onToggle?.();
         return;
       }
@@ -50,7 +48,7 @@ export function useLikeToggle({ serverValue, onToggle }: UseLikeToggleOptions): 
       setToggleCount((prev) => prev + 1);
       onToggle?.();
     },
-    [onToggle, isAuthenticated]
+    [onToggle]
   );
 
   return { isLiked, handleClick };

--- a/src/hooks/queries/likes/useLikes.ts
+++ b/src/hooks/queries/likes/useLikes.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toggleRecruitmentLike, toggleDesignerLike } from '@/src/apis';
-import { useAuthStore } from '@/src/stores';
+import { getAccessToken } from '@/src/stores';
 import { useToast } from '@/src/hooks/common/useToast';
 import { recruitmentKeys } from '../explore/useRecruitments';
 import { designerKeys } from '../explore/useDesigners';
@@ -13,12 +13,11 @@ import type { ApiResponse } from '@/src/types';
  */
 export function useToggleRecruitmentLike() {
   const queryClient = useQueryClient();
-  const { isAuthenticated } = useAuthStore();
   const { showToast } = useToast();
 
   return useMutation<ApiResponse<string>, Error, number>({
     mutationFn: (recruitmentId: number) => {
-      if (!isAuthenticated) {
+      if (!getAccessToken()) {
         showToast('로그인이 필요한 기능입니다.');
         return Promise.reject(new Error('Unauthorized'));
       }
@@ -40,12 +39,11 @@ export function useToggleRecruitmentLike() {
  */
 export function useToggleDesignerLike() {
   const queryClient = useQueryClient();
-  const { isAuthenticated } = useAuthStore();
   const { showToast } = useToast();
 
   return useMutation<ApiResponse<string>, Error, number>({
     mutationFn: (designerId: number) => {
-      if (!isAuthenticated) {
+      if (!getAccessToken()) {
         showToast('로그인이 필요한 기능입니다.');
         return Promise.reject(new Error('Unauthorized'));
       }


### PR DESCRIPTION
### 💡 To Reviewers

- [찜 버튼 오류](https://www.notion.so/2f17188b2e2080f3ba50f1f7f14d2e8d?source=copy_link)

### 🔥 작업 내용

- 찜 기능 인증 체크를 Zustand store(`isAuthenticated`) → 쿠키 기반(`getAccessToken()`)으로 변경
- Post 상세 페이지 찜 버튼에 비로그인 체크 추가

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 비로그인 시 찜 버튼 클릭 → UI 토글 없이 Toast만 표시

### 🔗 관련 이슈

- #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 좋아요 기능의 인증 처리 개선 - 접근 토큰 부재 시 더 안정적으로 요청을 처리하도록 업데이트했습니다.

---

**단어 수: 22**

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->