### PR TITLE
#126 [FIX] Explore 페이지 SSR 프리페치 시 인증 토큰 전달

### DIFF
--- a/src/apis/explore/recruitments.ts
+++ b/src/apis/explore/recruitments.ts
@@ -17,6 +17,8 @@ const DEFAULT_PAGE_SIZE = 6;
 interface GetRecruitmentsOptions {
   /** mock endpoint 오버라이드 (기본: 'recruitments') */
   mockEndpoint?: MockEndpoint;
+  /** SSR에서 쿠키로 전달받은 토큰 (선택) */
+  accessToken?: string;
 }
 
 /**
@@ -27,15 +29,22 @@ export async function getRecruitments(
   params: RecruitmentListParams = {},
   options: GetRecruitmentsOptions = {}
 ): Promise<ApiResponse<RecruitmentListResponse>> {
-  const { mockEndpoint = 'recruitments' } = options;
+  const { mockEndpoint = 'recruitments', accessToken } = options;
   if (isMockEnabled(mockEndpoint)) {
     return getMockRecruitments(params);
   }
 
   const { size = DEFAULT_PAGE_SIZE, ...restParams } = params;
+
+  // SSR에서 전달받은 토큰이 있으면 헤더에 추가
+  const headers: Record<string, string> = {};
+  if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
+
   const { data } = await axiosInstance.get<ApiResponse<RecruitmentListResponse>>(
     '/recruitments',
-    { params: { ...restParams, size } }
+    { params: { ...restParams, size }, headers }
   );
   return data;
 }

--- a/src/app/(model)/explore/page.tsx
+++ b/src/app/(model)/explore/page.tsx
@@ -1,3 +1,4 @@
+import { cookies } from 'next/headers';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { getQueryClient } from '@/src/providers/queryClient';
 import { getRecruitments } from '@/src/apis';
@@ -7,6 +8,10 @@ import { ExploreContent } from '@/src/components/explore';
 export default async function ExplorePage() {
   const queryClient = getQueryClient();
 
+  // SSR에서 쿠키로 토큰 읽기
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('access_token')?.value;
+
   // 서버에서 초기 데이터 프리페칭 (기본값: HAIR 카테고리, 최신순)
   await queryClient.prefetchInfiniteQuery({
     queryKey: recruitmentKeys.list({
@@ -14,10 +19,10 @@ export default async function ExplorePage() {
       sortOption: 'NEWEST',
     }),
     queryFn: () =>
-      getRecruitments({
-        category: 'HAIR',
-        sortOption: 'NEWEST',
-      }),
+      getRecruitments(
+        { category: 'HAIR', sortOption: 'NEWEST' },
+        { accessToken }
+      ),
     initialPageParam: undefined,
   });
 


### PR DESCRIPTION
### 💡 To Reviewers

- Explore 페이지 새로고침 시 로그인 사용자의 `isLiked`가 모두 `false`로 표시되는 문제 수정

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- `getRecruitments` API에 `accessToken` 옵션 추가
- Explore 페이지 SSR 프리페치 시 `cookies()`로 토큰 읽어서 API에 전달
- Post 상세 페이지(`post/[id]`)와 동일한 패턴으로 통일

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 로그인 후 Explore 페이지 새로고침 → 찜한 공고에 하트 정상 표시

### 🔗 관련 이슈

- #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 모집 정보 조회에 사용자 인증 지원 기능이 추가되었습니다. 인증된 사용자는 개인화된 모집 데이터에 안전하게 접근할 수 있으며, 권한에 따른 데이터 제어가 강화됩니다. 보안성이 개선되었고, 기존의 비인증 조회 기능과의 호환성도 유지됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->