### PR TITLE
#130 [FIX] 로그인 후 callbackUrl 리다이렉트 무한 루프 수정

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -50,8 +50,9 @@ const AUTH_REQUIRED_ENDPOINTS = ['/auth/logout', '/auth/validate'];
 axiosInstance.interceptors.request.use(
   (config) => {
     const url = config.url || '';
-    const isAuthEndpoint = url.startsWith('/auth/');
-    const requiresToken = AUTH_REQUIRED_ENDPOINTS.some((endpoint) => url.includes(endpoint));
+    const pathname = url.split('?')[0]; // 쿼리스트링 제거
+    const isAuthEndpoint = pathname.startsWith('/auth/');
+    const requiresToken = AUTH_REQUIRED_ENDPOINTS.includes(pathname);
 
     // /auth/ 엔드포인트가 아니거나, 인증이 필요한 /auth/ 엔드포인트인 경우만 토큰 추가
     if (!isAuthEndpoint || requiresToken) {

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -43,13 +43,23 @@ export const axiosInstance = axios.create({
   withCredentials: true, // refreshToken 쿠키 자동 전송
 });
 
+// /auth/ 엔드포인트 중 인증이 필요한 것만 명시 (나머지는 토큰 주입 제외)
+const AUTH_REQUIRED_ENDPOINTS = ['/auth/logout', '/auth/validate'];
+
 // Request Interceptor: 쿠키에서 accessToken 읽어서 헤더에 추가 + 로깅
 axiosInstance.interceptors.request.use(
   (config) => {
-    const token = getAccessToken();
-    if (token) {
-      config.headers = config.headers || {};
-      config.headers.Authorization = `Bearer ${token}`;
+    const url = config.url || '';
+    const isAuthEndpoint = url.startsWith('/auth/');
+    const requiresToken = AUTH_REQUIRED_ENDPOINTS.some((endpoint) => url.includes(endpoint));
+
+    // /auth/ 엔드포인트가 아니거나, 인증이 필요한 /auth/ 엔드포인트인 경우만 토큰 추가
+    if (!isAuthEndpoint || requiresToken) {
+      const token = getAccessToken();
+      if (token) {
+        config.headers = config.headers || {};
+        config.headers.Authorization = `Bearer ${token}`;
+      }
     }
 
     // API 로깅 (NEXT_PUBLIC_API_LOGGING=true 일 때만 활성화)

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -55,8 +55,10 @@ const LoginContent = () => {
             });
 
             // 로그인 성공 시 원래 경로로 이동 (fallback: 홈)
+            // Open Redirect 방지: 단일 슬래시로 시작하는 경로만 허용 (//evil.com 차단)
             const callbackUrl = searchParams.get('callbackUrl');
-            const redirectUrl = callbackUrl && callbackUrl.startsWith('/') ? callbackUrl : '/';
+            const isValidCallback = callbackUrl && callbackUrl.startsWith('/') && !callbackUrl.startsWith('//');
+            const redirectUrl = isValidCallback ? callbackUrl : '/';
             window.location.replace(redirectUrl); // 전체 페이지 리로드로 쿠키 동기화 보장
           } else {
             showToast(response.message || '로그인 실패');

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Suspense, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useQueryClient } from '@tanstack/react-query';
@@ -11,7 +11,6 @@ import { SOCIAL_LOGIN_URLS, showToast } from '@/src/utils';
 import { InstallPrompt } from '@/src/components/common';
 
 const LoginContent = () => {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const { setUser } = useAuthStore();
@@ -58,7 +57,7 @@ const LoginContent = () => {
             // 로그인 성공 시 원래 경로로 이동 (fallback: 홈)
             const callbackUrl = searchParams.get('callbackUrl');
             const redirectUrl = callbackUrl && callbackUrl.startsWith('/') ? callbackUrl : '/';
-            router.replace(redirectUrl); // 로그인 페이지를 히스토리에서 제거
+            window.location.replace(redirectUrl); // 전체 페이지 리로드로 쿠키 동기화 보장
           } else {
             showToast(response.message || '로그인 실패');
           }


### PR DESCRIPTION
### 💡 To Reviewers

- (쿠키, 권한 삭제 -> 로그인 → 마이페이지 → 알림설정 정상 접근 확인) 테스트 필요

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

**문제 현상**
- 로그인 → 마이페이지 → 알림설정 클릭 시 로그인 페이지로 리다이렉트
- 로그인 성공 후에도 로그인 페이지에 갇히는 무한 루프 발생

**근본 원인 (2가지)**

1. **axios 인터셉터가 인증 요청에도 만료된 토큰 주입**
   - 만료된 `access_token`이 `/auth/login` 요청에 포함되어 401 에러 발생
   - 로그인 자체가 실패하는 문제

2. **쿠키 설정과 라우터 네비게이션 간의 Race Condition**
   - `document.cookie` 설정 후 즉시 `router.replace()` 실행
   - 미들웨어가 쿠키를 읽을 때 아직 동기화되지 않음

**해결 방법**

- `src/apis/axios.ts`: 인증 엔드포인트 중 인증이 필요한 것(`/auth/validate`, `/auth/logout`)만 명시 (나머지는 토큰 주입 제외)
- `src/app/(auth)/login/page.tsx`: `router.replace()` → `window.location.replace()` 변경

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 로그인 → 홈 → 마이페이지 → 알림설정 정상 접근 확인

### 🔗 관련 이슈

- #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 로그인 후 쿠키 동기화를 위해 클라이언트 네비게이션을 전체 페이지 리로드 방식(window.location.replace)으로 변경했습니다.

* **Refactor**
  * 인증 토큰이 불필요한 요청에 주입되지 않도록 토큰 주입 로직을 조건화하여 보안성과 요청 처리 일관성을 향상시켰습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->