### PR TITLE
[FIX] 지도 페이지 iOS safe-area 대응

### DIFF
--- a/src/app/(model)/map/page.tsx
+++ b/src/app/(model)/map/page.tsx
@@ -14,6 +14,7 @@ import {
 import { useUserLocation } from '@/src/hooks/custom/useUserLocation';
 import { useMapState, useMapFilters, useSearchCenter, useMapData } from '@/src/hooks/custom/map';
 import { useToast } from '@/src/hooks/common/useToast';
+import { LAYOUT, DRAG } from '@/src/constants/map';
 
 function MapContent() {
   const { showToast } = useToast();
@@ -109,7 +110,8 @@ function MapContent() {
         shops={shops}
         selectedDesignerId={selectedShop?.designerId}
         userLocation={userLocationAsMapPosition}
-        bottomOffset={selectedShop ? 0 : bottomSheetHeight}
+        bottomOffset={selectedShop ? undefined : bottomSheetHeight}
+        bottomOffsetPx={selectedShop ? DRAG.CARD_FULL_HEIGHT + LAYOUT.BOTTOM_NAV_HEIGHT : undefined}
         onCenterChanged={handleCenterChanged}
         onZoomChanged={handleZoomChanged}
         onShopClick={handleShopClick}

--- a/src/app/(model)/map/page.tsx
+++ b/src/app/(model)/map/page.tsx
@@ -27,6 +27,7 @@ function MapContent() {
   // 지도 상태 관리
   const {
     zoom,
+    bottomSheetHeight,
     selectedShop,
     displayCenter,
     userLocationAsMapPosition,
@@ -108,6 +109,7 @@ function MapContent() {
         shops={shops}
         selectedDesignerId={selectedShop?.designerId}
         userLocation={userLocationAsMapPosition}
+        bottomOffset={selectedShop ? 0 : bottomSheetHeight}
         onCenterChanged={handleCenterChanged}
         onZoomChanged={handleZoomChanged}
         onShopClick={handleShopClick}

--- a/src/app/(model)/map/page.tsx
+++ b/src/app/(model)/map/page.tsx
@@ -27,9 +27,7 @@ function MapContent() {
   // 지도 상태 관리
   const {
     zoom,
-    bottomSheetHeight,
     selectedShop,
-    selectedCardDragOffset,
     displayCenter,
     userLocationAsMapPosition,
     handleCenterChanged,
@@ -115,15 +113,10 @@ function MapContent() {
         onShopClick={handleShopClick}
       />
 
-      {/* 지도 컨트롤 버튼 */}
+      {/* 새로고침 버튼 */}
       <MapControls
         onRefreshSearch={handleRefreshSearch}
-        onCurrentLocation={handleCurrentLocation}
         showRefreshButton={!isLocationLoading}
-        bottomSheetHeight={bottomSheetHeight}
-        isSelectedShopCard={!!selectedShop && !!designerProfile}
-        hasRecruitmentImages={designerRecruitments.some((r) => r.thumbnailUrl)}
-        selectedCardDragOffset={selectedCardDragOffset}
       />
 
       {/* 로딩 인디케이터 */}
@@ -143,6 +136,7 @@ function MapContent() {
           onClose={handleCloseSelectedShop}
           onDesignerLikeToggle={() => toggleDesignerLike(selectedShop.designerId)}
           onDragOffsetChange={setSelectedCardDragOffset}
+          onCurrentLocation={handleCurrentLocation}
         />
       ) : !selectedShop ? (
         <MapBottomSheet
@@ -154,6 +148,7 @@ function MapContent() {
           onSubCategoryChange={setSubCategory}
           onSortChange={setSortOption}
           onHeightChange={setBottomSheetHeight}
+          onCurrentLocation={handleCurrentLocation}
           hasNextPage={hasNextPage}
           isFetchingNextPage={isFetchingNextPage}
           onLoadMore={fetchNextPage}

--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -112,7 +112,7 @@ export default function BottomNav() {
   };
 
   return (
-    <nav className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 border-t border-gray-200 bg-white pt-2 pb-[calc(16px+env(safe-area-inset-bottom))] sm:w-[375px]">
+    <nav className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 border-t border-gray-200 bg-white pt-2 pb-[calc(16px+env(safe-area-inset-bottom))] touch-none sm:w-[375px]">
       <div className="flex">
         {navItems.map((item) => {
           const active = isActive(item.href);

--- a/src/components/map/MapBottomSheet.tsx
+++ b/src/components/map/MapBottomSheet.tsx
@@ -334,7 +334,7 @@ export default function MapBottomSheet({
       className="fixed right-0 left-0 z-20 rounded-t-[20px] bg-white shadow-[0_-4px_20px_rgba(0,0,0,0.1)] sm:left-1/2 sm:w-[375px] sm:-translate-x-1/2"
       style={{
         height: `${SHEET_HEIGHTS.max}dvh`,
-        bottom: `${LAYOUT.BOTTOM_NAV_HEIGHT}px`,
+        bottom: `calc(${LAYOUT.BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom, 0px))`,
         transform: `translateY(${getTranslateY(sheetState)}dvh)`,
         willChange: 'transform',
       }}

--- a/src/components/map/MapBottomSheet.tsx
+++ b/src/components/map/MapBottomSheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef, useState, useCallback, useEffect } from 'react';
+import Image from 'next/image';
 import type { Category, SubCategory, SortOption } from '@/src/types/recruitment';
 import type { BottomSheetState } from '@/src/types/map';
 import { CATEGORIES, SUB_CATEGORIES_BY_CATEGORY, SORT_OPTIONS } from '@/src/constants/explore';
@@ -22,6 +23,7 @@ interface MapBottomSheetProps {
   onSubCategoryChange: (subCategory: SubCategory | 'ALL') => void;
   onSortChange: (sortOption: SortOption) => void;
   onHeightChange?: (height: number) => void;
+  onCurrentLocation?: () => void;
   // 무한 스크롤 props
   hasNextPage?: boolean;
   isFetchingNextPage?: boolean;
@@ -43,6 +45,7 @@ export default function MapBottomSheet({
   onSubCategoryChange,
   onSortChange,
   onHeightChange,
+  onCurrentLocation,
   hasNextPage,
   isFetchingNextPage,
   onLoadMore,
@@ -339,6 +342,17 @@ export default function MapBottomSheet({
         willChange: 'transform',
       }}
     >
+      {/* GPS 버튼 - 시트 상단 18px 위에 배치 */}
+      {onCurrentLocation && (
+        <button
+          type="button"
+          onClick={onCurrentLocation}
+          className="absolute -top-[56px] right-4 z-10 cursor-pointer"
+        >
+          <Image src="/icons/map/gps.svg" alt="현재 위치" width={38} height={38} />
+        </button>
+      )}
+
       {/* 헤더 영역 - 전체 드래그 가능 */}
       <div
         onTouchStart={handleHeaderTouchStart}

--- a/src/components/map/MapControls.tsx
+++ b/src/components/map/MapControls.tsx
@@ -28,10 +28,11 @@ export default function MapControls({
     ? LAYOUT.SELECTED_CARD_HEIGHT_WITH_IMAGES
     : LAYOUT.SELECTED_CARD_HEIGHT_NO_IMAGES;
 
-  const safeAreaBottom = 'env(safe-area-inset-bottom, 0px)';
+  // GPS 버튼은 BottomSheet/SelectedCard 상단에서 18px 위에 위치
+  const baseBottom = `calc(${LAYOUT.BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom, 0px))`;
   const gpsButtonBottom = isSelectedShopCard
-    ? `calc(${LAYOUT.BOTTOM_NAV_HEIGHT}px + ${safeAreaBottom} + ${selectedCardHeight}px + 18px - ${selectedCardDragOffset}px)`
-    : `calc(${bottomSheetHeight}dvh + ${LAYOUT.BOTTOM_NAV_HEIGHT}px + ${safeAreaBottom} + 18px)`;
+    ? `calc(${baseBottom} + ${selectedCardHeight}px + 18px - ${selectedCardDragOffset}px)`
+    : `calc(${baseBottom} + ${bottomSheetHeight}dvh + 18px)`;
 
   return (
     <>

--- a/src/components/map/MapControls.tsx
+++ b/src/components/map/MapControls.tsx
@@ -29,10 +29,9 @@ export default function MapControls({
     : LAYOUT.SELECTED_CARD_HEIGHT_NO_IMAGES;
 
   // GPS 버튼은 BottomSheet/SelectedCard 상단에서 18px 위에 위치
-  const baseBottom = `calc(${LAYOUT.BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom, 0px))`;
   const gpsButtonBottom = isSelectedShopCard
-    ? `calc(${baseBottom} + ${selectedCardHeight}px + 18px - ${selectedCardDragOffset}px)`
-    : `calc(${baseBottom} + ${bottomSheetHeight}dvh + 18px)`;
+    ? `calc(${LAYOUT.BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom, 0px) + ${selectedCardHeight}px + 18px - ${selectedCardDragOffset}px)`
+    : `calc(${LAYOUT.BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom, 0px) + ${bottomSheetHeight}dvh + 18px)`;
 
   return (
     <>

--- a/src/components/map/MapControls.tsx
+++ b/src/components/map/MapControls.tsx
@@ -28,9 +28,10 @@ export default function MapControls({
     ? LAYOUT.SELECTED_CARD_HEIGHT_WITH_IMAGES
     : LAYOUT.SELECTED_CARD_HEIGHT_NO_IMAGES;
 
+  const safeAreaBottom = 'env(safe-area-inset-bottom, 0px)';
   const gpsButtonBottom = isSelectedShopCard
-    ? `${LAYOUT.BOTTOM_NAV_HEIGHT + selectedCardHeight + 18 - selectedCardDragOffset}px`
-    : `calc(${bottomSheetHeight}vh + ${LAYOUT.BOTTOM_NAV_HEIGHT}px + 18px)`;
+    ? `calc(${LAYOUT.BOTTOM_NAV_HEIGHT}px + ${safeAreaBottom} + ${selectedCardHeight}px + 18px - ${selectedCardDragOffset}px)`
+    : `calc(${bottomSheetHeight}dvh + ${LAYOUT.BOTTOM_NAV_HEIGHT}px + ${safeAreaBottom} + 18px)`;
 
   return (
     <>

--- a/src/components/map/MapControls.tsx
+++ b/src/components/map/MapControls.tsx
@@ -1,69 +1,26 @@
 'use client';
 
-import Image from 'next/image';
 import RefreshIcon from '@/public/icons/map/refresh.svg';
-import { LAYOUT } from '@/src/constants/map';
 
 interface MapControlsProps {
   onRefreshSearch: () => void;
-  onCurrentLocation: () => void;
   showRefreshButton?: boolean;
-  bottomSheetHeight: number; // vh 단위
-  isSelectedShopCard?: boolean; // SelectedShopCard 표시 여부
-  hasRecruitmentImages?: boolean; // SelectedShopCard에 공고 이미지 있는지 여부
-  selectedCardDragOffset?: number; // SelectedShopCard 드래그 오프셋 (px)
 }
 
 export default function MapControls({
   onRefreshSearch,
-  onCurrentLocation,
   showRefreshButton = true,
-  bottomSheetHeight,
-  isSelectedShopCard = false,
-  hasRecruitmentImages = false,
-  selectedCardDragOffset = 0,
 }: MapControlsProps) {
-  // GPS 버튼 bottom 위치 계산 (드래그 오프셋 반영)
-  const selectedCardHeight = hasRecruitmentImages
-    ? LAYOUT.SELECTED_CARD_HEIGHT_WITH_IMAGES
-    : LAYOUT.SELECTED_CARD_HEIGHT_NO_IMAGES;
-
-  // GPS 버튼은 BottomSheet/SelectedCard 상단에서 18px 위에 위치
-  const gpsButtonBottom = isSelectedShopCard
-    ? `calc(${LAYOUT.BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom, 0px) + ${selectedCardHeight}px + 18px - ${selectedCardDragOffset}px)`
-    : `calc(${LAYOUT.BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom, 0px) + ${bottomSheetHeight}dvh + 18px)`;
+  if (!showRefreshButton) return null;
 
   return (
-    <>
-      {/* 현 지도에서 검색 버튼 - 상단 중앙 */}
-      {showRefreshButton && (
-        <button
-          type="button"
-          onClick={onRefreshSearch}
-          className="absolute top-4 left-1/2 z-10 flex -translate-x-1/2 cursor-pointer items-center gap-1 rounded-[34px] border border-gray-400 bg-white px-3 py-2 shadow-sm"
-        >
-          <RefreshIcon className="size-6 text-gray-800" />
-          <span className="text-body-2-medium text-gray-900">현 지도에서 검색</span>
-        </button>
-      )}
-
-      {/* 현재 위치 버튼 - BottomSheet/SelectedCard 상단에서 18px 위 */}
-      <button
-        type="button"
-        onClick={onCurrentLocation}
-        className="absolute right-4 z-30 cursor-pointer"
-        style={{
-          bottom: gpsButtonBottom,
-          transition: 'bottom 0.1s ease-out',
-        }}
-      >
-        <Image
-          src="/icons/map/gps.svg"
-          alt="현재 위치"
-          width={38}
-          height={38}
-        />
-      </button>
-    </>
+    <button
+      type="button"
+      onClick={onRefreshSearch}
+      className="absolute top-4 left-1/2 z-10 flex -translate-x-1/2 cursor-pointer items-center gap-1 rounded-[34px] border border-gray-400 bg-white px-3 py-2 shadow-sm"
+    >
+      <RefreshIcon className="size-6 text-gray-800" />
+      <span className="text-body-2-medium text-gray-900">현 지도에서 검색</span>
+    </button>
   );
 }

--- a/src/components/map/NaverMapView.tsx
+++ b/src/components/map/NaverMapView.tsx
@@ -25,6 +25,7 @@ interface NaverMapViewProps {
   selectedDesignerId?: number;
   userLocation?: MapPosition | null; // 현재 사용자 위치
   bottomOffset?: number; // BottomSheet 높이 (vh 단위)
+  bottomOffsetPx?: number; // 하단 오프셋 (px 단위, 우선순위 높음)
   onCenterChanged?: (center: MapPosition) => void;
   onZoomChanged?: (zoom: number) => void;
   onShopClick?: (shop: MapShopItem) => void;
@@ -38,6 +39,7 @@ export default function NaverMapView({
   selectedDesignerId,
   userLocation,
   bottomOffset,
+  bottomOffsetPx,
   onCenterChanged,
   onZoomChanged,
   onShopClick,
@@ -217,14 +219,14 @@ export default function NaverMapView({
         center.lng
       );
 
-      // BottomSheet 오프셋 보정
-      if (bottomOffset && bottomOffset > 0) {
-        const offsetPx = ((bottomOffset / 100) * window.innerHeight) / 2;
+      // 하단 오프셋 보정 (px 우선, 없으면 vh 변환)
+      const offsetPx = bottomOffsetPx ?? ((bottomOffset ?? 0) / 100) * window.innerHeight;
+      if (offsetPx > 0) {
         const projection = mapInstance.getProjection();
         const pixelOffset = projection.fromCoordToOffset(targetCoord);
 
         // 지도 중심을 아래로 이동 → 사용자 위치가 보이는 영역 중앙으로 올라감
-        pixelOffset.y += offsetPx;
+        pixelOffset.y += offsetPx / 2;
 
         targetCoord = projection.fromOffsetToCoord(pixelOffset);
       }
@@ -234,7 +236,7 @@ export default function NaverMapView({
         easing: 'easeOutCubic',
       });
     }
-  }, [mapInstance, center, bottomOffset]);
+  }, [mapInstance, center, bottomOffset, bottomOffsetPx]);
 
   // zoom 변경 시 지도 줌 변경
   useEffect(() => {

--- a/src/components/map/NaverMapView.tsx
+++ b/src/components/map/NaverMapView.tsx
@@ -223,8 +223,8 @@ export default function NaverMapView({
         const projection = mapInstance.getProjection();
         const pixelOffset = projection.fromCoordToOffset(targetCoord);
 
-        // Y축 상향 이동 (화면 좌표계는 위가 0)
-        pixelOffset.y -= offsetPx;
+        // 지도 중심을 아래로 이동 → 사용자 위치가 보이는 영역 중앙으로 올라감
+        pixelOffset.y += offsetPx;
 
         targetCoord = projection.fromOffsetToCoord(pixelOffset);
       }

--- a/src/components/map/NaverMapView.tsx
+++ b/src/components/map/NaverMapView.tsx
@@ -24,6 +24,7 @@ interface NaverMapViewProps {
   shops?: MapShopItem[];
   selectedDesignerId?: number;
   userLocation?: MapPosition | null; // 현재 사용자 위치
+  bottomOffset?: number; // BottomSheet 높이 (vh 단위)
   onCenterChanged?: (center: MapPosition) => void;
   onZoomChanged?: (zoom: number) => void;
   onShopClick?: (shop: MapShopItem) => void;
@@ -36,6 +37,7 @@ export default function NaverMapView({
   shops = [],
   selectedDesignerId,
   userLocation,
+  bottomOffset,
   onCenterChanged,
   onZoomChanged,
   onShopClick,
@@ -210,12 +212,29 @@ export default function NaverMapView({
       Math.abs(currentLng - center.lng) < 0.0001;
 
     if (!isSameAsMapCenter) {
-      mapInstance.panTo(new naver.maps.LatLng(center.lat, center.lng), {
+      let targetCoord: naver.maps.LatLng | naver.maps.Coord = new naver.maps.LatLng(
+        center.lat,
+        center.lng
+      );
+
+      // BottomSheet 오프셋 보정
+      if (bottomOffset && bottomOffset > 0) {
+        const offsetPx = ((bottomOffset / 100) * window.innerHeight) / 2;
+        const projection = mapInstance.getProjection();
+        const pixelOffset = projection.fromCoordToOffset(targetCoord);
+
+        // Y축 상향 이동 (화면 좌표계는 위가 0)
+        pixelOffset.y -= offsetPx;
+
+        targetCoord = projection.fromOffsetToCoord(pixelOffset);
+      }
+
+      mapInstance.panTo(targetCoord, {
         duration: 300,
         easing: 'easeOutCubic',
       });
     }
-  }, [mapInstance, center]);
+  }, [mapInstance, center, bottomOffset]);
 
   // zoom 변경 시 지도 줌 변경
   useEffect(() => {

--- a/src/components/map/SelectedShopCard.tsx
+++ b/src/components/map/SelectedShopCard.tsx
@@ -26,6 +26,7 @@ interface SelectedShopCardProps {
   onClose: () => void;
   onDesignerLikeToggle?: () => void;
   onDragOffsetChange?: (offset: number) => void;
+  onCurrentLocation?: () => void;
 }
 
 export default function SelectedShopCard({
@@ -35,6 +36,7 @@ export default function SelectedShopCard({
   onClose,
   onDesignerLikeToggle,
   onDragOffsetChange,
+  onCurrentLocation,
 }: SelectedShopCardProps) {
   // 첫 번째 공고 (대표 공고)
   const firstRecruitment = recruitments[0] ?? null;
@@ -252,6 +254,17 @@ export default function SelectedShopCard({
       onTouchEnd={handleTouchEnd}
       onMouseDown={handleMouseDown}
     >
+      {/* GPS 버튼 - 카드 상단 18px 위에 배치 */}
+      {onCurrentLocation && (
+        <button
+          type="button"
+          onClick={onCurrentLocation}
+          className="absolute -top-[56px] right-4 z-10 cursor-pointer"
+        >
+          <Image src="/icons/map/gps.svg" alt="현재 위치" width={38} height={38} />
+        </button>
+      )}
+
       {/* 드래그 핸들 */}
       <div className="mb-3 flex cursor-grab justify-center py-1 active:cursor-grabbing">
         <div className="h-1.5 w-14 rounded-[9px] bg-gray-400" />

--- a/src/components/map/SelectedShopCard.tsx
+++ b/src/components/map/SelectedShopCard.tsx
@@ -243,7 +243,7 @@ export default function SelectedShopCard({
       ref={containerRef}
       className="fixed right-0 left-0 z-20 rounded-t-[20px] bg-white px-0 pt-3 pb-5 shadow-[0_0_4px_rgba(34,34,34,0.09)] sm:left-1/2 sm:w-[375px] sm:-translate-x-1/2"
       style={{
-        bottom: `${LAYOUT.BOTTOM_NAV_HEIGHT}px`,
+        bottom: `calc(${LAYOUT.BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom, 0px))`,
         transform: `translateY(${finalOffset}px)`,
         willChange: 'transform',
       }}

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -11,7 +11,7 @@ export const MAP_DEFAULTS = {
 
 // ===== 레이아웃 상수 =====
 export const LAYOUT = {
-  /** BottomNav 높이 (px) - safe-area 포함 */
+  /** BottomNav 높이 (px) - safe-area 미포함 */
   BOTTOM_NAV_HEIGHT: 76,
   /** SelectedShopCard 높이 - 공고 있을 때 (이미지 갤러리 포함) */
   SELECTED_CARD_HEIGHT_WITH_IMAGES: 340,

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -33,6 +33,8 @@ export const DRAG = {
   CARD_CONTENT_HEIGHT: 230,
   /** SelectedShopCard 접힘 임계값 (px) */
   COLLAPSE_THRESHOLD: 100,
+  /** SelectedShopCard 전체 높이 (px) - 핸들 + 콘텐츠 */
+  CARD_FULL_HEIGHT: 260,
 } as const;
 
 // ===== 타입 export =====

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -13,10 +13,6 @@ export const MAP_DEFAULTS = {
 export const LAYOUT = {
   /** BottomNav 높이 (px) - safe-area 미포함 */
   BOTTOM_NAV_HEIGHT: 76,
-  /** SelectedShopCard 높이 - 공고 있을 때 (이미지 갤러리 포함) */
-  SELECTED_CARD_HEIGHT_WITH_IMAGES: 340,
-  /** SelectedShopCard 높이 - 공고 없을 때 */
-  SELECTED_CARD_HEIGHT_NO_IMAGES: 160,
 } as const;
 
 // ===== BottomSheet 높이 설정 (vh 기준) =====

--- a/src/types/navermaps.d.ts
+++ b/src/types/navermaps.d.ts
@@ -9,7 +9,16 @@ declare namespace naver.maps {
     getZoom(): number;
     getBounds(): LatLngBounds;
     panTo(coord: LatLng | Coord, options?: PanOptions): void;
+    panBy(point: Point, options?: PanOptions): void;
+    getProjection(): MapSystemProjection;
     destroy(): void;
+  }
+
+  interface MapSystemProjection {
+    fromCoordToOffset(coord: Coord | LatLng): Point;
+    fromOffsetToCoord(offset: Point): LatLng;
+    fromCoordToPoint(coord: Coord | LatLng): Point;
+    fromPointToCoord(point: Point): LatLng;
   }
 
   class LatLng {


### PR DESCRIPTION
### 💡 To Reviewers

- 새롭게 설치한 라이브러리 없음
- CSS `env(safe-area-inset-bottom)` 환경 변수를 사용하여 iOS/Android 모두 대응
- Naver Maps Projection API를 사용하여 지도 중심점 오프셋 보정

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

#### Safe Area 대응
- `MapControls` GPS 버튼 bottom 위치에 safe-area 적용
- `MapBottomSheet` bottom 스타일에 safe-area 적용
- `SelectedShopCard` bottom 스타일에 safe-area 적용

#### GPS 버튼 구조 변경
- GPS 버튼을 `MapControls`에서 `MapBottomSheet`/`SelectedShopCard` 내부로 이동
- 미사용 상수 제거 (`SELECTED_CARD_HEIGHT_*`)

#### 지도 중심점 오프셋 보정 (신규)
- BottomSheet/SelectedShopCard가 화면 하단을 가릴 때, GPS 버튼 클릭 시 사용자 위치가 **보이는 영역의 중앙**에 표시되도록 보정
- `NaverMapView`에 `bottomOffset` (vh), `bottomOffsetPx` (px) prop 추가
- Naver Maps `MapSystemProjection` API 사용 (`fromCoordToOffset`, `fromOffsetToCoord`)
- `navermaps.d.ts`에 `MapSystemProjection` 인터페이스 타입 추가

### 🤔 추후 작업 예정

- 실제 iOS 기기에서 테스트 필요

### 📸 작업 결과 (스크린샷)

- Vercel preview에서 확인 필요

### 🔗 관련 이슈

- #113