### PR TITLE
[FIX] 채팅방 목록에서 IMAGE 타입 채팅방이 표시되지 않는 버그 수정

### DIFF
--- a/src/app/(common)/chat/page.tsx
+++ b/src/app/(common)/chat/page.tsx
@@ -42,10 +42,9 @@ export default function ChatPage() {
   const isListLoading = !authReady || isLoading || (isFetching && allChats.length === 0);
 
   // 채팅방은 생성된 채로 메세지가 없는 경우, 채팅방 리스트에 뜨는 것을 방지
+  // IMAGE 타입의 경우 lastMessage가 null일 수 있으므로 lastMessage 조건 제거
   const visibleChats = useMemo(() => {
-    return allChats.filter(
-      (chat) => chat.lastMessageTime != null && chat.lastMessage != null && chat.messageType != null,
-    );
+    return allChats.filter((chat) => chat.lastMessageTime != null && chat.messageType != null);
   }, [allChats]);
 
   // 에러 처리


### PR DESCRIPTION
### 💡 To Reviewers

- 버그 수정

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 채팅방 목록 필터링 조건에서 `lastMessage != null` 조건 제거
- IMAGE 타입 메시지의 경우 백엔드에서 `lastMessage`를 `null`로 반환하여 채팅방이 필터링되던 문제 해결

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- IMAGE 타입 채팅방이 정상적으로 목록에 표시됨

### 🔗 관련 이슈

- #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅 목록 필터링 로직 개선: lastMessage 필드의 null 값 처리 개선으로 더욱 안정적인 채팅 표시 처리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->