### PR TITLE
#136 [FIX] 마이페이지 일정 시간 분 단위 표시 오류 수정

### DIFF
--- a/src/app/(designer)/reservations/pending/page.tsx
+++ b/src/app/(designer)/reservations/pending/page.tsx
@@ -27,7 +27,7 @@ export default function PendingReservationsPage() {
       <header className="flex items-center justify-between px-4 py-3">
         <button
           type="button"
-          onClick={() => router.push('/designer/home')}
+          onClick={() => router.push('/')}
           className="flex size-6 cursor-pointer items-center justify-center"
           aria-label="뒤로가기"
         >

--- a/src/utils/common/formatTimeToKorean.ts
+++ b/src/utils/common/formatTimeToKorean.ts
@@ -1,11 +1,12 @@
 /**
  * 시간을 한글 형식으로 포맷
  * @param timeStr - "HH:mm" 형식의 시간 문자열 (예: "09:00", "14:30")
- * @returns "오전/오후 H시" 형식의 시간 문자열 (예: "오전 9시", "오후 2시")
+ * @returns "오전/오후 H시" 또는 "오전/오후 H시 M분" 형식의 시간 문자열 (예: "오전 9시", "오후 2시 30분")
  */
 export function formatTimeToKorean(timeStr: string): string {
-  const [hour] = timeStr.split(':');
+  const [hour, minute] = timeStr.split(':');
   const hourNum = parseInt(hour, 10);
+  const minuteNum = parseInt(minute, 10);
 
   // 유효하지 않은 입력 처리
   if (Number.isNaN(hourNum)) {
@@ -14,6 +15,11 @@ export function formatTimeToKorean(timeStr: string): string {
 
   const period = hourNum < 12 ? '오전' : '오후';
   const displayHour = hourNum === 0 ? 12 : hourNum > 12 ? hourNum - 12 : hourNum;
+
+  // 분이 0이 아닐 때만 분 표시
+  if (minuteNum > 0) {
+    return `${period} ${displayHour}시 ${minuteNum}분`;
+  }
 
   return `${period} ${displayHour}시`;
 }


### PR DESCRIPTION
### 💡 To Reviewers

- 신규 라이브러리 설치 없음
- `formatTimeToKorean()` 유틸 함수 수정으로 마이페이지 전체 예약 카드에 적용됨

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- `formatTimeToKorean()` 함수에서 분(minute)이 0이 아닐 때 분도 표시하도록 수정
  - Before: `"08:30"` → "오전 8시"
  - After: `"08:30"` → "오전 8시 30분"
- 분이 0인 경우는 기존과 동일하게 시간만 표시
  - `"08:00"` → "오전 8시"

- **추가 수정 사항**
- https://moandi.co.kr/reservations/pending -> 뒤로가기 라우팅 경로 "/" 디자이너 홈으로 수정

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 마이페이지 > 예약 탭에서 시간 표시 확인 필요

### 🔗 관련 이슈

- #136