### PR TITLE
[FIX] iOS PWA Safe-Area 레이아웃 수정

### DIFF
--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -7,6 +7,7 @@ import { useSendFindIdCode, useVerifyEmailCode, useFindId } from '@/src/hooks/qu
 import { validateEmail } from '@/src/utils/auth/find-id';
 import { useTimer } from '@/src/hooks/auth/find-id';
 import { AuthHeader, Spinner, AuthCodeInputWithTimer } from '@/src/components/auth';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { showToast } from '@/src/utils';
 
 interface StepInputProps {
@@ -199,11 +200,11 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
 
       </form>
       {/* 하단 버튼 */}
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <FixedBottomButton disabled={!isVerified || findIdMutation.isPending} onClick={handleFindId}>
           {findIdMutation.isPending ? '조회 중...' : '아이디 찾기'}
         </FixedBottomButton>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -199,7 +199,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
 
       </form>
       {/* 하단 버튼 */}
-      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <FixedBottomButton disabled={!isVerified || findIdMutation.isPending} onClick={handleFindId}>
           {findIdMutation.isPending ? '조회 중...' : '아이디 찾기'}
         </FixedBottomButton>

--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -133,7 +133,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
       </div>
 
       {/* 입력 폼 */}
-      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6" onSubmit={(e) => e.preventDefault()}>
+      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6 pb-[100px]" onSubmit={(e) => e.preventDefault()}>
         {/* 이름 입력 */}
         <div className="flex flex-col gap-2">
           <label className="text-body-1-medium tracking-tight text-gray-900">이름 (실명)</label>
@@ -197,13 +197,13 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
           )}
         </div>
 
-        {/* 하단 버튼 */}
-        <div className="mt-auto mb-3">
-          <FixedBottomButton disabled={!isVerified || findIdMutation.isPending} onClick={handleFindId}>
-            {findIdMutation.isPending ? '조회 중...' : '아이디 찾기'}
-          </FixedBottomButton>
-        </div>
       </form>
+      {/* 하단 버튼 */}
+      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+        <FixedBottomButton disabled={!isVerified || findIdMutation.isPending} onClick={handleFindId}>
+          {findIdMutation.isPending ? '조회 중...' : '아이디 찾기'}
+        </FixedBottomButton>
+      </div>
     </div>
   );
 };

--- a/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
@@ -50,7 +50,7 @@ export const StepComplete: React.FC<StepCompleteProps> = ({ name, loginId, login
       </div>
       <button
         onClick={handleGoToLogin}
-        className="text-body-1-medium fixed bottom-3 left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 tracking-tight text-white sm:w-[343px]"
+        className="text-body-1-medium fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 tracking-tight text-white sm:w-[343px]"
       >
         로그인 화면으로 이동
       </button>

--- a/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
@@ -48,12 +48,14 @@ export const StepComplete: React.FC<StepCompleteProps> = ({ name, loginId, login
           )}
         </div>
       </div>
-      <button
-        onClick={handleGoToLogin}
-        className="text-body-1-medium fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 tracking-tight text-white sm:w-[343px]"
-      >
-        로그인 화면으로 이동
-      </button>
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+        <button
+          onClick={handleGoToLogin}
+          className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
+        >
+          로그인 화면으로 이동
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
@@ -52,7 +52,7 @@ export const StepComplete: React.FC<StepCompleteProps> = ({ name, loginId, login
       <FixedBottomContainer>
         <button
           onClick={handleGoToLogin}
-          className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
+          className="text-body-1-semibold h-[56px] w-full cursor-pointer rounded-full bg-gray-900 text-white"
         >
           로그인 화면으로 이동
         </button>

--- a/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/2-Complete.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import SignupCompletedIcon from '@/public/icons/signup/signup-completed.svg';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { getSocialServiceName } from '@/src/utils/auth/common';
 
 interface StepCompleteProps {
@@ -48,14 +49,14 @@ export const StepComplete: React.FC<StepCompleteProps> = ({ name, loginId, login
           )}
         </div>
       </div>
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <button
           onClick={handleGoToLogin}
           className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
         >
           로그인 화면으로 이동
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
@@ -7,6 +7,7 @@ import { useSendResetPasswordCode, useVerifyEmailCode, useVerifyResetPassword } 
 import { validateEmail } from '@/src/utils/auth/find-password';
 import { useTimer } from '@/src/hooks/auth/find-password';
 import { AuthHeader, Spinner, AuthCodeInputWithTimer } from '@/src/components/auth';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { showToast } from '@/src/utils';
 
 interface StepInputProps {
@@ -227,11 +228,11 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
 
       </form>
       {/* 하단 버튼 */}
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <FixedBottomButton disabled={!isVerified || verifyResetMutation.isPending} onClick={handleNextStep}>
           {verifyResetMutation.isPending ? '검증 중...' : '비밀번호 재설정'}
         </FixedBottomButton>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
@@ -227,7 +227,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
 
       </form>
       {/* 하단 버튼 */}
-      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <FixedBottomButton disabled={!isVerified || verifyResetMutation.isPending} onClick={handleNextStep}>
           {verifyResetMutation.isPending ? '검증 중...' : '비밀번호 재설정'}
         </FixedBottomButton>

--- a/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
@@ -146,7 +146,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
       </div>
 
       {/* 입력 폼 */}
-      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6" onSubmit={(e) => e.preventDefault()}>
+      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6 pb-[100px]" onSubmit={(e) => e.preventDefault()}>
         {/* 이름 입력 */}
         <div className="flex flex-col gap-2">
           <label className="text-body-1-medium tracking-tight text-gray-900">이름 (실명)</label>
@@ -225,13 +225,13 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
           )}
         </div>
 
-        {/* 하단 버튼 */}
-        <div className="mt-auto mb-3">
-          <FixedBottomButton disabled={!isVerified || verifyResetMutation.isPending} onClick={handleNextStep}>
-            {verifyResetMutation.isPending ? '검증 중...' : '비밀번호 재설정'}
-          </FixedBottomButton>
-        </div>
       </form>
+      {/* 하단 버튼 */}
+      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+        <FixedBottomButton disabled={!isVerified || verifyResetMutation.isPending} onClick={handleNextStep}>
+          {verifyResetMutation.isPending ? '검증 중...' : '비밀번호 재설정'}
+        </FixedBottomButton>
+      </div>
     </div>
   );
 };

--- a/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
@@ -63,7 +63,7 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
       </div>
 
       {/* 입력 폼 */}
-      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6" onSubmit={(e) => e.preventDefault()}>
+      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6 pb-[100px]" onSubmit={(e) => e.preventDefault()}>
         {/* 새 비밀번호 입력 */}
         <PasswordInput
           label="새로운 비밀번호"
@@ -94,13 +94,13 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
           }
         />
 
-        {/* 하단 버튼 */}
-        <div className="mt-auto mb-3">
-          <FixedBottomButton disabled={!isValid || resetPasswordMutation.isPending} onClick={handleComplete}>
-            {resetPasswordMutation.isPending ? '변경 중...' : '완료'}
-          </FixedBottomButton>
-        </div>
       </form>
+      {/* 하단 버튼 */}
+      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+        <FixedBottomButton disabled={!isValid || resetPasswordMutation.isPending} onClick={handleComplete}>
+          {resetPasswordMutation.isPending ? '변경 중...' : '완료'}
+        </FixedBottomButton>
+      </div>
     </div>
   );
 };

--- a/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
@@ -96,7 +96,7 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
 
       </form>
       {/* 하단 버튼 */}
-      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <FixedBottomButton disabled={!isValid || resetPasswordMutation.isPending} onClick={handleComplete}>
           {resetPasswordMutation.isPending ? '변경 중...' : '완료'}
         </FixedBottomButton>

--- a/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
@@ -7,6 +7,7 @@ import { PasswordInput } from '@/src/components/common';
 import { useResetPassword } from '@/src/hooks/queries';
 import { usePasswordValidation } from '@/src/hooks/auth/find-password';
 import { AuthHeader } from '@/src/components/auth';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { showToast } from '@/src/utils';
 
 interface StepNewPasswordProps {
@@ -96,11 +97,11 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
 
       </form>
       {/* 하단 버튼 */}
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <FixedBottomButton disabled={!isValid || resetPasswordMutation.isPending} onClick={handleComplete}>
           {resetPasswordMutation.isPending ? '변경 중...' : '완료'}
         </FixedBottomButton>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/find-password/_funnel/steps/3-Complete.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/3-Complete.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import SignupCompletedIcon from '@/public/icons/signup/signup-completed.svg';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 export const StepComplete: React.FC = () => {
   const router = useRouter();
@@ -20,14 +21,14 @@ export const StepComplete: React.FC = () => {
           <p className="text-head-3-semibold text-center tracking-tight text-gray-900">비밀번호 변경이 완료되었어요</p>
         </div>
       </div>
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <button
           onClick={handleGoToLogin}
           className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
         >
           로그인 화면으로 이동
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/find-password/_funnel/steps/3-Complete.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/3-Complete.tsx
@@ -22,7 +22,7 @@ export const StepComplete: React.FC = () => {
       </div>
       <button
         onClick={handleGoToLogin}
-        className="text-body-1-medium fixed bottom-3 left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 tracking-tight text-white sm:w-[343px]"
+        className="text-body-1-medium fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 tracking-tight text-white sm:w-[343px]"
       >
         로그인 화면으로 이동
       </button>

--- a/src/app/(auth)/find-password/_funnel/steps/3-Complete.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/3-Complete.tsx
@@ -20,12 +20,14 @@ export const StepComplete: React.FC = () => {
           <p className="text-head-3-semibold text-center tracking-tight text-gray-900">비밀번호 변경이 완료되었어요</p>
         </div>
       </div>
-      <button
-        onClick={handleGoToLogin}
-        className="text-body-1-medium fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 tracking-tight text-white sm:w-[343px]"
-      >
-        로그인 화면으로 이동
-      </button>
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+        <button
+          onClick={handleGoToLogin}
+          className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
+        >
+          로그인 화면으로 이동
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/app/(auth)/find-password/_funnel/steps/3-Complete.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/3-Complete.tsx
@@ -24,7 +24,7 @@ export const StepComplete: React.FC = () => {
       <FixedBottomContainer>
         <button
           onClick={handleGoToLogin}
-          className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
+          className="text-body-1-semibold h-[56px] w-full cursor-pointer rounded-full bg-gray-900 text-white"
         >
           로그인 화면으로 이동
         </button>

--- a/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import SignupCompletedIcon from '@/public/icons/signup/signup-completed.svg';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { getSocialServiceName } from '@/src/utils/auth/common';
 
 interface StepSocialUserProps {
@@ -35,14 +36,14 @@ export const StepSocialUser: React.FC<StepSocialUserProps> = ({ name, loginType 
           </p>
         </div>
       </div>
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <button
           onClick={handleGoToLogin}
           className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
         >
           로그인 화면으로 이동
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
@@ -35,12 +35,14 @@ export const StepSocialUser: React.FC<StepSocialUserProps> = ({ name, loginType 
           </p>
         </div>
       </div>
-      <button
-        onClick={handleGoToLogin}
-        className="text-body-1-medium fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 tracking-tight text-white sm:w-[343px]"
-      >
-        로그인 화면으로 이동
-      </button>
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+        <button
+          onClick={handleGoToLogin}
+          className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
+        >
+          로그인 화면으로 이동
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
@@ -37,7 +37,7 @@ export const StepSocialUser: React.FC<StepSocialUserProps> = ({ name, loginType 
       </div>
       <button
         onClick={handleGoToLogin}
-        className="text-body-1-medium fixed bottom-3 left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 tracking-tight text-white sm:w-[343px]"
+        className="text-body-1-medium fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 tracking-tight text-white sm:w-[343px]"
       >
         로그인 화면으로 이동
       </button>

--- a/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/4-SocialUser.tsx
@@ -39,7 +39,7 @@ export const StepSocialUser: React.FC<StepSocialUserProps> = ({ name, loginType 
       <FixedBottomContainer>
         <button
           onClick={handleGoToLogin}
-          className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
+          className="text-body-1-semibold h-[56px] w-full cursor-pointer rounded-full bg-gray-900 text-white"
         >
           로그인 화면으로 이동
         </button>

--- a/src/app/(auth)/signup/_funnel/steps/1-Terms.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/1-Terms.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { useSignupStore } from '@/src/stores';
 import { SignupHeader, SignupTitle, FixedBottomButton } from '@/src/components/signup';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { SIGNUP_STEPS, SIGNUP_MESSAGES } from '@/src/constants/signup';
 import type { SignupStepProps } from '@/src/types';
 import SelectIcon from '@/public/icons/signup/select.svg';
@@ -51,11 +52,11 @@ export const StepTerms: React.FC<StepTermsProps> = ({ goNext, isSocial }) => {
           </div>
         ))}
       </div>
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <FixedBottomButton disabled={!requiredAgreed} onClick={goNext}>
           {SIGNUP_MESSAGES.BUTTON.NEXT}
         </FixedBottomButton>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/signup/_funnel/steps/1-Terms.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/1-Terms.tsx
@@ -51,7 +51,7 @@ export const StepTerms: React.FC<StepTermsProps> = ({ goNext, isSocial }) => {
           </div>
         ))}
       </div>
-      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <FixedBottomButton disabled={!requiredAgreed} onClick={goNext}>
           {SIGNUP_MESSAGES.BUTTON.NEXT}
         </FixedBottomButton>

--- a/src/app/(auth)/signup/_funnel/steps/1-Terms.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/1-Terms.tsx
@@ -51,7 +51,7 @@ export const StepTerms: React.FC<StepTermsProps> = ({ goNext, isSocial }) => {
           </div>
         ))}
       </div>
-      <div className="mx-4 mt-auto mb-3">
+      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
         <FixedBottomButton disabled={!requiredAgreed} onClick={goNext}>
           {SIGNUP_MESSAGES.BUTTON.NEXT}
         </FixedBottomButton>

--- a/src/app/(auth)/signup/_funnel/steps/2-Role.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/2-Role.tsx
@@ -35,7 +35,7 @@ export const StepRole: React.FC<StepRoleProps> = ({ goNext, goPrev, isSocial }) 
           </button>
         ))}
       </div>
-      <div className="mx-4 mt-auto mb-3">
+      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
         <FixedBottomButton
           disabled={!selectedRole}
           onClick={() => {

--- a/src/app/(auth)/signup/_funnel/steps/2-Role.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/2-Role.tsx
@@ -35,7 +35,7 @@ export const StepRole: React.FC<StepRoleProps> = ({ goNext, goPrev, isSocial }) 
           </button>
         ))}
       </div>
-      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <FixedBottomButton
           disabled={!selectedRole}
           onClick={() => {

--- a/src/app/(auth)/signup/_funnel/steps/2-Role.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/2-Role.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useSignupStore } from '@/src/stores';
 import { SignupHeader, SignupTitle, FixedBottomButton } from '@/src/components/signup';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { SIGNUP_ROLES, SIGNUP_STEPS, SIGNUP_MESSAGES } from '@/src/constants/signup';
 import type { SignupStepProps } from '@/src/types';
 
@@ -35,7 +36,7 @@ export const StepRole: React.FC<StepRoleProps> = ({ goNext, goPrev, isSocial }) 
           </button>
         ))}
       </div>
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <FixedBottomButton
           disabled={!selectedRole}
           onClick={() => {
@@ -47,7 +48,7 @@ export const StepRole: React.FC<StepRoleProps> = ({ goNext, goPrev, isSocial }) 
         >
           {SIGNUP_MESSAGES.BUTTON.NEXT}
         </FixedBottomButton>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/signup/_funnel/steps/3-BasicInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/3-BasicInfo.tsx
@@ -124,7 +124,7 @@ export const StepBasicInfo: React.FC<StepBasicInfoProps> = ({ goPrev, goNext, is
           </div>
         </div>
       </form>
-      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <FixedBottomButton disabled={!name || !email || !phoneNumber || !authCodeValid} onClick={goNext}>
           {SIGNUP_MESSAGES.BUTTON.NEXT}
         </FixedBottomButton>

--- a/src/app/(auth)/signup/_funnel/steps/3-BasicInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/3-BasicInfo.tsx
@@ -99,7 +99,7 @@ export const StepBasicInfo: React.FC<StepBasicInfoProps> = ({ goPrev, goNext, is
       <SignupHeader onBack={goPrev} totalSteps={SIGNUP_STEPS.REGULAR} currentStep={3} />
       <SignupTitle line1={SIGNUP_MESSAGES.BASIC_INFO.TITLE_1} line2={SIGNUP_MESSAGES.BASIC_INFO.TITLE_2} />
       <form
-        className="mx-4 mt-8 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 sm:w-[343px]"
+        className="mx-4 mt-8 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[100px] sm:w-[343px]"
         onSubmit={(e) => e.preventDefault()}
       >
         <div className="flex flex-col">
@@ -123,12 +123,12 @@ export const StepBasicInfo: React.FC<StepBasicInfoProps> = ({ goPrev, goNext, is
             />
           </div>
         </div>
-        <div className="mt-auto mb-3">
-          <FixedBottomButton disabled={!name || !email || !phoneNumber || !authCodeValid} onClick={goNext}>
-            {SIGNUP_MESSAGES.BUTTON.NEXT}
-          </FixedBottomButton>
-        </div>
       </form>
+      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+        <FixedBottomButton disabled={!name || !email || !phoneNumber || !authCodeValid} onClick={goNext}>
+          {SIGNUP_MESSAGES.BUTTON.NEXT}
+        </FixedBottomButton>
+      </div>
     </div>
   );
 };

--- a/src/app/(auth)/signup/_funnel/steps/3-BasicInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/3-BasicInfo.tsx
@@ -9,6 +9,7 @@ import {
   SignupTitle,
   FixedBottomButton,
 } from '@/src/components/signup';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { useSignupStore } from '@/src/stores';
 import { useSendSmsCode, useVerifySmsCode } from '@/src/hooks/queries';
 import { validatePhoneNumber } from '@/src/utils';
@@ -124,11 +125,11 @@ export const StepBasicInfo: React.FC<StepBasicInfoProps> = ({ goPrev, goNext, is
           </div>
         </div>
       </form>
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <FixedBottomButton disabled={!name || !email || !phoneNumber || !authCodeValid} onClick={goNext}>
           {SIGNUP_MESSAGES.BUTTON.NEXT}
         </FixedBottomButton>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/signup/_funnel/steps/4-LoginInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/4-LoginInfo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SignupHeader, SignupTitle, FixedBottomButton } from '@/src/components/signup';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { PasswordInput } from '@/src/components/common';
 import { useSignupStore } from '@/src/stores';
 import { useCheckLoginId } from '@/src/hooks/queries';
@@ -158,11 +159,11 @@ export const StepLoginInfo: React.FC<StepLoginInfoProps> = ({ goPrev, goNext, is
         </div>
 
       </form>
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <FixedBottomButton disabled={!isFormValid} onClick={goNext}>
           {SIGNUP_MESSAGES.BUTTON.NEXT}
         </FixedBottomButton>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/signup/_funnel/steps/4-LoginInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/4-LoginInfo.tsx
@@ -158,7 +158,7 @@ export const StepLoginInfo: React.FC<StepLoginInfoProps> = ({ goPrev, goNext, is
         </div>
 
       </form>
-      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <FixedBottomButton disabled={!isFormValid} onClick={goNext}>
           {SIGNUP_MESSAGES.BUTTON.NEXT}
         </FixedBottomButton>

--- a/src/app/(auth)/signup/_funnel/steps/4-LoginInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/4-LoginInfo.tsx
@@ -89,7 +89,7 @@ export const StepLoginInfo: React.FC<StepLoginInfoProps> = ({ goPrev, goNext, is
       <SignupHeader onBack={goPrev} totalSteps={SIGNUP_STEPS.REGULAR} currentStep={4} />
       <SignupTitle line1={SIGNUP_MESSAGES.LOGIN_INFO.TITLE_1} line2={SIGNUP_MESSAGES.LOGIN_INFO.TITLE_2} />
       <form
-        className="mx-4 mt-10 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 sm:w-[343px]"
+        className="mx-4 mt-10 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[100px] sm:w-[343px]"
         onSubmit={(e) => e.preventDefault()}
       >
         <div className="flex flex-col gap-6">
@@ -157,12 +157,12 @@ export const StepLoginInfo: React.FC<StepLoginInfoProps> = ({ goPrev, goNext, is
           />
         </div>
 
-        <div className="mt-auto mb-3">
-          <FixedBottomButton disabled={!isFormValid} onClick={goNext}>
-            {SIGNUP_MESSAGES.BUTTON.NEXT}
-          </FixedBottomButton>
-        </div>
       </form>
+      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+        <FixedBottomButton disabled={!isFormValid} onClick={goNext}>
+          {SIGNUP_MESSAGES.BUTTON.NEXT}
+        </FixedBottomButton>
+      </div>
     </div>
   );
 };

--- a/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
@@ -365,7 +365,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
         </div>
 
       </form>
-      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <FixedBottomButton disabled={!isFormValid || isSubmitting || isUploading} onClick={handleSubmit}>
           {isUploading ? '이미지 업로드 중...' : isSubmitting ? '처리 중...' : SIGNUP_MESSAGES.BUTTON.NEXT}
         </FixedBottomButton>

--- a/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
@@ -275,7 +275,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
       <SignupTitle line1={SIGNUP_MESSAGES.PROFILE_INFO.TITLE_1} line2={SIGNUP_MESSAGES.PROFILE_INFO.TITLE_2} />
 
       <form
-        className="mx-4 mt-10 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 sm:w-[343px]"
+        className="mx-4 mt-10 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[100px] sm:w-[343px]"
         onSubmit={(e) => e.preventDefault()}
       >
         <ProfileImageUpload profileImage={profileImage} onImageUpload={handleImageUpload} />
@@ -364,12 +364,12 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
           )}
         </div>
 
-        <div className={`mb-3 ${isDesigner ? 'mt-[45px]' : 'mt-auto'}`}>
-          <FixedBottomButton disabled={!isFormValid || isSubmitting || isUploading} onClick={handleSubmit}>
-            {isUploading ? '이미지 업로드 중...' : isSubmitting ? '처리 중...' : SIGNUP_MESSAGES.BUTTON.NEXT}
-          </FixedBottomButton>
-        </div>
       </form>
+      <div className="fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-4 right-4">
+        <FixedBottomButton disabled={!isFormValid || isSubmitting || isUploading} onClick={handleSubmit}>
+          {isUploading ? '이미지 업로드 중...' : isSubmitting ? '처리 중...' : SIGNUP_MESSAGES.BUTTON.NEXT}
+        </FixedBottomButton>
+      </div>
     </div>
   );
 };

--- a/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
@@ -11,6 +11,7 @@ import {
   PhoneInputWithAuth,
   AuthCodeInput,
 } from '@/src/components/signup';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { TextInput, Dropdown } from '@/src/components/common';
 import { useSignupStore } from '@/src/stores';
 import { useSignup, useSocialSignup, useSendSmsCode, useVerifySmsCode } from '@/src/hooks/queries';
@@ -365,11 +366,11 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
         </div>
 
       </form>
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <FixedBottomButton disabled={!isFormValid || isSubmitting || isUploading} onClick={handleSubmit}>
           {isUploading ? '이미지 업로드 중...' : isSubmitting ? '처리 중...' : SIGNUP_MESSAGES.BUTTON.NEXT}
         </FixedBottomButton>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/signup/_funnel/steps/6-Complete.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/6-Complete.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { SIGNUP_MESSAGES } from '@/src/constants/signup';
 import SignupCompletedIcon from '@/public/icons/signup/signup-completed.svg';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 export const StepComplete: React.FC = () => {
   const router = useRouter();
@@ -21,14 +22,14 @@ export const StepComplete: React.FC = () => {
           {SIGNUP_MESSAGES.COMPLETE.TITLE}
         </p>
       </div>
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <button
           onClick={handleStart}
           className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
         >
           {SIGNUP_MESSAGES.COMPLETE.BUTTON}
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 };

--- a/src/app/(auth)/signup/_funnel/steps/6-Complete.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/6-Complete.tsx
@@ -25,7 +25,7 @@ export const StepComplete: React.FC = () => {
       <FixedBottomContainer>
         <button
           onClick={handleStart}
-          className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
+          className="text-body-1-semibold h-[56px] w-full cursor-pointer rounded-full bg-gray-900 text-white"
         >
           {SIGNUP_MESSAGES.COMPLETE.BUTTON}
         </button>

--- a/src/app/(auth)/signup/_funnel/steps/6-Complete.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/6-Complete.tsx
@@ -23,7 +23,7 @@ export const StepComplete: React.FC = () => {
       </div>
       <button
         onClick={handleStart}
-        className="text-body-1-medium fixed bottom-3 left-1/2 w-[calc(100%-2rem)] max-w-[343px] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 text-white sm:w-[343px]"
+        className="text-body-1-medium fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-1/2 w-[calc(100%-2rem)] max-w-[343px] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 text-white sm:w-[343px]"
       >
         {SIGNUP_MESSAGES.COMPLETE.BUTTON}
       </button>

--- a/src/app/(auth)/signup/_funnel/steps/6-Complete.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/6-Complete.tsx
@@ -21,12 +21,14 @@ export const StepComplete: React.FC = () => {
           {SIGNUP_MESSAGES.COMPLETE.TITLE}
         </p>
       </div>
-      <button
-        onClick={handleStart}
-        className="text-body-1-medium fixed bottom-[calc(20px+env(safe-area-inset-bottom))] left-1/2 w-[calc(100%-2rem)] max-w-[343px] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 text-white sm:w-[343px]"
-      >
-        {SIGNUP_MESSAGES.COMPLETE.BUTTON}
-      </button>
+      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+        <button
+          onClick={handleStart}
+          className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
+        >
+          {SIGNUP_MESSAGES.COMPLETE.BUTTON}
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/app/(common)/mypage/profile/edit/page.tsx
+++ b/src/app/(common)/mypage/profile/edit/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import ArrowLeftIcon from '@/public/icons/common/arrow-left.svg';
 import { AddressInput, FixedBottomButton, GenderSelect, ProfileImageUpload } from '@/src/components/signup';
 import { Dropdown, TextInput } from '@/src/components/common';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { useProfileEditForm } from '@/src/hooks/custom/mypage';
 import { CATEGORY_OPTIONS } from '@/src/constants/mypage';
 
@@ -61,7 +62,7 @@ export default function ProfileEditPage() {
 
       {/* 폼 */}
       <form
-        className="mx-4 mt-4 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-6 sm:w-[343px]"
+        className="mx-4 mt-4 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-24 sm:w-[343px]"
         onSubmit={(e) => e.preventDefault()}
       >
         {/* 프로필 이미지 */}
@@ -147,20 +148,21 @@ export default function ProfileEditPage() {
           )}
         </div>
 
-        {/* 제출 버튼 */}
-        <div className="mt-auto mb-3">
-          <FixedBottomButton
-            disabled={!isFormValid || isLoading}
-            onClick={handleSubmit}
-          >
-            {isButtonLoading ? (
-              <div className="size-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
-            ) : (
-              '완료'
-            )}
-          </FixedBottomButton>
-        </div>
       </form>
+
+      {/* 하단 버튼 */}
+      <FixedBottomContainer>
+        <FixedBottomButton
+          disabled={!isFormValid || isLoading}
+          onClick={handleSubmit}
+        >
+          {isButtonLoading ? (
+            <div className="size-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+          ) : (
+            '완료'
+          )}
+        </FixedBottomButton>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(common)/mypage/profile/edit/page.tsx
+++ b/src/app/(common)/mypage/profile/edit/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import ArrowLeftIcon from '@/public/icons/common/arrow-left.svg';
 import { AddressInput, FixedBottomButton, GenderSelect, ProfileImageUpload } from '@/src/components/signup';
 import { Dropdown, TextInput } from '@/src/components/common';
-import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { useProfileEditForm } from '@/src/hooks/custom/mypage';
 import { CATEGORY_OPTIONS } from '@/src/constants/mypage';
 
@@ -62,7 +61,7 @@ export default function ProfileEditPage() {
 
       {/* 폼 */}
       <form
-        className="mx-4 mt-4 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-24 sm:w-[343px]"
+        className="mx-4 mt-4 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-6 sm:w-[343px]"
         onSubmit={(e) => e.preventDefault()}
       >
         {/* 프로필 이미지 */}
@@ -148,21 +147,20 @@ export default function ProfileEditPage() {
           )}
         </div>
 
+        {/* 제출 버튼 */}
+        <div className="mt-auto mb-3">
+          <FixedBottomButton
+            disabled={!isFormValid || isLoading}
+            onClick={handleSubmit}
+          >
+            {isButtonLoading ? (
+              <div className="size-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+            ) : (
+              '완료'
+            )}
+          </FixedBottomButton>
+        </div>
       </form>
-
-      {/* 하단 버튼 */}
-      <FixedBottomContainer>
-        <FixedBottomButton
-          disabled={!isFormValid || isLoading}
-          onClick={handleSubmit}
-        >
-          {isButtonLoading ? (
-            <div className="size-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
-          ) : (
-            '완료'
-          )}
-        </FixedBottomButton>
-      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(common)/mypage/reviews/edit/[reviewId]/page.tsx
+++ b/src/app/(common)/mypage/reviews/edit/[reviewId]/page.tsx
@@ -156,7 +156,7 @@ export default function ReviewEditPage() {
           type="button"
           onClick={handleSubmit}
           disabled={!isValidForm || isSubmitting}
-          className={`flex h-14 w-full cursor-pointer items-center justify-center rounded-full text-body-1-semibold transition-colors ${
+          className={`flex h-[56px] w-full cursor-pointer items-center justify-center rounded-full text-body-1-semibold transition-colors ${
             isValidForm && !isSubmitting
               ? 'bg-gray-900 text-white'
               : 'cursor-not-allowed bg-gray-200 text-gray-600'

--- a/src/app/(common)/mypage/reviews/edit/[reviewId]/page.tsx
+++ b/src/app/(common)/mypage/reviews/edit/[reviewId]/page.tsx
@@ -7,6 +7,7 @@ import { StarRatingInput } from '@/src/components/review';
 import { ReviewImageUploader } from '@/src/components/mypage/model-reviews';
 import { useWrittenReviews } from '@/src/hooks/queries/review';
 import { useReviewForm } from '@/src/hooks/custom/review';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import type { WrittenReviewItem } from '@/src/types';
 
 export default function ReviewEditPage() {
@@ -150,15 +151,15 @@ export default function ReviewEditPage() {
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed inset-x-0 bottom-0 mx-auto w-full max-w-[375px] border-t border-gray-100 bg-white px-4 pb-2 pt-3">
+      <FixedBottomContainer hasBorder>
         <button
           type="button"
           onClick={handleSubmit}
           disabled={!isValidForm || isSubmitting}
-          className={`flex w-full cursor-pointer items-center justify-center rounded-full py-4 text-body-1-semibold transition-colors ${
+          className={`flex h-14 w-full cursor-pointer items-center justify-center rounded-full text-body-1-semibold transition-colors ${
             isValidForm && !isSubmitting
               ? 'bg-gray-900 text-white'
-              : 'bg-gray-200 text-gray-600'
+              : 'cursor-not-allowed bg-gray-200 text-gray-600'
           }`}
         >
           {isSubmitting ? (
@@ -167,7 +168,7 @@ export default function ReviewEditPage() {
             '수정하기'
           )}
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(common)/mypage/reviews/write/[reservationId]/page.tsx
+++ b/src/app/(common)/mypage/reviews/write/[reservationId]/page.tsx
@@ -7,6 +7,7 @@ import { StarRatingInput } from '@/src/components/review';
 import { ReviewImageUploader } from '@/src/components/mypage/model-reviews';
 import { useUnreviewedReservations } from '@/src/hooks/queries/review';
 import { useReviewForm } from '@/src/hooks/custom/review';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import type { UnreviewedReservation } from '@/src/types';
 
 export default function ReviewWritePage() {
@@ -150,15 +151,15 @@ export default function ReviewWritePage() {
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed inset-x-0 bottom-0 mx-auto w-full max-w-[375px] border-t border-gray-100 bg-white px-4 pb-2 pt-3">
+      <FixedBottomContainer hasBorder>
         <button
           type="button"
           onClick={handleSubmit}
           disabled={!isValidForm || isSubmitting}
-          className={`flex w-full items-center justify-center rounded-full py-4 text-body-1-semibold transition-colors ${
+          className={`flex h-14 w-full cursor-pointer items-center justify-center rounded-full text-body-1-semibold transition-colors ${
             isValidForm && !isSubmitting
               ? 'bg-gray-900 text-white'
-              : 'bg-gray-200 text-gray-600'
+              : 'cursor-not-allowed bg-gray-200 text-gray-600'
           }`}
         >
           {isSubmitting ? (
@@ -167,7 +168,7 @@ export default function ReviewWritePage() {
             '작성하기'
           )}
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(common)/mypage/reviews/write/[reservationId]/page.tsx
+++ b/src/app/(common)/mypage/reviews/write/[reservationId]/page.tsx
@@ -156,7 +156,7 @@ export default function ReviewWritePage() {
           type="button"
           onClick={handleSubmit}
           disabled={!isValidForm || isSubmitting}
-          className={`flex h-14 w-full cursor-pointer items-center justify-center rounded-full text-body-1-semibold transition-colors ${
+          className={`flex h-[56px] w-full cursor-pointer items-center justify-center rounded-full text-body-1-semibold transition-colors ${
             isValidForm && !isSubmitting
               ? 'bg-gray-900 text-white'
               : 'cursor-not-allowed bg-gray-200 text-gray-600'

--- a/src/app/(common)/notification/page.tsx
+++ b/src/app/(common)/notification/page.tsx
@@ -43,7 +43,7 @@ export default function NotificationPage() {
   return (
     <div className="flex min-h-screen flex-col bg-white">
       {/* 헤더 */}
-      <header className="flex items-center justify-between px-4 py-3">
+      <header className="safe-area-top flex items-center justify-between px-4 py-3">
         <button
           type="button"
           onClick={() => router.push('/')}

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
@@ -199,12 +199,12 @@ export default function StepContent({ goNext, goPrev, isSubmitting = false, isEd
       </div>
 
       {/* 하단 등록 버튼 (Fixed) */}
-      <div className="fixed bottom-0 left-0 right-0 z-10 border-t border-gray-100 bg-white px-4 pt-3 pb-[calc(8px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 border-t border-gray-100 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <button
           type="button"
           onClick={goNext}
           disabled={!isSubmitButtonEnabled || isSubmitting}
-          className={`text-body-1-semibold flex w-full items-center justify-center rounded-full py-4 ${
+          className={`text-body-1-semibold flex h-14 w-full items-center justify-center rounded-full ${
             isSubmitButtonEnabled && !isSubmitting
               ? 'cursor-pointer bg-gray-900 text-white'
               : 'cursor-not-allowed bg-gray-200 text-gray-500'

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
@@ -199,7 +199,7 @@ export default function StepContent({ goNext, goPrev, isSubmitting = false, isEd
       </div>
 
       {/* 하단 등록 버튼 (Fixed) */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto w-full max-w-[375px] border-t border-gray-100 bg-white px-4 pt-3 pb-[calc(8px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-0 right-0 z-10 border-t border-gray-100 bg-white px-4 pt-3 pb-[calc(8px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
@@ -199,7 +199,7 @@ export default function StepContent({ goNext, goPrev, isSubmitting = false, isEd
       </div>
 
       {/* 하단 등록 버튼 (Fixed) */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto w-full max-w-[375px] border-t border-gray-100 bg-white px-4 pt-3 pb-2">
+      <div className="fixed right-0 bottom-0 left-0 mx-auto w-full max-w-[375px] border-t border-gray-100 bg-white px-4 pt-3 pb-[calc(8px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
@@ -14,6 +14,7 @@ import { getSubCategoryOptions } from '@/src/constants/explore';
 import { getUserCategory } from '@/src/stores';
 import { isStep2Valid } from '@/src/utils/myRecruitment';
 import type { PurposeType } from '@/src/types/myRecruitment';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 interface StepContentProps {
   goNext: () => void;
@@ -199,7 +200,7 @@ export default function StepContent({ goNext, goPrev, isSubmitting = false, isEd
       </div>
 
       {/* 하단 등록 버튼 (Fixed) */}
-      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 border-t border-gray-100 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer hasBorder>
         <button
           type="button"
           onClick={goNext}
@@ -216,7 +217,7 @@ export default function StepContent({ goNext, goPrev, isSubmitting = false, isEd
             isEdit ? '모집글 수정' : '새 모집글 등록'
           )}
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
@@ -142,7 +142,7 @@ export default function StepTitleDate({ goNext, goPrev, isEdit = false }: StepTi
       </div>
 
       {/* 하단 다음 버튼 (Fixed) */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto w-full max-w-[375px] bg-white px-4 py-3">
+      <div className="fixed right-0 bottom-0 left-0 mx-auto w-full max-w-[375px] bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
@@ -7,6 +7,7 @@ import TimeSelector from '@/src/components/myRecruitment/Calendar/TimeSelector';
 import TitleInput from '@/src/components/myRecruitment/Form/TitleInput';
 import { useRecruitmentFormStore } from '@/src/stores/myRecruitment/useRecruitmentFormStore';
 import { isStep1Valid } from '@/src/utils/myRecruitment';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 interface StepTitleDateProps {
   goNext: () => void;
@@ -142,7 +143,7 @@ export default function StepTitleDate({ goNext, goPrev, isEdit = false }: StepTi
       </div>
 
       {/* 하단 다음 버튼 (Fixed) */}
-      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <button
           type="button"
           onClick={goNext}
@@ -155,7 +156,7 @@ export default function StepTitleDate({ goNext, goPrev, isEdit = false }: StepTi
         >
           다음
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
@@ -142,12 +142,12 @@ export default function StepTitleDate({ goNext, goPrev, isEdit = false }: StepTi
       </div>
 
       {/* 하단 다음 버튼 (Fixed) */}
-      <div className="fixed bottom-0 left-0 right-0 z-10 bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <button
           type="button"
           onClick={goNext}
           disabled={!isNextButtonEnabled}
-          className={`text-body-1-semibold w-full rounded-full py-4 ${
+          className={`text-body-1-semibold h-14 w-full rounded-full ${
             isNextButtonEnabled
               ? 'cursor-pointer bg-gray-900 text-white'
               : 'cursor-not-allowed bg-gray-200 text-gray-600'

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
@@ -142,7 +142,7 @@ export default function StepTitleDate({ goNext, goPrev, isEdit = false }: StepTi
       </div>
 
       {/* 하단 다음 버튼 (Fixed) */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto w-full max-w-[375px] bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-0 right-0 z-10 bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(designer)/reservations/[reservationId]/page.tsx
+++ b/src/app/(designer)/reservations/[reservationId]/page.tsx
@@ -159,14 +159,14 @@ export default function ReservationDetailPage() {
             <button
               type="button"
               onClick={handleReject}
-              className="text-body-1-semibold h-14 flex-1 cursor-pointer rounded-full border border-gray-400 bg-white text-gray-900"
+              className="text-body-1-semibold h-[56px] flex-1 cursor-pointer rounded-full border border-gray-400 bg-white text-gray-900"
             >
               예약 거절
             </button>
             <button
               type="button"
               onClick={handleConfirm}
-              className="text-body-1-semibold h-14 flex-1 cursor-pointer rounded-full bg-gray-900 text-white"
+              className="text-body-1-semibold h-[56px] flex-1 cursor-pointer rounded-full bg-gray-900 text-white"
             >
               예약 확정
             </button>

--- a/src/app/(designer)/reservations/[reservationId]/page.tsx
+++ b/src/app/(designer)/reservations/[reservationId]/page.tsx
@@ -12,6 +12,7 @@ import {
   ReservationRejectModal,
   ReservationDetailSkeleton,
 } from '@/src/components/designerHome';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { useReservationDetail, useConfirmReservation, useRejectReservation } from '@/src/hooks/queries/designerHome';
 import { useCreateChatRoom } from '@/src/hooks/queries/chat';
 import { useToast } from '@/src/hooks/common/useToast';
@@ -153,22 +154,24 @@ export default function ReservationDetailPage() {
 
       {/* 하단 버튼 (예약대기 상태에서만 표시) */}
       {reservation.status === '예약대기' && (
-        <div className="fixed bottom-0 left-1/2 z-50 flex w-full -translate-x-1/2 gap-3 border-t border-gray-300 bg-white px-4 py-3 sm:w-[375px]">
-          <button
-            type="button"
-            onClick={handleReject}
-            className="text-body-1-semibold flex-1 cursor-pointer rounded-full border border-gray-400 bg-white py-4 text-gray-900"
-          >
-            예약 거절
-          </button>
-          <button
-            type="button"
-            onClick={handleConfirm}
-            className="text-body-1-semibold flex-1 cursor-pointer rounded-full bg-gray-900 py-4 text-white"
-          >
-            예약 확정
-          </button>
-        </div>
+        <FixedBottomContainer hasBorder>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={handleReject}
+              className="text-body-1-semibold h-14 flex-1 cursor-pointer rounded-full border border-gray-400 bg-white text-gray-900"
+            >
+              예약 거절
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirm}
+              className="text-body-1-semibold h-14 flex-1 cursor-pointer rounded-full bg-gray-900 text-white"
+            >
+              예약 확정
+            </button>
+          </div>
+        </FixedBottomContainer>
       )}
 
       {/* 예약 확정 완료 모달 */}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
@@ -116,7 +116,7 @@ export default function StepDateTime({
       </div>
 
       {/* 하단 버튼 */}
-      <div className="p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
+      <div className="bg-white p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
@@ -116,7 +116,7 @@ export default function StepDateTime({
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed bottom-0 left-0 right-0 z-10 bg-white p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
@@ -10,6 +10,7 @@ import {
 import { useReservationStore } from '@/src/stores/reservation/useReservationStore';
 import { useMonthNavigation } from '@/src/hooks/custom/myRecruitment';
 import { useAvailableSchedules } from '@/src/hooks/queries/reservation';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 interface StepDateTimeProps {
   recruitmentId: number;
@@ -116,7 +117,7 @@ export default function StepDateTime({
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <button
           type="button"
           onClick={goNext}
@@ -129,7 +130,7 @@ export default function StepDateTime({
         >
           다음
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
@@ -116,7 +116,7 @@ export default function StepDateTime({
       </div>
 
       {/* 하단 버튼 */}
-      <div className="p-4">
+      <div className="p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
@@ -72,7 +72,7 @@ export default function StepDateTime({
       <ReservationHeader onBack={goPrev} />
 
       {/* 콘텐츠 */}
-      <div className="flex flex-1 flex-col gap-6 px-4">
+      <div className="flex flex-1 flex-col gap-6 px-4 pb-[100px]">
         {/* 스텝 정보 */}
         <ReservationStepInfo
           currentStep={1}
@@ -116,7 +116,7 @@ export default function StepDateTime({
       </div>
 
       {/* 하단 버튼 */}
-      <div className="bg-white p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-0 right-0 z-10 bg-white p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
@@ -128,7 +128,7 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed bottom-0 left-0 right-0 z-10 bg-white p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
@@ -6,6 +6,7 @@ import { useReservationStore } from '@/src/stores/reservation/useReservationStor
 import { getReservationPresignedUrl } from '@/src/apis/reservation/model';
 import { uploadImageToS3 } from '@/src/apis/auth/profile';
 import { useToast } from '@/src/hooks/common/useToast';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 interface StepPhotoProps {
   category: string;
@@ -128,7 +129,7 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <button
           type="button"
           onClick={goNext}
@@ -139,7 +140,7 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
         >
           다음
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
@@ -128,7 +128,7 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
       </div>
 
       {/* 하단 버튼 */}
-      <div className="p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
+      <div className="bg-white p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
@@ -89,7 +89,7 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
       <ReservationHeader onBack={goPrev} />
 
       {/* 콘텐츠 */}
-      <div className="flex flex-1 flex-col gap-6 px-4">
+      <div className="flex flex-1 flex-col gap-6 px-4 pb-[100px]">
         {/* 스텝 정보 */}
         <div className="flex flex-col gap-2">
           <p className="text-[20px] leading-[1.4] font-normal tracking-[-0.4px]">
@@ -128,7 +128,7 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
       </div>
 
       {/* 하단 버튼 */}
-      <div className="bg-white p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-0 right-0 z-10 bg-white p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
@@ -128,7 +128,7 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
       </div>
 
       {/* 하단 버튼 */}
-      <div className="p-4">
+      <div className="p-4 pb-[calc(16px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
@@ -64,7 +64,7 @@ export default function StepContent({ goNext, goPrev }: StepContentProps) {
       </div>
 
       {/* 하단 버튼 */}
-      <div className="px-4 py-3">
+      <div className="px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
@@ -64,7 +64,7 @@ export default function StepContent({ goNext, goPrev }: StepContentProps) {
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed bottom-0 left-0 right-0 z-10 bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
@@ -64,7 +64,7 @@ export default function StepContent({ goNext, goPrev }: StepContentProps) {
       </div>
 
       {/* 하단 버튼 */}
-      <div className="px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
+      <div className="bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
@@ -2,6 +2,7 @@
 
 import { ReservationHeader } from '@/src/components/reservation';
 import { useReservationStore } from '@/src/stores/reservation/useReservationStore';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 const MAX_LENGTH = 100;
 
@@ -64,7 +65,7 @@ export default function StepContent({ goNext, goPrev }: StepContentProps) {
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <button
           type="button"
           onClick={goNext}
@@ -75,7 +76,7 @@ export default function StepContent({ goNext, goPrev }: StepContentProps) {
         >
           다음
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
@@ -30,7 +30,7 @@ export default function StepContent({ goNext, goPrev }: StepContentProps) {
       <ReservationHeader onBack={goPrev} />
 
       {/* 콘텐츠 */}
-      <div className="flex flex-1 flex-col gap-6 px-4">
+      <div className="flex flex-1 flex-col gap-6 px-4 pb-[100px]">
         {/* 스텝 정보 */}
         <div className="flex flex-col gap-2">
           <p className="text-[20px] leading-[1.4] font-normal tracking-[-0.4px]">
@@ -64,7 +64,7 @@ export default function StepContent({ goNext, goPrev }: StepContentProps) {
       </div>
 
       {/* 하단 버튼 */}
-      <div className="bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-0 right-0 z-10 bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={goNext}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
@@ -147,7 +147,7 @@ export default function StepConfirm({
       </div>
 
       {/* 하단 버튼 */}
-      <div className="px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
+      <div className="bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={handleReservation}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
@@ -147,7 +147,7 @@ export default function StepConfirm({
       </div>
 
       {/* 하단 버튼 */}
-      <div className="px-4 py-3">
+      <div className="px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={handleReservation}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
@@ -147,7 +147,7 @@ export default function StepConfirm({
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed bottom-0 left-0 right-0 z-10 bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
         <button
           type="button"
           onClick={handleReservation}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
@@ -9,6 +9,7 @@ import {
   subCategoryNameToCode,
   subCategoryCodeToName,
 } from '@/src/utils/myRecruitment/category/categoryMapping';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 interface StepConfirmProps {
   recruitmentId: number;
@@ -147,7 +148,7 @@ export default function StepConfirm({
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+      <FixedBottomContainer>
         <button
           type="button"
           onClick={handleReservation}
@@ -160,7 +161,7 @@ export default function StepConfirm({
         >
           {isPending ? '예약 중...' : '완료'}
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
@@ -114,7 +114,7 @@ export default function StepConfirm({
       <ReservationHeader onBack={goPrev} />
 
       {/* 콘텐츠 */}
-      <div className="flex flex-1 flex-col px-4 pt-1">
+      <div className="flex flex-1 flex-col px-4 pt-1 pb-[100px]">
         {/* 스텝 정보 */}
         <div className="flex flex-col gap-2">
           <p className="text-head-3 leading-140 font-normal tracking-[-0.4px] text-gray-900">4/4</p>
@@ -147,7 +147,7 @@ export default function StepConfirm({
       </div>
 
       {/* 하단 버튼 */}
-      <div className="bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
+      <div className="fixed bottom-0 left-0 right-0 z-10 bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
         <button
           type="button"
           onClick={handleReservation}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/5-StepComplete.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/5-StepComplete.tsx
@@ -26,7 +26,7 @@ export default function StepComplete() {
       <button
         type="button"
         onClick={handleConfirm}
-        className="text-body-1-medium fixed bottom-3 left-1/2 w-[calc(100%-2rem)] max-w-[343px] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 text-white"
+        className="text-body-1-medium fixed bottom-[calc(12px+env(safe-area-inset-bottom))] left-1/2 w-[calc(100%-2rem)] max-w-[343px] -translate-x-1/2 cursor-pointer rounded-full bg-gray-900 py-4 text-white"
       >
         확인
       </button>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
   },
   appleWebApp: {
     capable: true,
-    statusBarStyle: 'black-translucent',
+    statusBarStyle: 'default',
     title: 'Moandi',
   },
   openGraph: {

--- a/src/components/common/FixedBottomContainer.tsx
+++ b/src/components/common/FixedBottomContainer.tsx
@@ -1,0 +1,19 @@
+interface FixedBottomContainerProps {
+  children: React.ReactNode;
+  hasBorder?: boolean;
+  className?: string;
+}
+
+export function FixedBottomContainer({
+  children,
+  hasBorder = false,
+  className = '',
+}: FixedBottomContainerProps) {
+  return (
+    <div
+      className={`fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px] ${hasBorder ? 'border-t border-gray-100' : ''} ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/FixedBottomContainer.tsx
+++ b/src/components/common/FixedBottomContainer.tsx
@@ -11,7 +11,7 @@ export function FixedBottomContainer({
 }: FixedBottomContainerProps) {
   return (
     <div
-      className={`fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px] ${hasBorder ? 'border-t border-gray-100' : ''} ${className}`}
+      className={`fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(6px+env(safe-area-inset-bottom))] sm:w-[375px] ${hasBorder ? 'border-t border-gray-100' : ''} ${className}`}
     >
       {children}
     </div>

--- a/src/components/designerProfile/DesignerProfileHeader.tsx
+++ b/src/components/designerProfile/DesignerProfileHeader.tsx
@@ -17,7 +17,7 @@ export default function DesignerProfileHeader({ actionType = 'none', onBack, onA
   const ActionIcon = actionType === 'edit' ? EditIcon : ShareIcon;
 
   return (
-    <header className="absolute top-0 right-0 left-0 z-10 flex h-13 items-center justify-between px-4 py-3.5">
+    <header className="safe-area-top absolute top-0 right-0 left-0 z-10 flex h-13 items-center justify-between px-4 py-3.5">
       <button
         type="button"
         aria-label="뒤로가기"

--- a/src/components/map/MapControls.tsx
+++ b/src/components/map/MapControls.tsx
@@ -17,7 +17,7 @@ export default function MapControls({
     <button
       type="button"
       onClick={onRefreshSearch}
-      className="absolute top-4 left-1/2 z-10 flex -translate-x-1/2 cursor-pointer items-center gap-1 rounded-[34px] border border-gray-400 bg-white px-3 py-2 shadow-sm"
+      className="absolute top-[calc(16px+env(safe-area-inset-top))] left-1/2 z-10 flex -translate-x-1/2 cursor-pointer items-center gap-1 rounded-[34px] border border-gray-400 bg-white px-3 py-2 shadow-sm"
     >
       <RefreshIcon className="size-6 text-gray-800" />
       <span className="text-body-2-medium text-gray-900">현 지도에서 검색</span>

--- a/src/components/post/Actions/PostActions.tsx
+++ b/src/components/post/Actions/PostActions.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { useCreateChatRoom } from '@/src/hooks/queries/chat';
 import { useToast } from '@/src/hooks/common/useToast';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 interface PostActionsProps {
   recruitmentId: number;
@@ -30,7 +31,7 @@ export default function PostActions({ recruitmentId, designerUserId }: PostActio
   };
 
   return (
-    <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 border-t border-gray-100 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+    <FixedBottomContainer hasBorder>
       <div className="flex gap-2">
         <button
           type="button"
@@ -52,6 +53,6 @@ export default function PostActions({ recruitmentId, designerUserId }: PostActio
           예약하기
         </button>
       </div>
-    </div>
+    </FixedBottomContainer>
   );
 }

--- a/src/components/post/Actions/PostActions.tsx
+++ b/src/components/post/Actions/PostActions.tsx
@@ -30,7 +30,7 @@ export default function PostActions({ recruitmentId, designerUserId }: PostActio
   };
 
   return (
-    <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 border-t border-gray-100 bg-white px-4 pt-3 pb-2 sm:w-[375px]">
+    <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 border-t border-gray-100 bg-white px-4 pt-3 pb-[calc(8px+env(safe-area-inset-bottom))] sm:w-[375px]">
       <div className="flex gap-2">
         <button
           type="button"

--- a/src/components/post/Actions/PostActions.tsx
+++ b/src/components/post/Actions/PostActions.tsx
@@ -37,7 +37,7 @@ export default function PostActions({ recruitmentId, designerUserId }: PostActio
           type="button"
           onClick={handleChat}
           disabled={createChatRoom.isPending}
-          className={`text-body-1-semibold flex-1 rounded-full border h-14 ${
+          className={`text-body-1-semibold flex-1 rounded-full border h-[56px] ${
             createChatRoom.isPending
               ? 'cursor-not-allowed border-gray-300 text-gray-400'
               : 'cursor-pointer border-gray-400 text-gray-900'
@@ -48,7 +48,7 @@ export default function PostActions({ recruitmentId, designerUserId }: PostActio
         <button
           type="button"
           onClick={handleReservation}
-          className="text-body-1-semibold flex-1 cursor-pointer rounded-full bg-gray-900 h-14 text-white"
+          className="text-body-1-semibold flex-1 cursor-pointer rounded-full bg-gray-900 h-[56px] text-white"
         >
           예약하기
         </button>

--- a/src/components/post/Actions/PostActions.tsx
+++ b/src/components/post/Actions/PostActions.tsx
@@ -30,13 +30,13 @@ export default function PostActions({ recruitmentId, designerUserId }: PostActio
   };
 
   return (
-    <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 border-t border-gray-100 bg-white px-4 pt-3 pb-[calc(8px+env(safe-area-inset-bottom))] sm:w-[375px]">
+    <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 border-t border-gray-100 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
       <div className="flex gap-2">
         <button
           type="button"
           onClick={handleChat}
           disabled={createChatRoom.isPending}
-          className={`text-body-1-semibold flex-1 rounded-full border py-4 ${
+          className={`text-body-1-semibold flex-1 rounded-full border h-14 ${
             createChatRoom.isPending
               ? 'cursor-not-allowed border-gray-300 text-gray-400'
               : 'cursor-pointer border-gray-400 text-gray-900'
@@ -47,7 +47,7 @@ export default function PostActions({ recruitmentId, designerUserId }: PostActio
         <button
           type="button"
           onClick={handleReservation}
-          className="text-body-1-semibold flex-1 cursor-pointer rounded-full bg-gray-900 py-4 text-white"
+          className="text-body-1-semibold flex-1 cursor-pointer rounded-full bg-gray-900 h-14 text-white"
         >
           예약하기
         </button>

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -367,7 +367,7 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
       {/* 하단 액션 버튼 */}
       {isOwner ? (
         // 본인 공고: 수정하기 버튼
-        <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))] sm:w-[375px]">
+        <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
           <button
             type="button"
             onClick={() => router.push(`/myRecruitment/${recruitmentId}/edit`)}

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -372,7 +372,7 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
           <button
             type="button"
             onClick={() => router.push(`/myRecruitment/${recruitmentId}/edit`)}
-            className="text-body-1-semibold h-14 w-full cursor-pointer rounded-full bg-gray-900 text-white"
+            className="text-body-1-semibold h-[56px] w-full cursor-pointer rounded-full bg-gray-900 text-white"
           >
             수정하기
           </button>

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -367,7 +367,7 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
       {/* 하단 액션 버튼 */}
       {isOwner ? (
         // 본인 공고: 수정하기 버튼
-        <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 py-3 sm:w-[375px]">
+        <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))] sm:w-[375px]">
           <button
             type="button"
             onClick={() => router.push(`/myRecruitment/${recruitmentId}/edit`)}

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/src/hooks/queries/review';
 import CheckIcon from '@/public/icons/post/check.svg';
 import CloseIcon from '@/public/icons/common/close.svg';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 interface PostDetailContentProps {
   recruitmentId: number;
@@ -367,7 +368,7 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
       {/* 하단 액션 버튼 */}
       {isOwner ? (
         // 본인 공고: 수정하기 버튼
-        <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 pt-3 pb-[calc(4px+env(safe-area-inset-bottom))] sm:w-[375px]">
+        <FixedBottomContainer>
           <button
             type="button"
             onClick={() => router.push(`/myRecruitment/${recruitmentId}/edit`)}
@@ -375,7 +376,7 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
           >
             수정하기
           </button>
-        </div>
+        </FixedBottomContainer>
       ) : (
         // 다른 사람 공고: 채팅하기 / 예약하기
         <PostActions recruitmentId={detail.recruitmentId} designerUserId={detail.designerProfile.userId} />

--- a/src/components/post/Skeleton/PostPageSkeleton.tsx
+++ b/src/components/post/Skeleton/PostPageSkeleton.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from '@/src/components/common/Skeleton';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import ImageGallerySkeleton from './ImageGallerySkeleton';
 import PostInfoSkeleton from './PostInfoSkeleton';
 import PostContentSkeleton from './PostContentSkeleton';
@@ -16,11 +17,12 @@ export default function PostPageSkeleton() {
       <PostContentSkeleton />
 
       {/* 하단 버튼 영역 */}
-      <div className="h-[88px]" />
-      <div className="fixed right-0 bottom-0 left-0 flex gap-2 border-t border-gray-200 bg-white px-4 py-3">
-        <Skeleton className="h-12 flex-1 rounded-full" />
-        <Skeleton className="h-12 flex-1 rounded-full" />
-      </div>
+      <FixedBottomContainer hasBorder>
+        <div className="flex gap-2">
+          <Skeleton className="h-[56px] flex-1 rounded-full" />
+          <Skeleton className="h-[56px] flex-1 rounded-full" />
+        </div>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/components/signup/common/FixedBottomButton.tsx
+++ b/src/components/signup/common/FixedBottomButton.tsx
@@ -8,7 +8,7 @@ export const FixedBottomButton: React.FC<FixedBottomButtonProps> = ({ onClick, d
   return (
     <button
       type="button"
-      className={`text-body-1-semibold mx-auto flex w-full cursor-pointer items-center justify-center rounded-full h-14 tracking-tight sm:w-[343px] ${
+      className={`text-body-1-semibold mx-auto flex w-full cursor-pointer items-center justify-center rounded-full h-[56px] tracking-tight sm:w-[343px] ${
         disabled ? 'bg-gray-200 text-gray-600' : 'bg-black text-white'
       }`}
       disabled={disabled}

--- a/src/components/signup/common/FixedBottomButton.tsx
+++ b/src/components/signup/common/FixedBottomButton.tsx
@@ -8,7 +8,7 @@ export const FixedBottomButton: React.FC<FixedBottomButtonProps> = ({ onClick, d
   return (
     <button
       type="button"
-      className={`text-body-1-semibold mx-auto flex w-full cursor-pointer items-center justify-center rounded-full py-4 tracking-tight sm:w-[343px] ${
+      className={`text-body-1-semibold mx-auto flex w-full cursor-pointer items-center justify-center rounded-full h-14 tracking-tight sm:w-[343px] ${
         disabled ? 'bg-gray-200 text-gray-600' : 'bg-black text-white'
       }`}
       disabled={disabled}


### PR DESCRIPTION
### 💡 To Reviewers

- 새롭게 설치한 라이브러리 없음
- iOS PWA에서 Safe-Area (상단 노치, 하단 홈 인디케이터) 처리를 위한 레이아웃 수정입니다.
- `env(safe-area-inset-top)`, `env(safe-area-inset-bottom)` CSS 환경 변수를 활용했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

**1. 상단 Safe-Area 적용**
- 알림 페이지 헤더
- 디자이너 프로필 헤더  
- 지도 검색 버튼

**2. 하단 버튼 레이아웃 통일**

모든 하단 버튼을 아래 패턴으로 통일:
- 버튼 높이: `h-[56px]` (px 단위로 고정)
- 하단 간격: `pb-[calc(4px+env(safe-area-inset-bottom))]`
- 센터 정렬: `fixed bottom-0 left-1/2 -translate-x-1/2 w-full sm:w-[375px] px-4`

**3. FixedBottomContainer 공통 컴포넌트 생성**

반복되는 하단 고정 레이아웃을 공통 컴포넌트로 추출:

```tsx
<FixedBottomContainer>
  <FixedBottomButton>다음</FixedBottomButton>
</FixedBottomContainer>

// 상단 border가 필요한 경우
<FixedBottomContainer hasBorder>
  <button>등록</button>
</FixedBottomContainer>
```

적용 페이지 (총 25개 파일):
| 영역 | 파일 |
|------|------|
| 공고 상세 | PostActions.tsx, PostDetailContent.tsx |
| 예약 Funnel | 1-StepDateTime ~ 4-StepConfirm (4개) |
| 모집글 생성 | StepTitleDate.tsx, StepContent.tsx |
| 회원가입 | 1-Terms ~ 6-Complete (6개) |
| 아이디 찾기 | 1-Input.tsx, 2-Complete.tsx |
| 비밀번호 찾기 | 1-Input ~ 4-SocialUser (4개) |
| 리뷰 작성/수정 | write/[reservationId], edit/[reviewId] |
| 프로필 수정 | profile/edit/page.tsx |
| 디자이너 예약 상세 | reservations/[reservationId]/page.tsx |

**4. 버튼 높이 px 단위 변경**
- `h-14` (rem 기반) → `h-[56px]` (px 고정)으로 변경
- 다양한 디바이스에서 일관된 버튼 크기 보장

**5. 상태바 스타일 변경**
- `statusBarStyle: 'black-translucent'` → `'default'`로 변경

### 🤔 추후 작업 예정

- QA 테스트 후 추가 수정 필요 시 진행

### 📸 작업 결과 (스크린샷)

- iOS PWA 환경에서 테스트 필요

### 🔗 관련 이슈

- #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Style**
  * 모바일 기기의 안전 영역을 반영하여 상단 및 하단 요소의 위치 조정
  * 여러 페이지에서 하단 액션 버튼의 높이와 간격을 일관되게 표준화

* **Refactor**
  * 하단 액션 영역 컴포넌트 구조 개선으로 레이아웃 일관성 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->