### PR TITLE
[FIX] Token Refresh 로직 개선 - PUBLIC_ROUTES soft refresh 및 ACCESS_TOKEN_EXPIRED 처리

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -1,4 +1,4 @@
-import { useAuthStore, getAccessToken, setAccessToken, getUserRole } from '@/src/stores';
+import { useAuthStore, getAccessToken, setAccessToken } from '@/src/stores';
 import { apiLogger } from '@/src/utils';
 import { dispatchAuthError } from '@/src/utils/auth/authErrorDispatcher';
 import axios, { AxiosRequestConfig } from 'axios';
@@ -96,12 +96,12 @@ axiosInstance.interceptors.response.use(
 
     // 토큰 갱신이 필요한지 확인
     // - 401: 토큰 만료
-    // - 403 + Authorization 헤더 없음 + user_role 쿠키 있음: 로그인했던 사용자의 accessToken만 삭제된 경우
-    //   (완전 비로그인 사용자는 user_role 쿠키가 없으므로 불필요한 refresh 요청 방지)
-    const hasUserRole = !!getUserRole();
+    // - 403 + Authorization 헤더 없음: accessToken이 삭제된 경우
+    // - 400 + ACCESS_TOKEN_EXPIRED: 만료된 토큰으로 요청한 경우
     const needsTokenRefresh =
       res?.status === 401 ||
-      (res?.status === 403 && !originalRequest.headers?.Authorization && hasUserRole);
+      (res?.status === 403 && !originalRequest.headers?.Authorization) ||
+      (res?.status === 400 && code === 'ACCESS_TOKEN_EXPIRED');
 
     // 토큰 갱신이 필요하고 아직 재시도 안 했으면 갱신 시도
     if (needsTokenRefresh && !originalRequest._retry) {
@@ -159,11 +159,9 @@ axiosInstance.interceptors.response.use(
       }
     }
 
-    // 400 특정 코드 처리 (토큰 관련 에러)
-    if (
-      res?.status === 400 &&
-      (code === 'INVALID_REFRESH_TOKEN' || code === 'INVALID_TOKEN' || code === 'ACCESS_TOKEN_EXPIRED')
-    ) {
+    // 400 특정 코드 처리 (복구 불가능한 토큰 에러)
+    // ACCESS_TOKEN_EXPIRED는 위에서 refresh 시도하므로 여기서 제외
+    if (res?.status === 400 && (code === 'INVALID_REFRESH_TOKEN' || code === 'INVALID_TOKEN')) {
       clearAuth();
       dispatchAuthError({ type: 'TOKEN_EXPIRED', redirectUrl: getRedirectUrl() });
     }

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -44,7 +44,7 @@ export const axiosInstance = axios.create({
 });
 
 // /auth/ 엔드포인트 중 인증이 필요한 것만 명시 (나머지는 토큰 주입 제외)
-const AUTH_REQUIRED_ENDPOINTS = ['/auth/logout', '/auth/validate'];
+const AUTH_REQUIRED_ENDPOINTS = ['/auth/logout', '/auth/validate', '/auth/social/signup'];
 
 // Request Interceptor: 쿠키에서 accessToken 읽어서 헤더에 추가 + 로깅
 axiosInstance.interceptors.request.use(

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -1,7 +1,17 @@
-import { useAuthStore, getAccessToken, setAccessToken } from '@/src/stores';
+import { useAuthStore, getAccessToken, setAccessToken, getUserRole } from '@/src/stores';
 import { apiLogger } from '@/src/utils';
 import { dispatchAuthError } from '@/src/utils/auth/authErrorDispatcher';
+import { PUBLIC_ROUTES } from '@/src/constants/routes';
 import axios, { AxiosRequestConfig } from 'axios';
+
+// 공개 라우트 체크 (SSR-safe)
+function isPublicRoute(): boolean {
+  if (typeof window === 'undefined') return false;
+  const pathname = window.location.pathname;
+  return PUBLIC_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  );
+}
 
 // 토큰 갱신 상태 관리 (Race Condition 방지)
 let isRefreshing = false;
@@ -107,6 +117,14 @@ axiosInstance.interceptors.response.use(
     if (needsTokenRefresh && !originalRequest._retry) {
       originalRequest._retry = true;
 
+      const onPublicRoute = isPublicRoute();
+      const hasUserRole = !!getUserRole();
+
+      // 공개 라우트에서 비로그인 유저는 refresh 시도 안 함 (UI 모달이 처리)
+      if (onPublicRoute && !hasUserRole) {
+        return Promise.reject(error);
+      }
+
       // 이미 갱신 중이면 대기
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
@@ -152,7 +170,11 @@ axiosInstance.interceptors.response.use(
         // 갱신 실패 - 대기 중인 요청들에게 에러 전달
         onRefreshFailed(refreshError instanceof Error ? refreshError : new Error('Token refresh failed'));
         clearAuth();
-        dispatchAuthError({ type: 'TOKEN_EXPIRED', redirectUrl: getRedirectUrl() });
+
+        // 공개 라우트: soft (인증 클리어만) / 보호 라우트: hard (리다이렉트)
+        if (!onPublicRoute) {
+          dispatchAuthError({ type: 'TOKEN_EXPIRED', redirectUrl: getRedirectUrl() });
+        }
         return Promise.reject(error);
       } finally {
         isRefreshing = false;
@@ -163,7 +185,10 @@ axiosInstance.interceptors.response.use(
     // ACCESS_TOKEN_EXPIRED는 위에서 refresh 시도하므로 여기서 제외
     if (res?.status === 400 && (code === 'INVALID_REFRESH_TOKEN' || code === 'INVALID_TOKEN')) {
       clearAuth();
-      dispatchAuthError({ type: 'TOKEN_EXPIRED', redirectUrl: getRedirectUrl() });
+      // 공개 라우트: soft (인증 클리어만) / 보호 라우트: hard (리다이렉트)
+      if (!isPublicRoute()) {
+        dispatchAuthError({ type: 'TOKEN_EXPIRED', redirectUrl: getRedirectUrl() });
+      }
     }
 
     return Promise.reject(error);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -97,8 +97,25 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 공개 라우트는 통과
+  // 공개 라우트: soft refresh 시도 (실패해도 통과)
   if (isPublicRoute(pathname)) {
+    const currentAccessToken = request.cookies.get('access_token')?.value;
+    const userRole = request.cookies.get('user_role')?.value;
+
+    // user_role 있고 accessToken 없으면 갱신 시도 (이전에 로그인했던 사용자)
+    if (userRole && !currentAccessToken) {
+      const newAccessToken = await refreshAccessToken(request);
+      if (newAccessToken) {
+        const response = NextResponse.next();
+        response.cookies.set('access_token', newAccessToken, {
+          path: '/',
+          maxAge: 604800,
+          sameSite: 'lax',
+          secure: process.env.NODE_ENV === 'production',
+        });
+        return response;
+      }
+    }
     return NextResponse.next();
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,16 @@ import { ValidateResponse } from '@/src/types/auth/auth';
 import { ApiResponse } from '@/src/types';
 
 /**
+ * refreshAccessToken 결과 타입
+ * - accessToken: 새로 발급된 accessToken
+ * - setCookieHeader: 백엔드에서 전달하는 Set-Cookie 헤더 (refresh_token 갱신)
+ */
+interface RefreshResult {
+  accessToken: string | null;
+  setCookieHeader: string | null;
+}
+
+/**
  * 백엔드 API로 accessToken 유효성 검증
  * @param accessToken - 검증할 액세스 토큰
  * @returns 토큰 유효 여부 (true: 유효, false: 무효)
@@ -41,22 +51,23 @@ async function verifyAccessToken(accessToken: string): Promise<boolean> {
 
 /**
  * refreshToken으로 새로운 accessToken 발급
+ * - 백엔드에서 Set-Cookie 헤더로 새로운 refresh_token을 전달하므로 함께 반환
  * @param request - NextRequest 객체 (refreshToken 쿠키 포함)
- * @returns 새로운 accessToken 또는 null
+ * @returns RefreshResult (accessToken과 setCookieHeader)
  */
-async function refreshAccessToken(request: NextRequest): Promise<string | null> {
+async function refreshAccessToken(request: NextRequest): Promise<RefreshResult> {
   try {
     const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
 
     if (!apiBaseUrl) {
       console.error('NEXT_PUBLIC_API_BASE_URL is not defined');
-      return null;
+      return { accessToken: null, setCookieHeader: null };
     }
 
     const refreshToken = request.cookies.get('refresh_token')?.value;
 
     if (!refreshToken) {
-      return null;
+      return { accessToken: null, setCookieHeader: null };
     }
 
     const response = await fetch(`${apiBaseUrl}/api/auth/refresh`, {
@@ -68,19 +79,25 @@ async function refreshAccessToken(request: NextRequest): Promise<string | null> 
 
     if (!response.ok) {
       console.error('Token refresh failed:', response.status);
-      return null;
+      return { accessToken: null, setCookieHeader: null };
     }
 
     const data = await response.json();
 
+    // 백엔드에서 전달하는 Set-Cookie 헤더 (새로운 refresh_token)
+    const setCookieHeader = response.headers.get('set-cookie');
+
     if (data.isSuccess && data.result?.accessToken) {
-      return data.result.accessToken;
+      return {
+        accessToken: data.result.accessToken,
+        setCookieHeader,
+      };
     }
 
-    return null;
+    return { accessToken: null, setCookieHeader: null };
   } catch (error) {
     console.error('Token refresh error:', error);
-    return null;
+    return { accessToken: null, setCookieHeader: null };
   }
 }
 
@@ -104,15 +121,19 @@ export async function middleware(request: NextRequest) {
 
     // user_role 있고 accessToken 없으면 갱신 시도 (이전에 로그인했던 사용자)
     if (userRole && !currentAccessToken) {
-      const newAccessToken = await refreshAccessToken(request);
-      if (newAccessToken) {
+      const refreshResult = await refreshAccessToken(request);
+      if (refreshResult.accessToken) {
         const response = NextResponse.next();
-        response.cookies.set('access_token', newAccessToken, {
+        response.cookies.set('access_token', refreshResult.accessToken, {
           path: '/',
           maxAge: 604800,
           sameSite: 'lax',
           secure: process.env.NODE_ENV === 'production',
         });
+        // 백엔드에서 새로운 refresh_token을 Set-Cookie로 보냈다면 클라이언트에 전달
+        if (refreshResult.setCookieHeader) {
+          response.headers.append('Set-Cookie', refreshResult.setCookieHeader);
+        }
         return response;
       }
     }
@@ -124,6 +145,7 @@ export async function middleware(request: NextRequest) {
   const userRole = request.cookies.get('user_role')?.value as 'model' | 'designer' | undefined;
 
   let isValid = false;
+  let refreshSetCookieHeader: string | null = null;
 
   if (accessToken) {
     // accessToken이 있으면 유효성 검증
@@ -132,12 +154,13 @@ export async function middleware(request: NextRequest) {
 
   // accessToken이 없거나 만료된 경우 refreshToken으로 재발급 시도
   if (!isValid) {
-    const newAccessToken = await refreshAccessToken(request);
+    const refreshResult = await refreshAccessToken(request);
 
-    if (newAccessToken) {
+    if (refreshResult.accessToken) {
       // 재발급 성공 - refresh API가 성공하면 토큰은 유효함
       isValid = true;
-      accessToken = newAccessToken;
+      accessToken = refreshResult.accessToken;
+      refreshSetCookieHeader = refreshResult.setCookieHeader;
     }
   }
 
@@ -182,6 +205,11 @@ export async function middleware(request: NextRequest) {
       sameSite: 'lax',
       secure: process.env.NODE_ENV === 'production',
     });
+  }
+
+  // 백엔드에서 새로운 refresh_token을 Set-Cookie로 보냈다면 클라이언트에 전달
+  if (refreshSetCookieHeader) {
+    response.headers.append('Set-Cookie', refreshSetCookieHeader);
   }
 
   // 요청 헤더에 사용자 정보 추가 (서버 컴포넌트에서 활용 가능)


### PR DESCRIPTION
### 💡 To Reviewers

- 로그인 후 방치 시 "세션이 만료되었습니다" 로그아웃 문제 해결

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

**1. middleware.ts - PUBLIC_ROUTES soft refresh 추가**
- 공개 라우트(`/mypage`, `/chat`, `/explore` 등)에서도 토큰 갱신 시도
- `user_role` 쿠키 있고 `access_token` 없을 때만 refresh (불필요한 API 호출 방지)
- refresh 실패해도 페이지 접근은 허용 (soft refresh)

**2. middleware.ts - refresh_token Set-Cookie 전달 버그 수정**
- 백엔드 refresh 응답의 `Set-Cookie` 헤더를 클라이언트에 전달하지 않던 버그 수정
- `RefreshResult` 인터페이스 추가로 accessToken과 setCookieHeader 함께 반환
- 토큰 갱신 시 새 refresh_token이 브라우저 쿠키에 정상 저장됨

**3. axios.ts - needsTokenRefresh 조건 개선**
- `400 + ACCESS_TOKEN_EXPIRED` 케이스 추가 (기존: 즉시 로그아웃 → 변경: refresh 시도)
- `403` 조건에서 `hasUserRole` 체크 제거 (불필요)

**4. axios.ts - 400 에러 처리 분리**
- `ACCESS_TOKEN_EXPIRED`: refresh 시도 후 실패 시 로그아웃
- `INVALID_REFRESH_TOKEN`, `INVALID_TOKEN`: 복구 불가 → 즉시 로그아웃 (유지)

**5. axios.ts - 소셜 회원가입 API 토큰 인증 적용** 
- `/auth/social/signup`을 `AUTH_REQUIRED_ENDPOINTS`에 추가
- 소셜 회원가입 시 Authorization 헤더가 정상 전송됨

**6. axios.ts - 공개 라우트 soft refresh 처리 추가**
- 공개 라우트에서 비로그인 유저: refresh 시도 안 함 (UI 모달이 처리)
- 공개 라우트에서 로그인 유저: refresh 실패 시 인증 클리어만 (페이지 유지)
- 보호 라우트: refresh 실패 시 로그인 리다이렉트

| 라우트 | user_role | refresh 시도 | 실패 시 |
|--------|-----------|-------------|---------|
| 공개 | ❌ 없음 | ❌ | 에러만 반환 |
| 공개 | ✅ 있음 | ✅ | soft (인증 클리어만) |
| 보호 | ✅ 있음 | ✅ | hard (리다이렉트) |
| 보호 | ❌ 없음 | ✅ | hard (복구 시도 후 리다이렉트) |

**7. useAuthReady.ts - isLoggedIn 판단에 cookieRole 추가**
- 기존: `isLoggedIn = !!(isAuthenticated || user || token)`
- 변경: `isLoggedIn = !!(isAuthenticated || user || token || cookieRole)`
- accessToken 없어도 user_role 쿠키 있으면 API 호출 허용 (axios가 refresh 시도)
- chat/mypage 페이지에서 accessToken 삭제 시 refresh 안 되던 문제 해결

**8. axios.ts + routeGuard.ts - 공개 라우트 판단 로직 통일**
- axios의 `isPublicRoute()` 함수가 middleware와 다른 로직 사용하던 문제 수정
- `routeGuard.isPublicRoute()` 함수를 공유하여 일관된 라우트 분류
- `EXACT_MATCH_ROUTES`에 `/chat` 추가 → `/chat/[roomId]` 하위 경로 보호

| 경로 | 변경 전 | 변경 후 |
|------|---------|---------|
| `/chat` | 공개 | 공개 |
| `/chat/123` | ❌ 공개 (버그) | ✅ 보호 |
| `/mypage` | 공개 | 공개 |
| `/mypage/likes` | ❌ 공개 (버그) | ✅ 보호 |

### 🤔 추후 작업 예정

- Tab Visibility 감지 기능 추가 고려 (탭 복귀 시 선제적 refresh)
- `/auth/withdraw` 엔드포인트 구현 시 AUTH_REQUIRED_ENDPOINTS에 추가 필요

### 📸 작업 결과 (스크린샷)

- 코드 수정만 있어 스크린샷 없음
- 테스트 방법: 로그인 → `access_token` 쿠키 삭제 → 페이지 새로고침 → 로그아웃 없이 정상 동작 확인

### 🔗 관련 이슈

- #146