### PR TITLE
[FIX] 디자이너 로그인 시 explore/map/post 라우트 접근 차단

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -23,6 +23,9 @@ export const MODEL_ONLY_ROUTES: string[] = [
   '/reservation', // 예약
 ];
 
+// ===== 디자이너 접근 차단 라우트 (모델/비로그인만 허용) =====
+export const DESIGNER_BLOCKED_ROUTES = ['/explore', '/map', '/post'];
+
 // ===== 디자이너 전용 라우트 =====
 export const DESIGNER_ONLY_ROUTES = [
   '/myRecruitment', // 내 공고 관리 (목록, 생성, 수정, 상세)

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { isPublicRoute, checkRoleAccess } from '@/src/utils/middleware/routeGuard';
+import { isPublicRoute, checkRoleAccess, isDesignerBlockedRoute } from '@/src/utils/middleware/routeGuard';
 import { ValidateResponse } from '@/src/types/auth/auth';
 import { ApiResponse } from '@/src/types';
 
@@ -118,6 +118,11 @@ export async function middleware(request: NextRequest) {
   if (isPublicRoute(pathname)) {
     const currentAccessToken = request.cookies.get('access_token')?.value;
     const userRole = request.cookies.get('user_role')?.value;
+
+    // 디자이너가 차단된 라우트에 접근 시 홈으로 리다이렉트
+    if (userRole === 'designer' && isDesignerBlockedRoute(pathname)) {
+      return NextResponse.redirect(new URL('/', request.url));
+    }
 
     // user_role 있고 accessToken 없으면 갱신 시도 (이전에 로그인했던 사용자)
     if (userRole && !currentAccessToken) {

--- a/src/utils/middleware/routeGuard.ts
+++ b/src/utils/middleware/routeGuard.ts
@@ -2,6 +2,7 @@ import {
   PUBLIC_ROUTES,
   MODEL_ONLY_ROUTES,
   DESIGNER_ONLY_ROUTES,
+  DESIGNER_BLOCKED_ROUTES,
   AUTHENTICATED_ROUTES,
 } from '@/src/constants/routes';
 
@@ -50,4 +51,11 @@ export function checkRoleAccess(pathname: string, role: string): boolean {
   }
   // 미등록 라우트는 기본 차단 (보안 강화)
   return false;
+}
+
+/**
+ * 디자이너 차단 라우트 확인
+ */
+export function isDesignerBlockedRoute(pathname: string): boolean {
+  return DESIGNER_BLOCKED_ROUTES.some((route) => matchRoute(pathname, route));
 }


### PR DESCRIPTION
### 💡 To Reviewers

- 기존 토큰 인증 시스템과 충돌 없음 확인 완료

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 디자이너 접근 차단 라우트 상수 추가 (`DESIGNER_BLOCKED_ROUTES`)
- 디자이너 차단 라우트 체크 함수 추가 (`isDesignerBlockedRoute`)
- 미들웨어에서 공개 라우트 접근 시 디자이너 차단 로직 추가

**차단 대상 라우트**: `/explore`, `/map`, `/post` (및 하위 경로)

| 사용자 | 차단 라우트 접근 시 |
|--------|------------------|
| 디자이너 | 홈으로 리다이렉트 |
| 모델 | 정상 접근 |
| 비로그인 | 정상 접근 |

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 디자이너 계정으로 `/explore`, `/map`, `/post` 접근 시 홈으로 리다이렉트 확인

### 🔗 관련 이슈

- #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 특정 사용자 그룹이 탐색, 지도, 게시 페이지에 접근할 수 없도록 제한되었습니다. 접근 시도 시 홈페이지로 자동 리다이렉트됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->