### PR TITLE
[FIX] FCM 알림 권한 상태 관리 개선

### DIFF
--- a/src/app/(common)/mypage/notification-settings/page.tsx
+++ b/src/app/(common)/mypage/notification-settings/page.tsx
@@ -232,7 +232,10 @@ export default function NotificationSettingsPage() {
       {/* 상태 안내 배너 (컴포넌트로 분리) */}
       <NotificationStatusBanner
         uiConfig={uiConfig}
-        onResetDismissed={resetDismissed}
+        onResetDismissed={() => {
+          resetDismissed();
+          setPermissionModalDismissed(false);
+        }}
       />
 
       {/* 알림 설정 리스트 */}

--- a/src/app/(common)/mypage/notification-settings/page.tsx
+++ b/src/app/(common)/mypage/notification-settings/page.tsx
@@ -4,9 +4,14 @@ import { useEffect, useState, useSyncExternalStore } from 'react';
 import { useRouter } from 'next/navigation';
 import ArrowLeftIcon from '@/public/icons/common/arrow-left.svg';
 import { Toggle, ConfirmModal } from '@/src/components/common';
+import { NotificationStatusBanner } from '@/src/components/notification';
 import { getUserRole } from '@/src/stores';
-import { useNotificationSettings, useUpdateNotificationSettings, useSaveFcmToken } from '@/src/hooks/queries';
-import { useFCM } from '@/src/hooks/custom';
+import {
+  useNotificationSettings,
+  useUpdateNotificationSettings,
+  useSaveFcmToken,
+} from '@/src/hooks/queries';
+import { useNotificationPermission } from '@/src/hooks/custom';
 import { useToast } from '@/src/hooks/common/useToast';
 import type { NotificationSettings } from '@/src/types';
 
@@ -22,9 +27,21 @@ type NotificationItemConfig = {
 
 // 디자이너 알림 설정 항목
 const DESIGNER_NOTIFICATIONS: NotificationItemConfig[] = [
-  { key: 'reservationNotification', title: '예약 신청 알림', description: '모델 예약 신청 시 알림' },
-  { key: 'scheduleNotification', title: '일정 알림', description: '일정 변동 및 리마인드 알림' },
-  { key: 'reviewNotification', title: '리뷰 알림', description: '새 리뷰 등록 시 알림' },
+  {
+    key: 'reservationNotification',
+    title: '예약 신청 알림',
+    description: '모델 예약 신청 시 알림',
+  },
+  {
+    key: 'scheduleNotification',
+    title: '일정 알림',
+    description: '일정 변동 및 리마인드 알림',
+  },
+  {
+    key: 'reviewNotification',
+    title: '리뷰 알림',
+    description: '새 리뷰 등록 시 알림',
+  },
 ];
 
 // 모델 알림 설정 항목
@@ -34,8 +51,16 @@ const MODEL_NOTIFICATIONS: NotificationItemConfig[] = [
     title: '예약 확정/취소 알림',
     description: '신청한 예약 확정 및 취소 시 알림',
   },
-  { key: 'scheduleNotification', title: '일정 알림', description: '일정 변동 및 리마인드 알림' },
-  { key: 'reviewNotification', title: '리뷰 답글 알림', description: '리뷰 답글 시 알림' },
+  {
+    key: 'scheduleNotification',
+    title: '일정 알림',
+    description: '일정 변동 및 리마인드 알림',
+  },
+  {
+    key: 'reviewNotification',
+    title: '리뷰 답글 알림',
+    description: '리뷰 답글 시 알림',
+  },
 ];
 
 export default function NotificationSettingsPage() {
@@ -53,26 +78,37 @@ export default function NotificationSettingsPage() {
   const role = isClient ? (getUserRole() ?? 'model') : 'model';
   const isDesigner = role === 'designer';
 
-  // 알림 설정 조회
+  // 알림 설정 조회/수정
   const { data: settingsData, isLoading } = useNotificationSettings(isClient);
-
-  // 알림 설정 수정
-  const { mutate: updateSettings, isPending: isUpdating } = useUpdateNotificationSettings();
-
-  // FCM 권한 및 토큰 관리
-  const { permission, requestPermission } = useFCM();
+  const { mutate: updateSettings, isPending: isUpdating } =
+    useUpdateNotificationSettings();
   const { mutate: saveFcmToken, isPending: isSavingToken } = useSaveFcmToken();
-  const [permissionModalDismissed, setPermissionModalDismissed] = useState(false);
+
+  // 통합 권한 훅 사용
+  const {
+    state: permissionState,
+    uiConfig,
+    setDismissed,
+    resetDismissed,
+    requestPermission,
+  } = useNotificationPermission();
+
+  // 모달 닫힘 상태 (세션 내에서만 유지)
+  const [permissionModalDismissed, setPermissionModalDismissed] =
+    useState(false);
+
+  // 권한이 granted인데 토큰이 저장 안 됐으면 자동 발급/저장
   const [tokenSaved, setTokenSaved] = useState(false);
   const [tokenSaveAttempted, setTokenSaveAttempted] = useState(false);
 
-  // 권한 상태가 default이고 모달을 닫지 않았을 때 표시
-  const isPermissionModalOpen = isClient && permission === 'default' && !permissionModalDismissed;
-
-  // 권한이 granted인데 토큰이 저장 안 됐으면 자동 발급/저장
   useEffect(() => {
     const autoRegisterToken = async () => {
-      if (isClient && permission === 'granted' && !tokenSaved && !tokenSaveAttempted) {
+      if (
+        isClient &&
+        permissionState === 'granted' &&
+        !tokenSaved &&
+        !tokenSaveAttempted
+      ) {
         const fcmToken = await requestPermission();
         if (fcmToken) {
           saveFcmToken(fcmToken, {
@@ -80,9 +116,7 @@ export default function NotificationSettingsPage() {
               setTokenSaved(true);
               setTokenSaveAttempted(true);
             },
-            onError: () => {
-              setTokenSaveAttempted(true);
-            },
+            onError: () => setTokenSaveAttempted(true),
           });
         } else {
           setTokenSaveAttempted(true);
@@ -90,9 +124,20 @@ export default function NotificationSettingsPage() {
       }
     };
     autoRegisterToken();
-  }, [isClient, permission, tokenSaved, tokenSaveAttempted, requestPermission, saveFcmToken]);
+  }, [
+    isClient,
+    permissionState,
+    tokenSaved,
+    tokenSaveAttempted,
+    requestPermission,
+    saveFcmToken,
+  ]);
 
-  // 권한 요청 모달 확인 핸들러
+  // 권한 요청 모달 - 표시 조건
+  const isPermissionModalOpen =
+    isClient && uiConfig.showModal === true && !permissionModalDismissed;
+
+  // 모달 확인 핸들러
   const handlePermissionConfirm = async () => {
     setPermissionModalDismissed(true);
     const fcmToken = await requestPermission();
@@ -102,18 +147,16 @@ export default function NotificationSettingsPage() {
           setTokenSaved(true);
           showToast('알림이 활성화되었습니다.');
         },
-        onError: () => {
-          showToast('알림 설정에 실패했습니다.');
-        },
+        onError: () => showToast('알림 설정에 실패했습니다.'),
       });
     }
   };
 
-  // PWA 여부에 따른 denied 안내 문구
-  const isPWA = isClient && window.matchMedia('(display-mode: standalone)').matches;
-  const deniedMessage = isPWA
-    ? '기기 설정에서 알림을 허용해주세요'
-    : '브라우저 설정에서 알림을 허용해주세요';
+  // 모달 닫기 핸들러 (취소/X)
+  const handlePermissionClose = () => {
+    setDismissed(); // localStorage에 저장
+    setPermissionModalDismissed(true);
+  };
 
   // 현재 설정값
   const settings: NotificationSettings = settingsData?.result ?? {
@@ -124,21 +167,26 @@ export default function NotificationSettingsPage() {
   };
 
   // 설정 업데이트 핸들러
-  const handleSettingChange = (key: keyof NotificationSettings, value: boolean) => {
-    const newSettings = { ...settings, [key]: value };
-
-    updateSettings(newSettings, {
-      onSuccess: () => {
-        showToast('알림 설정이 변경되었습니다.');
-      },
-      onError: () => {
-        showToast('알림 설정 변경에 실패했습니다.');
-      },
-    });
+  const handleSettingChange = (
+    key: keyof NotificationSettings,
+    value: boolean
+  ) => {
+    updateSettings(
+      { ...settings, [key]: value },
+      {
+        onSuccess: () => showToast('알림 설정이 변경되었습니다.'),
+        onError: () => showToast('알림 설정 변경에 실패했습니다.'),
+      }
+    );
   };
 
   // 역할에 따른 알림 항목
-  const notificationItems = isDesigner ? DESIGNER_NOTIFICATIONS : MODEL_NOTIFICATIONS;
+  const notificationItems = isDesigner
+    ? DESIGNER_NOTIFICATIONS
+    : MODEL_NOTIFICATIONS;
+
+  // UI 비활성화 여부 (uiConfig에서 가져옴)
+  const isDisabled = uiConfig.disabled;
 
   // 로딩 중
   if (isLoading) {
@@ -153,7 +201,9 @@ export default function NotificationSettingsPage() {
           >
             <ArrowLeftIcon className="size-6" />
           </button>
-          <h1 className="text-head-4-medium text-center text-black">알림 설정</h1>
+          <h1 className="text-head-4-medium text-center text-black">
+            알림 설정
+          </h1>
           <div className="size-6" />
         </header>
         <div className="flex flex-1 items-center justify-center">
@@ -162,9 +212,6 @@ export default function NotificationSettingsPage() {
       </div>
     );
   }
-
-  // 권한 denied 상태
-  const isPermissionDenied = permission === 'denied';
 
   return (
     <div className="flex min-h-screen flex-col bg-white">
@@ -182,15 +229,16 @@ export default function NotificationSettingsPage() {
         <div className="size-6" />
       </header>
 
-      {/* 권한 거부 안내 */}
-      {isPermissionDenied && (
-        <div className="mx-4 mb-2 rounded-xl bg-gray-100 p-3">
-          <p className="text-body-2-regular text-gray-600">{deniedMessage}</p>
-        </div>
-      )}
+      {/* 상태 안내 배너 (컴포넌트로 분리) */}
+      <NotificationStatusBanner
+        uiConfig={uiConfig}
+        onResetDismissed={resetDismissed}
+      />
 
       {/* 알림 설정 리스트 */}
-      <div className={`flex flex-col ${isPermissionDenied ? 'pointer-events-none opacity-50' : ''}`}>
+      <div
+        className={`flex flex-col ${isDisabled ? 'pointer-events-none opacity-50' : ''}`}
+      >
         {/* 채팅 알림 */}
         <div
           className={`flex items-center justify-between p-4 transition-opacity ${
@@ -200,8 +248,10 @@ export default function NotificationSettingsPage() {
           <span className="text-body-1-medium text-gray-900">채팅 알림</span>
           <Toggle
             checked={settings.chattingNotification}
-            onChange={(checked) => handleSettingChange('chattingNotification', checked)}
-            disabled={isUpdating || isPermissionDenied}
+            onChange={(checked) =>
+              handleSettingChange('chattingNotification', checked)
+            }
+            disabled={isUpdating || isDisabled}
           />
         </div>
 
@@ -218,19 +268,25 @@ export default function NotificationSettingsPage() {
                 }`}
               >
                 <div className="flex flex-col gap-0.5">
-                  <span className="text-body-1-medium text-gray-900">{item.title}</span>
+                  <span className="text-body-1-medium text-gray-900">
+                    {item.title}
+                  </span>
                   {item.description && (
-                    <span className="text-body-2-regular text-gray-500">{item.description}</span>
+                    <span className="text-body-2-regular text-gray-500">
+                      {item.description}
+                    </span>
                   )}
                 </div>
                 <Toggle
                   checked={settings[item.key]}
                   onChange={(checked) => handleSettingChange(item.key, checked)}
-                  disabled={isUpdating || isPermissionDenied}
+                  disabled={isUpdating || isDisabled}
                 />
               </div>
               {/* 마지막 항목이 아니면 구분선 */}
-              {index < notificationItems.length - 1 && <div className="mx-4 h-px bg-gray-300" />}
+              {index < notificationItems.length - 1 && (
+                <div className="mx-4 h-px bg-gray-300" />
+              )}
             </div>
           ))}
         </div>
@@ -239,7 +295,7 @@ export default function NotificationSettingsPage() {
       {/* 알림 권한 요청 모달 */}
       <ConfirmModal
         isOpen={isPermissionModalOpen}
-        onClose={() => setPermissionModalDismissed(true)}
+        onClose={handlePermissionClose}
         onConfirm={handlePermissionConfirm}
         message="알림을 허용하시겠습니까?"
         confirmText="허용"

--- a/src/app/(common)/mypage/notification-settings/page.tsx
+++ b/src/app/(common)/mypage/notification-settings/page.tsx
@@ -140,6 +140,7 @@ export default function NotificationSettingsPage() {
   // 모달 확인 핸들러
   const handlePermissionConfirm = async () => {
     setPermissionModalDismissed(true);
+    setTokenSaveAttempted(true); // 중복 저장 방지
     const fcmToken = await requestPermission();
     if (fcmToken) {
       saveFcmToken(fcmToken, {

--- a/src/components/notification/IOSInstallGuide.tsx
+++ b/src/components/notification/IOSInstallGuide.tsx
@@ -1,0 +1,18 @@
+interface IOSInstallGuideProps {
+  className?: string;
+}
+
+/**
+ * iOS Safari에서 PWA 설치 안내 컴포넌트
+ */
+export default function IOSInstallGuide({ className }: IOSInstallGuideProps) {
+  return (
+    <ol
+      className={`text-caption-1-medium text-gray-500 space-y-0.5 ${className ?? ''}`}
+    >
+      <li>1. 하단 공유 버튼(□↑) 탭</li>
+      <li>2. &quot;홈 화면에 추가&quot; 선택</li>
+      <li>3. 추가된 앱에서 알림 설정</li>
+    </ol>
+  );
+}

--- a/src/components/notification/NotificationStatusBanner.tsx
+++ b/src/components/notification/NotificationStatusBanner.tsx
@@ -31,7 +31,7 @@ export default function NotificationStatusBanner({
         <button
           type="button"
           onClick={onResetDismissed}
-          className="text-caption-1-medium text-purple-500 mt-2 underline"
+          className="text-caption-1-medium text-purple-500 mt-2 underline cursor-pointer"
         >
           다시 활성화
         </button>

--- a/src/components/notification/NotificationStatusBanner.tsx
+++ b/src/components/notification/NotificationStatusBanner.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import type { PermissionUIConfig } from '@/src/types/notification';
+import IOSInstallGuide from './IOSInstallGuide';
+
+interface NotificationStatusBannerProps {
+  uiConfig: PermissionUIConfig;
+  onResetDismissed?: () => void;
+}
+
+/**
+ * 알림 권한 상태 안내 배너 컴포넌트
+ */
+export default function NotificationStatusBanner({
+  uiConfig,
+  onResetDismissed,
+}: NotificationStatusBannerProps) {
+  const { message, showInstallGuide, showResetButton } = uiConfig;
+
+  if (!message) return null;
+
+  return (
+    <div className="mx-4 mb-2 rounded-xl bg-gray-100 p-3">
+      <p className="text-body-2-regular text-gray-600">{message}</p>
+
+      {/* iOS PWA 설치 안내 */}
+      {showInstallGuide && <IOSInstallGuide className="mt-2" />}
+
+      {/* 다시 활성화 버튼 */}
+      {showResetButton && onResetDismissed && (
+        <button
+          type="button"
+          onClick={onResetDismissed}
+          className="text-caption-1-medium text-purple-500 mt-2 underline"
+        >
+          다시 활성화
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/notification/index.ts
+++ b/src/components/notification/index.ts
@@ -1,3 +1,5 @@
 export { default as NotificationFilter } from './NotificationFilter';
 export { default as NotificationItem } from './NotificationItem';
 export { default as NotificationList } from './NotificationList';
+export { default as IOSInstallGuide } from './IOSInstallGuide';
+export { default as NotificationStatusBanner } from './NotificationStatusBanner';

--- a/src/constants/notification.ts
+++ b/src/constants/notification.ts
@@ -1,3 +1,19 @@
+/** localStorage/sessionStorage 키 */
+export const NOTIFICATION_STORAGE_KEYS = {
+  /** 앱 모달에서 거부 여부 (localStorage) */
+  PROMPT_DISMISSED: 'notification_prompt_dismissed',
+  /** FCM 토큰 등록 여부 (sessionStorage) */
+  TOKEN_REGISTERED: 'fcm_token_registered',
+} as const;
+
+/** 권한 상태별 안내 메시지 */
+export const PERMISSION_MESSAGES = {
+  not_supported: 'iOS에서 알림을 받으려면 홈 화면에 앱을 추가해주세요.',
+  browser_denied_pwa: '기기 설정에서 알림을 허용해주세요.',
+  browser_denied_web: '브라우저 설정에서 알림을 허용해주세요.',
+  app_dismissed: '알림이 비활성화되어 있습니다.',
+} as const;
+
 /**
  * 알림 타입별 라우팅 경로
  * - 'chat': 채팅 페이지 (/chat/{targetId})

--- a/src/hooks/custom/notification/index.ts
+++ b/src/hooks/custom/notification/index.ts
@@ -1,1 +1,2 @@
 export * from './useFCM';
+export * from './useNotificationPermission';

--- a/src/hooks/custom/notification/useNotificationPermission.ts
+++ b/src/hooks/custom/notification/useNotificationPermission.ts
@@ -92,20 +92,20 @@ export function useNotificationPermission(): UseNotificationPermissionReturn {
   const setDismissed = useCallback(() => {
     try {
       localStorage.setItem(NOTIFICATION_STORAGE_KEYS.PROMPT_DISMISSED, 'true');
-      setUserDismissed(true);
     } catch {
       // Private mode
     }
+    setUserDismissed(true);
   }, []);
 
   // 거부 상태 리셋 (다시 활성화)
   const resetDismissed = useCallback(() => {
     try {
       localStorage.removeItem(NOTIFICATION_STORAGE_KEYS.PROMPT_DISMISSED);
-      setUserDismissed(false);
     } catch {
       // Private mode
     }
+    setUserDismissed(false);
   }, []);
 
   // 유효 권한 상태 계산

--- a/src/hooks/custom/notification/useNotificationPermission.ts
+++ b/src/hooks/custom/notification/useNotificationPermission.ts
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState, useCallback, useMemo, useSyncExternalStore } from 'react';
+import { useFCM } from './useFCM';
+import {
+  NOTIFICATION_STORAGE_KEYS,
+  PERMISSION_MESSAGES,
+} from '@/src/constants/notification';
+import type {
+  EffectivePermissionState,
+  PermissionUIConfig,
+} from '@/src/types/notification';
+
+// 클라이언트 상태 확인을 위한 외부 스토어
+const emptySubscribe = () => () => {};
+
+/** localStorage에서 거부 상태 초기값 로드 */
+function getInitialDismissedState(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return (
+      localStorage.getItem(NOTIFICATION_STORAGE_KEYS.PROMPT_DISMISSED) === 'true'
+    );
+  } catch {
+    return false;
+  }
+}
+
+interface PlatformInfo {
+  isIOS: boolean;
+  isPWA: boolean;
+  isIOSSafari: boolean;
+  isNotificationSupported: boolean;
+}
+
+interface UseNotificationPermissionReturn {
+  /** 유효 권한 상태 */
+  state: EffectivePermissionState;
+  /** UI 설정 */
+  uiConfig: PermissionUIConfig;
+  /** 플랫폼 정보 */
+  platform: PlatformInfo;
+  /** 앱 거부 상태 리셋 */
+  resetDismissed: () => void;
+  /** 앱 거부 상태 설정 */
+  setDismissed: () => void;
+  /** 원본 브라우저 권한 */
+  browserPermission: NotificationPermission;
+  /** FCM 권한 요청 함수 */
+  requestPermission: () => Promise<string | null>;
+}
+
+/**
+ * 알림 권한 상태 통합 관리 훅
+ *
+ * 브라우저 권한 + 앱 상태 + 플랫폼 정보를 통합하여
+ * 유효 권한 상태와 UI 설정을 제공합니다.
+ */
+export function useNotificationPermission(): UseNotificationPermissionReturn {
+  const { permission: browserPermission, requestPermission } = useFCM();
+
+  // 클라이언트 여부 확인 (hydration-safe)
+  const isClient = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
+
+  // localStorage에서 거부 상태 로드 (lazy initialization)
+  const [userDismissed, setUserDismissed] = useState(getInitialDismissedState);
+
+  // 플랫폼 감지
+  const platform = useMemo((): PlatformInfo => {
+    if (!isClient) {
+      return {
+        isIOS: false,
+        isPWA: false,
+        isIOSSafari: false,
+        isNotificationSupported: false,
+      };
+    }
+
+    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+    const isPWA = window.matchMedia('(display-mode: standalone)').matches;
+    const isIOSSafari = isIOS && !isPWA;
+    const isNotificationSupported = 'Notification' in window;
+
+    return { isIOS, isPWA, isIOSSafari, isNotificationSupported };
+  }, [isClient]);
+
+  // 거부 상태 설정
+  const setDismissed = useCallback(() => {
+    try {
+      localStorage.setItem(NOTIFICATION_STORAGE_KEYS.PROMPT_DISMISSED, 'true');
+      setUserDismissed(true);
+    } catch {
+      // Private mode
+    }
+  }, []);
+
+  // 거부 상태 리셋 (다시 활성화)
+  const resetDismissed = useCallback(() => {
+    try {
+      localStorage.removeItem(NOTIFICATION_STORAGE_KEYS.PROMPT_DISMISSED);
+      setUserDismissed(false);
+    } catch {
+      // Private mode
+    }
+  }, []);
+
+  // 유효 권한 상태 계산
+  const state = useMemo((): EffectivePermissionState => {
+    if (!isClient) return 'prompt_needed';
+
+    // 1. iOS Safari (PWA 미설치) 또는 Notification API 미지원
+    if (platform.isIOSSafari || !platform.isNotificationSupported) {
+      return 'not_supported';
+    }
+
+    // 2. 브라우저에서 권한 거부
+    if (browserPermission === 'denied') {
+      return 'browser_denied';
+    }
+
+    // 3. 앱 모달에서 거부
+    if (browserPermission === 'default' && userDismissed) {
+      return 'app_dismissed';
+    }
+
+    // 4. 권한 허용됨
+    if (browserPermission === 'granted') {
+      return 'granted';
+    }
+
+    // 5. 아직 요청 전
+    return 'prompt_needed';
+  }, [isClient, platform, browserPermission, userDismissed]);
+
+  // UI 설정 매핑
+  const uiConfig = useMemo((): PermissionUIConfig => {
+    const configs: Record<EffectivePermissionState, PermissionUIConfig> = {
+      not_supported: {
+        disabled: true,
+        message: PERMISSION_MESSAGES.not_supported,
+        showInstallGuide: true,
+      },
+      browser_denied: {
+        disabled: true,
+        message: platform.isPWA
+          ? PERMISSION_MESSAGES.browser_denied_pwa
+          : PERMISSION_MESSAGES.browser_denied_web,
+      },
+      app_dismissed: {
+        disabled: true,
+        message: PERMISSION_MESSAGES.app_dismissed,
+        showResetButton: true,
+      },
+      granted: {
+        disabled: false,
+        message: null,
+      },
+      prompt_needed: {
+        disabled: false,
+        message: null,
+        showModal: true,
+      },
+    };
+
+    return configs[state];
+  }, [state, platform.isPWA]);
+
+  return {
+    state,
+    uiConfig,
+    platform,
+    resetDismissed,
+    setDismissed,
+    browserPermission,
+    requestPermission,
+  };
+}

--- a/src/providers/FCMProvider.tsx
+++ b/src/providers/FCMProvider.tsx
@@ -1,13 +1,36 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState, ReactNode } from 'react';
+import { useCallback, useEffect, useState, ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
 import { MessagePayload } from 'firebase/messaging';
 import { useQueryClient } from '@tanstack/react-query';
 import { useFCM } from '@/src/hooks/custom';
 import { useSaveFcmToken, notificationKeys } from '@/src/hooks/queries';
 import { getAccessToken } from '@/src/stores';
+import { NOTIFICATION_STORAGE_KEYS } from '@/src/constants/notification';
 import NotificationBanner from '@/src/components/common/NotificationBanner';
+
+/** sessionStorage에서 토큰 등록 상태 조회 */
+function getTokenRegistered(): boolean {
+  try {
+    return sessionStorage.getItem(NOTIFICATION_STORAGE_KEYS.TOKEN_REGISTERED) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** sessionStorage에 토큰 등록 상태 저장 */
+function setTokenRegistered(value: boolean): void {
+  try {
+    if (value) {
+      sessionStorage.setItem(NOTIFICATION_STORAGE_KEYS.TOKEN_REGISTERED, 'true');
+    } else {
+      sessionStorage.removeItem(NOTIFICATION_STORAGE_KEYS.TOKEN_REGISTERED);
+    }
+  } catch {
+    // Private mode fallback
+  }
+}
 
 interface FCMProviderProps {
   children: ReactNode;
@@ -28,7 +51,6 @@ interface NotificationState {
  */
 export function FCMProvider({ children }: FCMProviderProps) {
   const [notification, setNotification] = useState<NotificationState | null>(null);
-  const tokenRegisteredRef = useRef(false);
   const queryClient = useQueryClient();
   const pathname = usePathname();
 
@@ -76,25 +98,25 @@ export function FCMProvider({ children }: FCMProviderProps) {
     const autoRegisterToken = async () => {
       const accessToken = getAccessToken();
 
-      // 로그아웃 상태면 ref 리셋 (다음 로그인 시 재등록 가능하도록)
+      // 로그아웃 상태면 sessionStorage 리셋 (다음 로그인 시 재등록 가능하도록)
       if (!accessToken) {
-        tokenRegisteredRef.current = false;
+        setTokenRegistered(false);
         return;
       }
 
       // 로그인 상태 + 권한 허용 + 아직 등록 안 함
-      if (permission === 'granted' && !tokenRegisteredRef.current) {
-        tokenRegisteredRef.current = true;
+      if (permission === 'granted' && !getTokenRegistered()) {
+        setTokenRegistered(true);
 
         const fcmToken = await requestPermission();
         if (fcmToken) {
           saveFcmToken(fcmToken, {
             onError: () => {
-              tokenRegisteredRef.current = false;
+              setTokenRegistered(false);
             },
           });
         } else {
-          tokenRegisteredRef.current = false;
+          setTokenRegistered(false);
         }
       }
     };

--- a/src/stores/auth/useAuthStore.ts
+++ b/src/stores/auth/useAuthStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 
 import { categoryNameToCode } from '@/src/utils/myRecruitment';
+import { NOTIFICATION_STORAGE_KEYS } from '@/src/constants/notification';
 import type { Category } from '@/src/types/recruitment';
 
 interface User {
@@ -35,6 +36,17 @@ export const useAuthStore = create<AuthState>((set) => ({
       document.cookie = 'user_role=; path=/; max-age=0';
       document.cookie = 'user_category=; path=/; max-age=0';
     }
+
+    // 알림 관련 스토리지 클리어
+    if (typeof window !== 'undefined') {
+      try {
+        localStorage.removeItem(NOTIFICATION_STORAGE_KEYS.PROMPT_DISMISSED);
+        sessionStorage.removeItem(NOTIFICATION_STORAGE_KEYS.TOKEN_REGISTERED);
+      } catch {
+        // Private mode fallback
+      }
+    }
+
     set({ user: null, isAuthenticated: false });
   },
 }));

--- a/src/types/notification/index.ts
+++ b/src/types/notification/index.ts
@@ -50,3 +50,25 @@ export interface NotificationListParams {
 export interface SaveFcmTokenRequest {
   fcmToken: string;
 }
+
+/** 유효 권한 상태 (브라우저 권한 + 앱 상태 + 플랫폼 통합) */
+export type EffectivePermissionState =
+  | 'not_supported' // iOS Safari (PWA 미설치) 또는 Notification API 미지원
+  | 'browser_denied' // 브라우저에서 권한 거부
+  | 'app_dismissed' // 앱 모달에서 거부/취소
+  | 'granted' // 권한 허용됨
+  | 'prompt_needed'; // 권한 요청 필요 (모달 표시)
+
+/** 권한 상태별 UI 설정 */
+export interface PermissionUIConfig {
+  /** 토글 비활성화 여부 */
+  disabled: boolean;
+  /** 안내 메시지 (null이면 표시 안 함) */
+  message: string | null;
+  /** iOS PWA 설치 가이드 표시 */
+  showInstallGuide?: boolean;
+  /** "다시 활성화" 버튼 표시 */
+  showResetButton?: boolean;
+  /** 권한 요청 모달 표시 */
+  showModal?: boolean;
+}


### PR DESCRIPTION
### 💡 To Reviewers

- FCM 알림 (기기별/알림권한별) 안내 UI 설정해두었습니다
- iOS에서는 pwa 설치 안할시 기본적으로 알림 자체가 안됨. -> 기기 인식 후 알림 UI
- 알림 권한 거부시/모달에서 취소누를시 -> 안내 UI
- `useSyncExternalStore`를 사용하여 hydration mismatch 방지

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

#### 문제 1: 새로고침 시 FCM 토큰 중복 POST

- `useRef`로 관리하던 토큰 등록 상태가 새로고침 시 리셋되어 매번 `/fcm-token` POST 요청 발생
- **해결**: `sessionStorage`로 토큰 등록 상태 관리 (탭 닫으면 리셋, 새로고침은 유지)

#### 문제 2: 모달 취소/X 클릭 시 UI 비활성화 안 됨

- `permission === 'denied'`만 체크하여 `default` 상태에서 모달 거부 시 토글이 활성화 상태 유지
- **해결**: `localStorage`로 사용자 거부 상태 관리, 토글 비활성화 처리

#### 수정 파일

| 파일                                                         | 변경 내용                                                  |
| ------------------------------------------------------------ | ---------------------------------------------------------- |
| `src/types/notification/index.ts`                            | `EffectivePermissionState`, `PermissionUIConfig` 타입 추가 |
| `src/constants/notification.ts`                              | 스토리지 키 상수, 권한 메시지 상수 추가                    |
| `src/hooks/custom/notification/useNotificationPermission.ts` | 권한 상태 통합 훅 (신규)                                   |
| `src/components/notification/IOSInstallGuide.tsx`            | iOS PWA 설치 가이드 (신규)                                 |
| `src/components/notification/NotificationStatusBanner.tsx`   | 상태 안내 배너 (신규)                                      |
| `src/providers/FCMProvider.tsx`                              | sessionStorage로 토큰 등록 상태 관리                       |
| `src/app/(common)/mypage/notification-settings/page.tsx`     | 통합 훅/컴포넌트 적용                                      |
| `src/stores/auth/useAuthStore.ts`                            | 로그아웃 시 스토리지 클리어                                |

### 🤔 추후 작업 예정

- iOS Safari (PWA 미설치) 사용자에게 PWA 설치 안내 UI 노출 검토
- 다른 기기에서 허용 후 현재 기기 접속 시 안내 문구 추가 검토

### 📸 작업 결과 (스크린샷)

- 알림 설정 페이지에서 모달 취소 시 토글 비활성화 (배포링크에서 확인 필요)
- 새로고침 시 FCM 토큰 중복 POST 방지 (Network 탭 확인)

### ✅ 테스트 시나리오

#### 1. 새로고침 시 중복 POST 방지

- [x] 로그인 후 알림 권한 허용
- [x] 페이지 새로고침
- [x] Network 탭에서 `/fcm-token` POST가 **한 번만** 호출되는지 확인

#### 2. 모달 취소 시 UI 비활성화

- [x] 알림 설정 페이지 진입 (권한 default 상태)
- [x] 모달에서 "취소" 또는 X 클릭
- [x] 토글이 비활성화(opacity-50, pointer-events-none)되는지 확인
- [x] "알림이 비활성화되어 있습니다." 배너 표시 확인

#### 3. 새로고침 후 상태 유지

- [x] 모달 취소 후 페이지 새로고침
- [x] 모달이 다시 뜨지 않는지 확인
- [x] 토글이 비활성화 상태 유지되는지 확인

#### 4. "다시 활성화" 버튼

- [x] 모달 취소 상태에서 "다시 활성화" 버튼 클릭
- [x] 모달이 다시 표시되는지 확인
- [x] 권한 허용 시 토글 활성화되는지 확인

#### 5. 로그아웃/재로그인

- [x] 모달 취소 후 로그아웃
- [x] 다시 로그인
- [x] 알림 설정 페이지에서 모달이 **다시 표시**되는지 확인

#### 6. 브라우저 권한 denied 상태

- [x] 브라우저 설정에서 알림 권한 차단
- [x] 알림 설정 페이지 진입
- [x] "브라우저 설정에서 알림을 허용해주세요" 배너 표시 확인
- [x] 토글 비활성화 확인

#### 7. iOS Safari (PWA 미설치) - 선택

- [x] iOS Safari에서 알림 설정 페이지 진입
- [x] "iOS에서 알림을 받으려면 홈 화면에 앱을 추가해주세요" 배너 표시 확인
- [x] PWA 설치 안내 표시 확인

### 🔗 관련 이슈

- #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 알림 상태 배너 추가(권한/상태 메시지 및 재활성화 버튼)
  * iOS 홈화면 설치 가이드 컴포넌트 추가

* **개선 사항**
  * 알림 권한·토큰 관리 흐름 통합(단일 권한 상태 기반 UI 및 자동 토큰 등록)
  * 권한 모달 및 일시 닫기 상태 통합·제어, 토스트 메시지 정돈
  * 설정 섹션 전체 및 개별 토글 비활성화 처리 통일
  * 로그아웃 시 알림 관련 로컬/세션 데이터 정리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->