### PR TITLE
[FIX] 다음 버튼에 가려지는 UI 요소 문제 해결

### DIFF
--- a/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-id/_funnel/steps/1-Input.tsx
@@ -134,7 +134,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext }) => {
       </div>
 
       {/* 입력 폼 */}
-      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6 pb-[100px]" onSubmit={(e) => e.preventDefault()}>
+      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6 pb-[250px]" onSubmit={(e) => e.preventDefault()}>
         {/* 이름 입력 */}
         <div className="flex flex-col gap-2">
           <label className="text-body-1-medium tracking-tight text-gray-900">이름 (실명)</label>

--- a/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/1-Input.tsx
@@ -147,7 +147,7 @@ export const StepInput: React.FC<StepInputProps> = ({ goNext, goSocialUser }) =>
       </div>
 
       {/* 입력 폼 */}
-      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6 pb-[100px]" onSubmit={(e) => e.preventDefault()}>
+      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6 pb-[250px]" onSubmit={(e) => e.preventDefault()}>
         {/* 이름 입력 */}
         <div className="flex flex-col gap-2">
           <label className="text-body-1-medium tracking-tight text-gray-900">이름 (실명)</label>

--- a/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
+++ b/src/app/(auth)/find-password/_funnel/steps/2-NewPassword.tsx
@@ -64,7 +64,7 @@ export const StepNewPassword: React.FC<StepNewPasswordProps> = ({ email, goNext 
       </div>
 
       {/* 입력 폼 */}
-      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6 pb-[100px]" onSubmit={(e) => e.preventDefault()}>
+      <form className="mx-4 mt-8 flex flex-1 flex-col gap-6 pb-[250px]" onSubmit={(e) => e.preventDefault()}>
         {/* 새 비밀번호 입력 */}
         <PasswordInput
           label="새로운 비밀번호"

--- a/src/app/(auth)/signup/_funnel/steps/3-BasicInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/3-BasicInfo.tsx
@@ -100,7 +100,7 @@ export const StepBasicInfo: React.FC<StepBasicInfoProps> = ({ goPrev, goNext, is
       <SignupHeader onBack={goPrev} totalSteps={SIGNUP_STEPS.REGULAR} currentStep={3} />
       <SignupTitle line1={SIGNUP_MESSAGES.BASIC_INFO.TITLE_1} line2={SIGNUP_MESSAGES.BASIC_INFO.TITLE_2} />
       <form
-        className="mx-4 mt-8 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[100px] sm:w-[343px]"
+        className="mx-4 mt-8 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[250px] sm:w-[343px]"
         onSubmit={(e) => e.preventDefault()}
       >
         <div className="flex flex-col">

--- a/src/app/(auth)/signup/_funnel/steps/4-LoginInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/4-LoginInfo.tsx
@@ -90,7 +90,7 @@ export const StepLoginInfo: React.FC<StepLoginInfoProps> = ({ goPrev, goNext, is
       <SignupHeader onBack={goPrev} totalSteps={SIGNUP_STEPS.REGULAR} currentStep={4} />
       <SignupTitle line1={SIGNUP_MESSAGES.LOGIN_INFO.TITLE_1} line2={SIGNUP_MESSAGES.LOGIN_INFO.TITLE_2} />
       <form
-        className="mx-4 mt-10 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[100px] sm:w-[343px]"
+        className="mx-4 mt-10 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[250px] sm:w-[343px]"
         onSubmit={(e) => e.preventDefault()}
       >
         <div className="flex flex-col gap-6">

--- a/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
@@ -276,7 +276,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
       <SignupTitle line1={SIGNUP_MESSAGES.PROFILE_INFO.TITLE_1} line2={SIGNUP_MESSAGES.PROFILE_INFO.TITLE_2} />
 
       <form
-        className="mx-4 mt-10 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[100px] sm:w-[343px]"
+        className="mx-4 mt-10 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[250px] sm:w-[343px]"
         onSubmit={(e) => e.preventDefault()}
       >
         <ProfileImageUpload profileImage={profileImage} onImageUpload={handleImageUpload} />

--- a/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
@@ -276,7 +276,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
       <SignupTitle line1={SIGNUP_MESSAGES.PROFILE_INFO.TITLE_1} line2={SIGNUP_MESSAGES.PROFILE_INFO.TITLE_2} />
 
       <form
-        className="mx-4 mt-10 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[250px] sm:w-[343px]"
+        className="mx-4 mt-10 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[300px] sm:w-[343px]"
         onSubmit={(e) => e.preventDefault()}
       >
         <ProfileImageUpload profileImage={profileImage} onImageUpload={handleImageUpload} />

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
@@ -105,7 +105,7 @@ export default function StepContent({ goNext, goPrev, isSubmitting = false, isEd
       </div>
 
       {/* 컨텐츠 영역 */}
-      <div className="flex-1 space-y-7 p-4 pb-[250px]">
+      <div className="flex-1 space-y-7 p-4 pb-[150px]">
         {/* 시술 내용 */}
         <TextArea
           label="시술 내용"

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
@@ -105,7 +105,7 @@ export default function StepContent({ goNext, goPrev, isSubmitting = false, isEd
       </div>
 
       {/* 컨텐츠 영역 */}
-      <div className="flex-1 space-y-7 p-4 pb-24">
+      <div className="flex-1 space-y-7 p-4 pb-[250px]">
         {/* 시술 내용 */}
         <TextArea
           label="시술 내용"

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
@@ -96,7 +96,7 @@ export default function StepTitleDate({ goNext, goPrev, isEdit = false }: StepTi
       </div>
 
       {/* 컨텐츠 영역 */}
-      <div className="flex-1 space-y-6 p-4 pb-[250px]">
+      <div className="flex-1 space-y-6 p-4 pb-[150px]">
         {/* TitleInput */}
         <TitleInput value={title} onChange={setTitle} />
 

--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepTitleDate.tsx
@@ -96,7 +96,7 @@ export default function StepTitleDate({ goNext, goPrev, isEdit = false }: StepTi
       </div>
 
       {/* 컨텐츠 영역 */}
-      <div className="flex-1 space-y-6 p-4 pb-24">
+      <div className="flex-1 space-y-6 p-4 pb-[250px]">
         {/* TitleInput */}
         <TitleInput value={title} onChange={setTitle} />
 

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
@@ -73,7 +73,7 @@ export default function StepDateTime({
       <ReservationHeader onBack={goPrev} />
 
       {/* 콘텐츠 */}
-      <div className="flex flex-1 flex-col gap-6 px-4 pb-[100px]">
+      <div className="flex flex-1 flex-col gap-6 px-4 pb-[250px]">
         {/* 스텝 정보 */}
         <ReservationStepInfo
           currentStep={1}

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
@@ -90,7 +90,7 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
       <ReservationHeader onBack={goPrev} />
 
       {/* 콘텐츠 */}
-      <div className="flex flex-1 flex-col gap-6 px-4 pb-[100px]">
+      <div className="flex flex-1 flex-col gap-6 px-4 pb-[250px]">
         {/* 스텝 정보 */}
         <div className="flex flex-col gap-2">
           <p className="text-[20px] leading-[1.4] font-normal tracking-[-0.4px]">

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/3-StepContent.tsx
@@ -31,7 +31,7 @@ export default function StepContent({ goNext, goPrev }: StepContentProps) {
       <ReservationHeader onBack={goPrev} />
 
       {/* 콘텐츠 */}
-      <div className="flex flex-1 flex-col gap-6 px-4 pb-[100px]">
+      <div className="flex flex-1 flex-col gap-6 px-4 pb-[250px]">
         {/* 스텝 정보 */}
         <div className="flex flex-col gap-2">
           <p className="text-[20px] leading-[1.4] font-normal tracking-[-0.4px]">

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
@@ -115,7 +115,7 @@ export default function StepConfirm({
       <ReservationHeader onBack={goPrev} />
 
       {/* 콘텐츠 */}
-      <div className="flex flex-1 flex-col px-4 pt-1 pb-[100px]">
+      <div className="flex flex-1 flex-col px-4 pt-1 pb-[250px]">
         {/* 스텝 정보 */}
         <div className="flex flex-col gap-2">
           <p className="text-head-3 leading-140 font-normal tracking-[-0.4px] text-gray-900">4/4</p>

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -206,7 +206,7 @@ export default function Dropdown<T = string>({
           {isOpen && !disabled && (
             <>
               {/* Overlay for outside click */}
-              <div className="fixed inset-0 z-10" onClick={handleClose} aria-hidden="true" />
+              <div className="fixed inset-0 z-50" onClick={handleClose} aria-hidden="true" />
               <div
                 ref={listRef}
                 id={listboxId}
@@ -214,7 +214,7 @@ export default function Dropdown<T = string>({
                 aria-labelledby={label ? `${listboxId}-label` : undefined}
                 aria-label={ariaLabel || (!label ? placeholder : undefined)}
                 aria-activedescendant={focusedIndex >= 0 ? `${listboxId}-option-${focusedIndex}` : undefined}
-                className={`absolute top-14 z-20 w-full rounded-xl border border-solid border-gray-400 bg-white px-4 py-3.5 shadow-dropdown ${
+                className={`absolute top-14 z-60 w-full rounded-xl border border-solid border-gray-400 bg-white px-4 py-3.5 shadow-dropdown ${
                   maxHeight ? 'overflow-y-auto scrollbar-hide' : ''
                 }`}
                 style={maxHeight ? { maxHeight: `${maxHeight}px` } : undefined}
@@ -278,14 +278,14 @@ export default function Dropdown<T = string>({
       {isOpen && !disabled && (
         <>
           {/* Overlay for outside click */}
-          <div className="fixed inset-0 z-10" onClick={handleClose} aria-hidden="true" />
+          <div className="fixed inset-0 z-50" onClick={handleClose} aria-hidden="true" />
           <div
             ref={listRef}
             id={listboxId}
             role="listbox"
             aria-label={ariaLabel || label || placeholder}
             aria-activedescendant={focusedIndex >= 0 ? `${listboxId}-option-${focusedIndex}` : undefined}
-            className={`absolute top-full right-0 z-20 mt-0.5 flex min-w-[100px] flex-col gap-1.5 overflow-hidden rounded-xl border border-gray-400 bg-white p-3 shadow-dropdown ${
+            className={`absolute top-full right-0 z-60 mt-0.5 flex min-w-[100px] flex-col gap-1.5 overflow-hidden rounded-xl border border-gray-400 bg-white p-3 shadow-dropdown ${
               maxHeight ? 'overflow-y-auto scrollbar-hide' : ''
             }`}
             style={maxHeight ? { maxHeight: `${maxHeight}px` } : undefined}


### PR DESCRIPTION
### 💡 To Reviewers

- 새로 설치한 라이브러리 없음
- FixedBottomContainer(z-50)에 가려지는 드롭다운 문제를 두 가지 방법으로 해결했습니다.

### 문제

- 디자이너/모델 회원가입, 예약, 공고 등록 등 여러 화면에서 드롭다운이 하단 고정 버튼(FixedBottomContainer)에 가려지는 문제
- **원인**: FixedBottomContainer의 z-index(z-50)가 Dropdown 옵션 목록(z-20)보다 높아서 드롭다운이 버튼 뒤에 렌더링됨

### 해결 방안

1. **Dropdown z-index 상향**: 옵션 목록이 FixedBottomContainer 위에 표시되도록 z-index 상향
2. **폼 하단 패딩 확대**: 드롭다운이 화면 중앙까지 스크롤 가능하도록 여유 공간 확보

### 🔥 작업 내용

#### 1. Dropdown 컴포넌트 z-index 상향
- Overlay: z-10 → z-50
- 옵션 목록: z-20 → z-60

#### 2. 폼 하단 패딩 확대

| 영역 | 파일 | 패딩 |
|------|------|------|
| 회원가입 3단계 | 3-BasicInfo.tsx | pb-[250px] |
| 회원가입 4단계 | 4-LoginInfo.tsx | pb-[250px] |
| 회원가입 5단계 | 5-ProfileInfo.tsx | pb-[300px] |
| 예약 1단계 | 1-StepDateTime.tsx | pb-[250px] |
| 예약 2단계 | 2-StepPhoto.tsx | pb-[250px] |
| 예약 3단계 | 3-StepContent.tsx | pb-[250px] |
| 예약 4단계 | 4-StepConfirm.tsx | pb-[250px] |
| 아이디 찾기 | find-id/1-Input.tsx | pb-[250px] |
| 비밀번호 찾기 1단계 | find-password/1-Input.tsx | pb-[250px] |
| 비밀번호 찾기 2단계 | find-password/2-NewPassword.tsx | pb-[250px] |
| 공고 등록 1단계 | StepTitleDate.tsx | pb-[150px] |
| 공고 등록 2단계 | StepContent.tsx | pb-[150px] |

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 드롭다운이 다음 버튼 위에 정상 표시됨

### 🔗 관련 이슈

- #156