### PR TITLE
[FIX] 지도 중심점 강제 이동 버그 수정

### DIFF
--- a/src/components/map/NaverMapView.tsx
+++ b/src/components/map/NaverMapView.tsx
@@ -213,7 +213,9 @@ export default function NaverMapView({
     prevSelectedDesignerIdRef.current = selectedDesignerId;
   }, [selectedDesignerId]);
 
-  // center prop 변경 감지 - primitive 의존성 사용
+  // center prop 변경 감지 - 실제 지도 중심과 비교하여 이동
+  // 의존성: center 객체 (GPS 버튼 클릭 시 새 객체 생성으로 useEffect 실행 보장)
+  // bottomOffset은 ref로 관리 (offset 변경만으로는 지도 이동하지 않음)
   useEffect(() => {
     if (!mapInstance) return;
 
@@ -248,7 +250,7 @@ export default function NaverMapView({
         easing: 'easeOutCubic',
       });
     }
-  }, [mapInstance, center.lat, center.lng]);
+  }, [mapInstance, center]);
 
   // zoom 변경 시 지도 줌 변경
   useEffect(() => {

--- a/src/components/map/NaverMapView.tsx
+++ b/src/components/map/NaverMapView.tsx
@@ -63,6 +63,11 @@ export default function NaverMapView({
   const onCenterChangedRef = useRef(onCenterChanged);
   const onZoomChangedRef = useRef(onZoomChanged);
 
+  // bottomOffset 값을 ref로 관리 (useLatest 패턴)
+  // offset은 "center 이동 시 적용할 보정값"이지, "offset 변경 시 지도를 이동"하는 것이 아님
+  const bottomOffsetRef = useRef(bottomOffset);
+  const bottomOffsetPxRef = useRef(bottomOffsetPx);
+
   useEffect(() => {
     onCenterChangedRef.current = onCenterChanged;
   }, [onCenterChanged]);
@@ -70,6 +75,14 @@ export default function NaverMapView({
   useEffect(() => {
     onZoomChangedRef.current = onZoomChanged;
   }, [onZoomChanged]);
+
+  useEffect(() => {
+    bottomOffsetRef.current = bottomOffset;
+  }, [bottomOffset]);
+
+  useEffect(() => {
+    bottomOffsetPxRef.current = bottomOffsetPx;
+  }, [bottomOffsetPx]);
 
   // 지도 초기화 (한 번만 실행)
   useEffect(() => {
@@ -200,18 +213,16 @@ export default function NaverMapView({
     prevSelectedDesignerIdRef.current = selectedDesignerId;
   }, [selectedDesignerId]);
 
-  // center prop 변경 감지 - 실제 지도 중심과 비교하여 이동
+  // center prop 변경 감지 - primitive 의존성 사용
   useEffect(() => {
     if (!mapInstance) return;
 
     // 실제 지도의 현재 중심 좌표를 가져옴
     const currentMapCenter = mapInstance.getCenter();
-    const currentLat = currentMapCenter.y;
-    const currentLng = currentMapCenter.x;
 
     const isSameAsMapCenter =
-      Math.abs(currentLat - center.lat) < 0.0001 &&
-      Math.abs(currentLng - center.lng) < 0.0001;
+      Math.abs(currentMapCenter.y - center.lat) < 0.0001 &&
+      Math.abs(currentMapCenter.x - center.lng) < 0.0001;
 
     if (!isSameAsMapCenter) {
       let targetCoord: naver.maps.LatLng | naver.maps.Coord = new naver.maps.LatLng(
@@ -219,8 +230,9 @@ export default function NaverMapView({
         center.lng
       );
 
-      // 하단 오프셋 보정 (px 우선, 없으면 vh 변환)
-      const offsetPx = bottomOffsetPx ?? ((bottomOffset ?? 0) / 100) * window.innerHeight;
+      // 하단 오프셋 보정 (ref에서 최신 값 읽음)
+      const offsetPx =
+        bottomOffsetPxRef.current ?? ((bottomOffsetRef.current ?? 0) / 100) * window.innerHeight;
       if (offsetPx > 0) {
         const projection = mapInstance.getProjection();
         const pixelOffset = projection.fromCoordToOffset(targetCoord);
@@ -236,7 +248,7 @@ export default function NaverMapView({
         easing: 'easeOutCubic',
       });
     }
-  }, [mapInstance, center, bottomOffset, bottomOffsetPx]);
+  }, [mapInstance, center.lat, center.lng]);
 
   // zoom 변경 시 지도 줌 변경
   useEffect(() => {

--- a/src/components/map/markers/CurrentLocationMarker.ts
+++ b/src/components/map/markers/CurrentLocationMarker.ts
@@ -26,6 +26,7 @@ function createCurrentLocationMarkerHtml(): string {
       display: flex;
       align-items: center;
       justify-content: center;
+      pointer-events: none;
     ">
       <!-- 정확도 원 (반투명 보라색) -->
       <div class="current-location-accuracy" style="
@@ -74,7 +75,8 @@ export function createCurrentLocationMarker(
       content: createCurrentLocationMarkerHtml(),
       anchor: new naver.maps.Point(ACCURACY_CIRCLE_SIZE / 2, ACCURACY_CIRCLE_SIZE / 2),
     },
-    zIndex: 100, // 다른 마커보다 위에 표시
+    clickable: false, // 클릭 이벤트 비활성화 (샵 마커 클릭 방해 방지)
+    zIndex: 50, // 샵 마커(기본 100)보다 아래에 표시
   });
 
   return marker;


### PR DESCRIPTION
### 💡 To Reviewers

- 새로 설치한 라이브러리 없음
- React Best Practice의 `useLatest` 패턴을 적용하여 offset 값을 ref로 관리

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

#### 1. 지도 중심점 강제 이동 버그 수정
- **문제**: 마커 클릭 또는 SelectedShopCard 닫기 시 지도가 사용자 GPS 위치로 강제 이동되는 버그
- **원인**: `bottomOffset`/`bottomOffsetPx`가 useEffect 의존성에 포함되어 offset 변경 시 재실행됨
- **해결**: 
  - `bottomOffsetRef`, `bottomOffsetPxRef` 추가 (useLatest 패턴)
  - useEffect 의존성을 `[mapInstance, center]`로 변경
  - offset은 center 이동 시점에 ref에서 최신 값을 읽도록 수정

#### 2. GPS 버튼 동작 복구
- **문제**: primitive 의존성(`center.lat, center.lng`) 사용 시 GPS 버튼 클릭해도 지도 이동 안됨
- **원인**: 좌표 값이 같으면 useEffect 미실행
- **해결**: `center` 객체를 의존성으로 유지 (새 객체 생성 시 useEffect 실행 보장)

#### 3. 현재 위치 마커 클릭 이벤트 충돌 해결
- **문제**: 현재 위치 마커(파란 점 + 파동 애니메이션) 근처의 샵 마커 클릭 안됨
- **원인**: 현재 위치 마커가 zIndex 100으로 샵 마커 위에 표시되고, 80px 정확도 원이 클릭 가로챔
- **해결**:
  - `clickable: false` 옵션 추가
  - `pointer-events: none` CSS 추가
  - `zIndex: 50`으로 변경 (샵 마커 아래로)

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 기능 테스트 필요:
  - [x] BottomSheet 상태에서 지도 드래그 후 마커 클릭 → 지도 위치 유지
  - [x] 마커 클릭 후 다른 마커 클릭 → 정상 동작
  - [x] SelectedShopCard X 버튼 클릭 → 지도 위치 유지
  - [x] GPS 버튼 클릭 → 사용자 위치로 이동 (정상)
  - [x] 현재 위치 마커 근처 샵 마커 클릭 → 정상 동작

### 🔗 관련 이슈

- #160