### PR TITLE
[FEAT] 회원 탈퇴 기능 구현

### DIFF
--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -11,6 +11,7 @@ import type {
   SocialSignupResponse,
   SocialLoginCallbackRequest,
   SocialLoginCallbackResponse,
+  WithdrawResponse,
 } from '@/src/types';
 
 /**
@@ -110,4 +111,18 @@ export const processSocialLoginCallback = async (
     payload, // request body로 전달
   );
   return response.data;
+};
+
+/**
+ * 회원 탈퇴
+ * - 백엔드에 탈퇴 요청
+ * - 성공/실패 여부와 관계없이 프론트엔드에서 인증 정보 삭제
+ */
+export const withdraw = async (): Promise<ApiResponse<WithdrawResponse>> => {
+  try {
+    const response = await axiosInstance.delete<ApiResponse<WithdrawResponse>>('/auth/withdraw');
+    return response.data;
+  } finally {
+    useAuthStore.getState().clearAuth();
+  }
 };

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -51,7 +51,7 @@ export const axiosInstance = axios.create({
 });
 
 // /auth/ 엔드포인트 중 인증이 필요한 것만 명시 (나머지는 토큰 주입 제외)
-const AUTH_REQUIRED_ENDPOINTS = ['/auth/logout', '/auth/validate', '/auth/social/signup'];
+const AUTH_REQUIRED_ENDPOINTS = ['/auth/logout', '/auth/validate', '/auth/social/signup', '/auth/withdraw'];
 
 // Request Interceptor: 쿠키에서 accessToken 읽어서 헤더에 추가 + 로깅
 axiosInstance.interceptors.request.use(

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -209,7 +209,7 @@ export default function MypagePage() {
               type="button"
               onClick={handleCloseWithdrawModal}
               disabled={isWithdrawing}
-              className="flex h-12 flex-1 items-center justify-center rounded-full border border-gray-400 bg-white text-body-2-medium text-gray-900 disabled:cursor-not-allowed"
+              className="flex h-12 flex-1 cursor-pointer items-center justify-center rounded-full border border-gray-400 bg-white text-body-2-medium text-gray-900 disabled:cursor-not-allowed"
             >
               {WITHDRAW_MODAL.cancelButton}
             </button>

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -115,6 +115,7 @@ export default function MypagePage() {
       },
       onError: () => {
         showToast('탈퇴 처리 중 오류가 발생했습니다.');
+        router.replace('/login');
       },
       onSettled: () => {
         setIsWithdrawModalOpen(false);
@@ -191,13 +192,16 @@ export default function MypagePage() {
           </div>
 
           {/* 체크박스 */}
-          <div
-            className="flex cursor-pointer items-center gap-3 px-2"
-            onClick={() => setIsWithdrawAgreed(!isWithdrawAgreed)}
-          >
-            {isWithdrawAgreed ? <SelectedIcon /> : <SelectIcon />}
+          <label className="flex cursor-pointer items-center gap-3 px-2">
+            <input
+              type="checkbox"
+              checked={isWithdrawAgreed}
+              onChange={(e) => setIsWithdrawAgreed(e.target.checked)}
+              className="sr-only"
+            />
+            {isWithdrawAgreed ? <SelectedIcon aria-hidden /> : <SelectIcon aria-hidden />}
             <span className="text-body-2-medium text-gray-900">{WITHDRAW_MODAL.checkboxLabel}</span>
-          </div>
+          </label>
 
           {/* 버튼 */}
           <div className="flex gap-2">

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -217,7 +217,7 @@ export default function MypagePage() {
               type="button"
               onClick={handleWithdraw}
               disabled={!isWithdrawAgreed || isWithdrawing}
-              className="flex h-12 flex-1 items-center justify-center rounded-full bg-gray-900 text-body-2-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex h-12 flex-1 cursor-pointer items-center justify-center rounded-full bg-gray-900 text-body-2-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
             >
               {isWithdrawing ? <Spinner /> : WITHDRAW_MODAL.confirmButton}
             </button>

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import ArrowRightIcon from '@/public/icons/common/arrow-right.svg';
-import { BottomNav } from '@/src/components/common';
+import SelectIcon from '@/public/icons/signup/select.svg';
+import SelectedIcon from '@/public/icons/signup/selected.svg';
+import { BottomNav, BaseModal } from '@/src/components/common';
+import { Spinner } from '@/src/components/auth/common/Spinner';
 import { MenuList, MyMenuCard, ProfileCard } from '@/src/components/mypage';
 import { useAuthReady, useSimpleProfile } from '@/src/hooks/custom/mypage';
-import { useLogout } from '@/src/hooks/queries/auth';
+import { useLogout, useWithdraw } from '@/src/hooks/queries/auth';
 import { useUnreadNotificationCount } from '@/src/hooks/queries';
 import { useToast } from '@/src/hooks/common/useToast';
 import {
@@ -16,13 +19,19 @@ import {
   MODEL_QUICK_ACTIONS,
   DESIGNER_QUICK_ACTIONS,
   ROLE_FALLBACK_NAMES,
+  WITHDRAW_MODAL,
 } from '@/src/constants/mypage';
 
 export default function MypagePage() {
   const router = useRouter();
   const { user, role, isLoggedIn, authReady } = useAuthReady();
   const { mutate: logout, isPending: isLoggingOut } = useLogout();
+  const { mutate: withdraw, isPending: isWithdrawing } = useWithdraw();
   const { showToast } = useToast();
+
+  // 탈퇴 모달 상태
+  const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
+  const [isWithdrawAgreed, setIsWithdrawAgreed] = useState(false);
 
   // 프로필 조회
   const {
@@ -83,10 +92,41 @@ export default function MypagePage() {
     });
   };
 
+  // 탈퇴 모달 열기
+  const handleOpenWithdrawModal = () => {
+    setIsWithdrawAgreed(false);
+    setIsWithdrawModalOpen(true);
+  };
+
+  // 탈퇴 모달 닫기
+  const handleCloseWithdrawModal = () => {
+    if (isWithdrawing) return;
+    setIsWithdrawModalOpen(false);
+    setIsWithdrawAgreed(false);
+  };
+
+  // 탈퇴 처리
+  const handleWithdraw = () => {
+    if (isWithdrawing || !isWithdrawAgreed) return;
+    withdraw(undefined, {
+      onSuccess: () => {
+        showToast('탈퇴가 완료되었습니다.');
+        router.replace('/login');
+      },
+      onError: () => {
+        showToast('탈퇴 처리 중 오류가 발생했습니다.');
+      },
+      onSettled: () => {
+        setIsWithdrawModalOpen(false);
+      },
+    });
+  };
+
   // 계정 메뉴 아이템 (onClick 연결, 비로그인 시 비활성화)
   const accountMenuItems = ACCOUNT_LINKS.map((label) => ({
     label,
-    onClick: label === '로그아웃' ? handleLogout : undefined,
+    onClick:
+      label === '로그아웃' ? handleLogout : label === '탈퇴하기' ? handleOpenWithdrawModal : undefined,
     disabled: !isLoggedIn,
   }));
 
@@ -130,6 +170,56 @@ export default function MypagePage() {
         </div>
       </div>
       <BottomNav />
+
+      {/* 탈퇴 확인 모달 */}
+      <BaseModal
+        isOpen={isWithdrawModalOpen}
+        onClose={handleCloseWithdrawModal}
+        disableClose={isWithdrawing}
+      >
+        <div className="flex flex-col gap-6">
+          {/* 제목 + 유의사항 */}
+          <div className="flex flex-col items-center gap-6 text-gray-900">
+            <p className="text-head-4-semibold text-center">{WITHDRAW_MODAL.title}</p>
+            <ul className="flex flex-col gap-4 text-body-2-medium list-disc pl-5">
+              {WITHDRAW_MODAL.notices.map((notice, index) => (
+                <li key={index} className="whitespace-pre-wrap">
+                  {notice}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* 체크박스 */}
+          <div
+            className="flex cursor-pointer items-center gap-3 px-2"
+            onClick={() => setIsWithdrawAgreed(!isWithdrawAgreed)}
+          >
+            {isWithdrawAgreed ? <SelectedIcon /> : <SelectIcon />}
+            <span className="text-body-2-medium text-gray-900">{WITHDRAW_MODAL.checkboxLabel}</span>
+          </div>
+
+          {/* 버튼 */}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleCloseWithdrawModal}
+              disabled={isWithdrawing}
+              className="flex h-12 flex-1 items-center justify-center rounded-full border border-gray-400 bg-white text-body-2-medium text-gray-900 disabled:cursor-not-allowed"
+            >
+              {WITHDRAW_MODAL.cancelButton}
+            </button>
+            <button
+              type="button"
+              onClick={handleWithdraw}
+              disabled={!isWithdrawAgreed || isWithdrawing}
+              className="flex h-12 flex-1 items-center justify-center rounded-full bg-gray-900 text-body-2-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isWithdrawing ? <Spinner /> : WITHDRAW_MODAL.confirmButton}
+            </button>
+          </div>
+        </div>
+      </BaseModal>
     </div>
   );
 }

--- a/src/constants/mypage.ts
+++ b/src/constants/mypage.ts
@@ -43,3 +43,15 @@ export const ROLE_FALLBACK_NAMES = {
   model: '모델',
   designer: '디자이너',
 } as const;
+
+/** 탈퇴 모달 텍스트 */
+export const WITHDRAW_MODAL = {
+  title: '정말 탈퇴하시겠습니까?',
+  notices: [
+    '탈퇴일 포함 5일 동안 재가입이 불가하며,\n재가입 시에도 이용 내역은 복구되지 않습니다.',
+    '탈퇴 고객의 개인 정보는 개인정보 관련 법령에\n따라, 일정 기간 안전하게 보관되며 그 이후에\n자동 파기됩니다.',
+  ],
+  checkboxLabel: '유의사항을 확인했습니다',
+  cancelButton: '취소',
+  confirmButton: '탈퇴하기',
+} as const;

--- a/src/hooks/queries/auth/useAuth.ts
+++ b/src/hooks/queries/auth/useAuth.ts
@@ -74,5 +74,6 @@ export function useSocialLoginCallback() {
 export function useWithdraw() {
   return useMutation<ApiResponse<WithdrawResponse>, Error, void>({
     mutationFn: withdraw,
+    retry: 0, // 탈퇴는 재시도하지 않음
   });
 }

--- a/src/hooks/queries/auth/useAuth.ts
+++ b/src/hooks/queries/auth/useAuth.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { login, logout, validateToken, socialSignup, processSocialLoginCallback } from '@/src/apis';
+import { login, logout, validateToken, socialSignup, processSocialLoginCallback, withdraw } from '@/src/apis';
 import type {
   LoginRequest,
   LoginResponse,
@@ -9,6 +9,7 @@ import type {
   SocialSignupResponse,
   SocialLoginCallbackRequest,
   SocialLoginCallbackResponse,
+  WithdrawResponse,
   ApiResponse,
 } from '@/src/types';
 
@@ -64,5 +65,14 @@ export function useSocialLoginCallback() {
   >({
     mutationFn: ({ provider, payload }) => processSocialLoginCallback(provider, payload),
     retry: 0, // 소셜 로그인 콜백은 재시도하지 않음
+  });
+}
+
+/**
+ * 회원 탈퇴 mutation hook
+ */
+export function useWithdraw() {
+  return useMutation<ApiResponse<WithdrawResponse>, Error, void>({
+    mutationFn: withdraw,
   });
 }

--- a/src/types/auth/auth.ts
+++ b/src/types/auth/auth.ts
@@ -125,3 +125,9 @@ export interface SocialLoginCallbackResponse {
   userRole: 'MODEL' | 'DESIGNER';
   category?: 'HAIR' | 'NAIL' | 'TATTOO' | 'EYELASH'; // 디자이너 카테고리
 }
+
+// 회원 탈퇴 관련 타입
+
+export interface WithdrawResponse {
+  message: string;
+}


### PR DESCRIPTION
### 💡 To Reviewers

- 탈퇴 API 연동 및 모달 UI 구현

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- `DELETE /auth/withdraw` API 연동
- axios interceptor에 `/auth/withdraw` 엔드포인트 토큰 주입 설정 추가
- `WithdrawResponse` 타입, `withdraw` API 함수, `useWithdraw` 훅 구현
- 마이페이지 탈퇴 모달 UI 구현 (피그마 디자인 기준)
  - 유의사항 체크박스 (체크해야 탈퇴 버튼 활성화)
  - 로딩 시 Spinner 표시
  - 탈퇴 완료 시 토스트 + 로그인 페이지 이동
- 탈퇴 모달 텍스트 상수 분리 (`WITHDRAW_MODAL`)

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 탈퇴하기 버튼 클릭 → 확인 모달 표시
- 체크박스 체크 후 탈퇴 버튼 활성화
- 탈퇴 완료 시 로그인 페이지 이동

### 🔗 관련 이슈

- #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 마이페이지에 계정 탈퇴 기능 추가
  * 탈퇴 확인 모달에서 다국어 주의사항 안내 및 동의 체크박스 제공
  * 탈퇴 동작 중 로딩(스피너) 표시 및 버튼 비활성화 처리
  * 탈퇴 성공 시 로그인 화면으로 자동 이동 및 완료 알림 표시
  * 탈퇴 실패 시 오류 알림 표시 및 모달 안전한 종료 처리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->