### PR TITLE
[FIX] 포트폴리오 Mock 데이터 삭제 및 프로필 관련 일부 수정

### DIFF
--- a/src/app/(common)/mypage/portfolio/page.tsx
+++ b/src/app/(common)/mypage/portfolio/page.tsx
@@ -16,6 +16,9 @@ export default function PortfolioManagePage() {
 
   const portfolioItems = useMemo(() => data?.pages.flatMap((page) => page.result.items) ?? [], [data]);
   const portfolioImages = useMemo(() => portfolioItems.map((item) => item.thumbnail), [portfolioItems]);
+  const portfolioKey = portfolioItems.length
+    ? portfolioItems.map((item) => item.portfolioId).join('-')
+    : 'empty';
   const { loadMoreRef } = useInfiniteScroll({ hasNextPage, isFetchingNextPage, fetchNextPage });
 
   const handleAddPortfolio = () => {
@@ -70,6 +73,7 @@ export default function PortfolioManagePage() {
         ) : (
           <>
             <DesignerProfileEditPortfolio
+              key={portfolioKey}
               images={portfolioImages}
               onEditImage={handleEditImage}
               onDeleteImage={handleDeleteImage}

--- a/src/components/designerProfile/DesignerPortfolioReviewSection.tsx
+++ b/src/components/designerProfile/DesignerPortfolioReviewSection.tsx
@@ -41,6 +41,7 @@ export default function DesignerPortfolioReviewSection({
   onReviewPreviewMore,
 }: DesignerPortfolioReviewSectionProps) {
   const portfolioCount = portfolioTotalCount ?? portfolioImages.length;
+  const hasPortfolios = portfolioImages.length > 0;
 
   return (
     <section className="border-gray-200">
@@ -79,43 +80,49 @@ export default function DesignerPortfolioReviewSection({
             <button
               type="button"
               onClick={onPortfolioViewAll}
-              disabled={!onPortfolioViewAll}
+              disabled={!onPortfolioViewAll || !hasPortfolios}
               className="text-body-2-medium flex cursor-pointer items-center justify-center gap-0.5 text-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
             >
               자세히 보기
               <ChevronRightIcon className="h-5 w-5 -translate-y-px text-gray-800" />
             </button>
           </div>
-          <div className="grid grid-cols-3 gap-2.5 px-4 pt-3 pb-[calc(32px+env(safe-area-inset-bottom))]">
-            {portfolioImages.map((imageUrl, index) => {
-              const portfolioId = portfolioIds?.[index];
-              const isClickable = typeof portfolioId === 'number' && !!onPortfolioSelect;
+          {hasPortfolios ? (
+            <div className="grid grid-cols-3 gap-2.5 px-4 pt-3 pb-[calc(32px+env(safe-area-inset-bottom))]">
+              {portfolioImages.map((imageUrl, index) => {
+                const portfolioId = portfolioIds?.[index];
+                const isClickable = typeof portfolioId === 'number' && !!onPortfolioSelect;
 
-              return (
-                <button
-                  key={`${imageUrl}-${index}`}
-                  type="button"
-                  onClick={() => {
-                    if (!isClickable) return;
-                    onPortfolioSelect?.(portfolioId);
-                  }}
-                  className={`border-0 p-0 relative h-[151px] w-full overflow-hidden rounded-lg bg-gray-200 ${
-                    isClickable ? 'cursor-pointer' : 'cursor-default'
-                  }`}
-                  disabled={!isClickable}
-                  aria-label={isClickable ? '포트폴리오 상세 보기' : undefined}
-                >
-                  <Image
-                    src={imageUrl}
-                    alt={`포트폴리오 이미지 ${index + 1}`}
-                    fill
-                    sizes="33vw"
-                    className="object-cover"
-                  />
-                </button>
-              );
-            })}
-          </div>
+                return (
+                  <button
+                    key={`${imageUrl}-${index}`}
+                    type="button"
+                    onClick={() => {
+                      if (!isClickable) return;
+                      onPortfolioSelect?.(portfolioId);
+                    }}
+                    className={`relative h-[151px] w-full overflow-hidden rounded-lg border-0 bg-gray-200 p-0 ${
+                      isClickable ? 'cursor-pointer' : 'cursor-default'
+                    }`}
+                    disabled={!isClickable}
+                    aria-label={isClickable ? '포트폴리오 상세 보기' : undefined}
+                  >
+                    <Image
+                      src={imageUrl}
+                      alt={`포트폴리오 이미지 ${index + 1}`}
+                      fill
+                      sizes="33vw"
+                      className="object-cover"
+                    />
+                  </button>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="flex items-center justify-center px-4 pt-11 pb-[calc(60px+env(safe-area-inset-bottom))]">
+              <p className="text-body-2-medium text-gray-500">등록된 포트폴리오가 없습니다.</p>
+            </div>
+          )}
         </>
       ) : (
         <>

--- a/src/components/designerProfile/DesignerPortfolioReviewSection.tsx
+++ b/src/components/designerProfile/DesignerPortfolioReviewSection.tsx
@@ -77,15 +77,16 @@ export default function DesignerPortfolioReviewSection({
               <span className="text-body-1-medium text-black">전체</span>
               <span className="text-body-1-semibold text-gray-600">{portfolioCount}</span>
             </div>
-            <button
-              type="button"
-              onClick={onPortfolioViewAll}
-              disabled={!onPortfolioViewAll || !hasPortfolios}
-              className="text-body-2-medium flex cursor-pointer items-center justify-center gap-0.5 text-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              자세히 보기
-              <ChevronRightIcon className="h-5 w-5 -translate-y-px text-gray-800" />
-            </button>
+            {onPortfolioViewAll && hasPortfolios && (
+              <button
+                type="button"
+                onClick={onPortfolioViewAll}
+                className="text-body-2-medium flex cursor-pointer items-center justify-center gap-0.5 text-gray-800"
+              >
+                자세히 보기
+                <ChevronRightIcon className="h-5 w-5 -translate-y-px text-gray-800" />
+              </button>
+            )}
           </div>
           {hasPortfolios ? (
             <div className="grid grid-cols-3 gap-2.5 px-4 pt-3 pb-[calc(32px+env(safe-area-inset-bottom))]">

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -33,23 +33,11 @@ interface DesignerProfileViewProps {
   onAction?: () => void;
 }
 
-const defaultPortfolioImages = [
-  '/images/mocks/portfolio-1.png',
-  '/images/mocks/portfolio-2.png',
-  '/images/mocks/portfolio-3.png',
-  '/images/mocks/portfolio-4.png',
-  '/images/mocks/portfolio-5.png',
-  '/images/mocks/portfolio-6.png',
-  '/images/mocks/hair-1.png',
-  '/images/mocks/hair-2.png',
-  '/images/mocks/hair-3.png',
-];
-
 export default function DesignerProfileView({
   profile,
   openRecruitments,
   portfolioItems,
-  portfolioImages = defaultPortfolioImages,
+  portfolioImages = [],
   portfolioTotalCount,
   actionType = 'none',
   showActionBar = false,
@@ -217,7 +205,7 @@ export default function DesignerProfileView({
     if (portfolioItems && portfolioItems.length > 0) {
       return portfolioItems.map((item) => item.thumbnail);
     }
-    return portfolioImages;
+    return portfolioImages ?? [];
   }, [portfolioItems, portfolioImages]);
 
   const resolvedPortfolioIds = useMemo(() => {

--- a/src/components/designerProfile/edit/DesignerProfileEditHero.tsx
+++ b/src/components/designerProfile/edit/DesignerProfileEditHero.tsx
@@ -33,13 +33,15 @@ export default function DesignerProfileEditHero({
 
       <DesignerProfileHeader actionType="none" onBack={onBack} />
 
-      <button
-        type="button"
-        onClick={onEditImage}
-        className="text-body-2-medium absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full border border-gray-400 bg-white px-4 py-2 text-gray-900 shadow-sm"
-      >
-        대표 이미지 수정
-      </button>
+      {onEditImage && (
+        <button
+          type="button"
+          onClick={onEditImage}
+          className="text-body-2-medium absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full border border-gray-400 bg-white px-4 py-2 text-gray-900 shadow-sm"
+        >
+          대표 이미지 수정
+        </button>
+      )}
     </section>
   );
 }

--- a/src/components/designerProfile/edit/DesignerProfileEditPortfolio.tsx
+++ b/src/components/designerProfile/edit/DesignerProfileEditPortfolio.tsx
@@ -96,7 +96,6 @@ export default function DesignerProfileEditPortfolio({
                     }}
                   />
                 </div>
-
                 <KebabMenu
                   isOpen={isMenuOpen}
                   onOpenChange={(open) => setOpenMenuIndex(open ? index : null)}

--- a/src/components/designerProfile/edit/DesignerProfileEditPortfolio.tsx
+++ b/src/components/designerProfile/edit/DesignerProfileEditPortfolio.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import Image from 'next/image';
 import ChevronRightIcon from '@/public/icons/common/chevron-right.svg';
 import KebabMenu from '@/src/components/common/KebabMenu/KebabMenu';
@@ -25,34 +25,23 @@ export default function DesignerProfileEditPortfolio({
   gridClassName = 'relative mt-3 grid grid-cols-3 gap-2.5',
 }: DesignerProfileEditPortfolioProps) {
   const [openMenuIndex, setOpenMenuIndex] = useState<number | null>(null);
-  const [imageSources, setImageSources] = useState<string[]>(images);
   const [imageLoaded, setImageLoaded] = useState<boolean[]>(() => images.map(() => false));
-  const retryCountsRef = useRef<Record<number, number>>({});
-
-  useEffect(() => {
-    setImageSources(images);
-    retryCountsRef.current = {};
-    setImageLoaded(images.map(() => false));
-  }, [images]);
+  const [retrySeeds, setRetrySeeds] = useState<number[]>(() => images.map(() => 0));
 
   const handleImageError = (index: number) => {
-    const retries = retryCountsRef.current[index] ?? 0;
-    if (retries >= 2) return;
-    retryCountsRef.current[index] = retries + 1;
-
-    const original = imageSources[index];
-    if (!original) return;
-    const separator = original.includes('?') ? '&' : '?';
-    const nextSrc = `${original}${separator}retry=${Date.now()}`;
-
-    setTimeout(() => {
-      setImageSources((prev) => {
-        if (!prev[index]) return prev;
-        const next = [...prev];
-        next[index] = nextSrc;
-        return next;
-      });
-    }, 600);
+    setRetrySeeds((prev) => {
+      const current = prev[index] ?? 0;
+      if (current >= 2) return prev;
+      const next = [...prev];
+      next[index] = current + 1;
+      return next;
+    });
+    setImageLoaded((prev) => {
+      if (!prev[index]) return prev;
+      const next = [...prev];
+      next[index] = false;
+      return next;
+    });
   };
 
   return (
@@ -71,22 +60,25 @@ export default function DesignerProfileEditPortfolio({
         )}
       </div>
 
-      {imageSources.length > 0 ? (
+      {images.length > 0 ? (
         <div className={gridClassName}>
-          {imageSources.map((imageUrl, index) => {
+          {images.map((imageUrl, index) => {
             const isMenuOpen = openMenuIndex === index;
             const isLoaded = imageLoaded[index];
+            const seed = retrySeeds[index] ?? 0;
+            const separator = imageUrl.includes('?') ? '&' : '?';
+            const resolvedSrc = seed > 0 ? `${imageUrl}${separator}retry=${seed}` : imageUrl;
             return (
               <div key={`${imageUrl}-${index}`} className="relative overflow-visible">
                 <div className="relative h-[135px] w-full overflow-hidden rounded-2xl bg-gray-200">
                   <Image
-                    src={imageUrl}
+                    src={resolvedSrc}
                     alt={`포트폴리오 이미지 ${index + 1}`}
                     fill
                     sizes="33vw"
                     className={`object-cover transition-opacity ${isLoaded ? 'opacity-100' : 'opacity-0'}`}
                     onError={() => handleImageError(index)}
-                    onLoadingComplete={() => {
+                    onLoad={() => {
                       setImageLoaded((prev) => {
                         if (prev[index]) return prev;
                         const next = [...prev];

--- a/src/components/designerProfile/edit/DesignerProfileEditPortfolio.tsx
+++ b/src/components/designerProfile/edit/DesignerProfileEditPortfolio.tsx
@@ -71,44 +71,50 @@ export default function DesignerProfileEditPortfolio({
         )}
       </div>
 
-      <div className={gridClassName}>
-        {imageSources.map((imageUrl, index) => {
-          const isMenuOpen = openMenuIndex === index;
-          const isLoaded = imageLoaded[index];
-          return (
-            <div key={`${imageUrl}-${index}`} className="relative overflow-visible">
-              <div className="relative h-[135px] w-full overflow-hidden rounded-2xl bg-gray-200">
-                <Image
-                  src={imageUrl}
-                  alt={`포트폴리오 이미지 ${index + 1}`}
-                  fill
-                  sizes="33vw"
-                  className={`object-cover transition-opacity ${isLoaded ? 'opacity-100' : 'opacity-0'}`}
-                  onError={() => handleImageError(index)}
-                  onLoadingComplete={() => {
-                    setImageLoaded((prev) => {
-                      if (prev[index]) return prev;
-                      const next = [...prev];
-                      next[index] = true;
-                      return next;
-                    });
-                  }}
+      {imageSources.length > 0 ? (
+        <div className={gridClassName}>
+          {imageSources.map((imageUrl, index) => {
+            const isMenuOpen = openMenuIndex === index;
+            const isLoaded = imageLoaded[index];
+            return (
+              <div key={`${imageUrl}-${index}`} className="relative overflow-visible">
+                <div className="relative h-[135px] w-full overflow-hidden rounded-2xl bg-gray-200">
+                  <Image
+                    src={imageUrl}
+                    alt={`포트폴리오 이미지 ${index + 1}`}
+                    fill
+                    sizes="33vw"
+                    className={`object-cover transition-opacity ${isLoaded ? 'opacity-100' : 'opacity-0'}`}
+                    onError={() => handleImageError(index)}
+                    onLoadingComplete={() => {
+                      setImageLoaded((prev) => {
+                        if (prev[index]) return prev;
+                        const next = [...prev];
+                        next[index] = true;
+                        return next;
+                      });
+                    }}
+                  />
+                </div>
+
+                <KebabMenu
+                  isOpen={isMenuOpen}
+                  onOpenChange={(open) => setOpenMenuIndex(open ? index : null)}
+                  items={[
+                    { label: '수정', onClick: () => onEditImage?.(index) },
+                    { label: '삭제', onClick: () => onDeleteImage?.(index) },
+                  ]}
+                  wrapperClassName="absolute top-2 right-2"
                 />
               </div>
-
-              <KebabMenu
-                isOpen={isMenuOpen}
-                onOpenChange={(open) => setOpenMenuIndex(open ? index : null)}
-                items={[
-                  { label: '수정', onClick: () => onEditImage?.(index) },
-                  { label: '삭제', onClick: () => onDeleteImage?.(index) },
-                ]}
-                wrapperClassName="absolute top-2 right-2"
-              />
-            </div>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-3 rounded-2xl bg-gray-100 px-4 py-6 text-center">
+          <p className="text-body-2-medium text-gray-500">등록된 포트폴리오가 없습니다.</p>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/components/designerProfile/edit/DesignerProfileEditView.tsx
+++ b/src/components/designerProfile/edit/DesignerProfileEditView.tsx
@@ -163,6 +163,9 @@ export default function DesignerProfileEditView({
   const resolvedPortfolioImages = portfolioItems?.length
     ? portfolioItems.map((item) => item.thumbnail)
     : portfolioImages;
+  const portfolioKey = portfolioItems?.length
+    ? portfolioItems.map((item) => item.portfolioId).join('-')
+    : resolvedPortfolioImages.join('|') || 'empty';
 
   return (
     <div className="flex min-h-screen flex-col bg-gray-100">
@@ -267,6 +270,7 @@ export default function DesignerProfileEditView({
 
       <section className="px-4 pt-6 pb-[calc(24px+env(safe-area-inset-bottom))]">
         <DesignerProfileEditPortfolio
+          key={portfolioKey}
           images={resolvedPortfolioImages}
           onViewAll={() => router.push('/mypage/portfolio')}
           onEditImage={

--- a/src/components/designerProfile/edit/DesignerProfileEditView.tsx
+++ b/src/components/designerProfile/edit/DesignerProfileEditView.tsx
@@ -170,7 +170,7 @@ export default function DesignerProfileEditView({
         profileImageUrl={resolvedProfileImageUrl}
         nickname={form.nickname}
         onBack={handleBack}
-        onEditImage={handleEditImage}
+        onEditImage={isEditing ? handleEditImage : undefined}
       />
       <input ref={fileInputRef} type="file" accept="image/*" onChange={handleImageChange} className="hidden" />
 

--- a/src/components/designerProfile/review/DesignerReviewSummary.tsx
+++ b/src/components/designerProfile/review/DesignerReviewSummary.tsx
@@ -17,7 +17,7 @@ export default function DesignerReviewSummary({ rating, count, onViewAll }: Desi
         <span className="text-body-1-semibold text-gray-900">{rating.toFixed(1)}</span>
         <span className="text-body-2-semibold text-gray-500">({count})</span>
       </div>
-      {onViewAll && (
+      {onViewAll && count > 0 && (
         <button
           type="button"
           onClick={onViewAll}

--- a/src/hooks/queries/profile/useDesignerProfile.ts
+++ b/src/hooks/queries/profile/useDesignerProfile.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getMyDesignerProfile, getPublicDesignerProfile, updateMyDesignerProfile } from '@/src/apis/profile';
 import { useToast } from '@/src/hooks/common/useToast';
+import { mypageKeys } from '@/src/hooks/queries/mypage';
 import type { ApiResponse } from '@/src/types';
 import type { DesignerProfileResponse, DesignerProfileUpdateRequest } from '@/src/types/profile';
 
@@ -63,6 +64,7 @@ export function useUpdateMyDesignerProfile() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: designerProfileKeys.all });
       queryClient.invalidateQueries({ queryKey: publicProfileKeys.all });
+      queryClient.invalidateQueries({ queryKey: mypageKeys.all });
       showToast('프로필이 저장되었습니다.');
     },
     onError: () => {


### PR DESCRIPTION
### 💡 To Reviewers

- 기존에 등록된 포트폴리오가 없을 시 뜨던 Mock 데이터를 삭제 후, 리뷰나 포트폴리오가 없을 경우 문구를 추가했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 기존에 등록된 포트폴리오가 없을 시 뜨던 Mock 데이터를 삭제
- 리뷰, 포트폴리오가 없을 경우 문구 추가
- 데이터 없을 경우 전체보기, 자세히 보기 버튼 안뜨도록
- 프로필 수정 화면 이미지 수정 버튼 - 수정하기 눌러야 버튼 활성화
- 이미지 수정 후 mypage 돌아오면 데이터 갱신 안되던 문제 수정

### 🤔 추후 작업 예정


### 📸 작업 결과 (스크린샷)

<img width="301" height="646" alt="image" src="https://github.com/user-attachments/assets/fc01768b-a322-43fc-868f-deb5ad2c71ca" />


### 🔗 관련 이슈

- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #158 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 포트폴리오가 없을 때 "등록된 포트폴리오가 없습니다." 안내 메시지 표시
  * 포트폴리오가 있을 때만 "자세히 보기"/"전체보기" 버튼 노출
  * 편집 모드에서만 대표 이미지 수정 버튼 활성화
  * 포트폴리오 항목 클릭성 및 메뉴 작동 개선으로 편집/삭제 접근성 향상
  * 이미지 로딩 신뢰성 개선 및 프로필 업데이트 시 캐시 동기화 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->