### PR TITLE
[FEAT] 예약 상태 필드 연동 및 수정/삭제 권한 구현

### DIFF
--- a/src/app/(designer)/myRecruitment/page.tsx
+++ b/src/app/(designer)/myRecruitment/page.tsx
@@ -11,9 +11,11 @@ import { RecruitmentTabs, type RecruitmentTabType } from '@/src/components/myRec
 import { ConfirmModal } from '@/src/components/common';
 import { useDesignerRecruitments, useDeleteRecruitment } from '@/src/hooks/queries/myRecruitment';
 import { useMonthNavigation, useDeleteModal } from '@/src/hooks/custom/myRecruitment';
+import { useToast } from '@/src/hooks/common/useToast';
 
 export default function MyRecruitmentPage() {
   const router = useRouter();
+  const { showToast } = useToast();
 
   // 탭 상태
   const [activeTab, setActiveTab] = useState<RecruitmentTabType>('active');
@@ -90,9 +92,35 @@ export default function MyRecruitmentPage() {
     router.push(`/myRecruitment/${id}`);
   };
 
+  // 공고 찾기 헬퍼
+  const findRecruitment = (id: number) => activeRecruitments.find((r) => r.recruitmentId === id);
+
   // 수정 핸들러
   const handleEdit = (id: number) => {
+    const recruitment = findRecruitment(id);
+    if (recruitment && !recruitment.canModify) {
+      if (recruitment.hasPendingReservation) {
+        showToast('대기 중인 예약이 있어 수정이 불가합니다.');
+      } else if (recruitment.hasConfirmedReservation) {
+        showToast('확정된 예약이 있어 수정이 불가합니다.');
+      }
+      return;
+    }
     router.push(`/myRecruitment/${id}/edit`);
+  };
+
+  // 삭제 모달 열기 핸들러
+  const handleDeleteClick = (id: number) => {
+    const recruitment = findRecruitment(id);
+    if (recruitment && !recruitment.canModify) {
+      if (recruitment.hasPendingReservation) {
+        showToast('대기 중인 예약이 있어 삭제가 불가합니다.');
+      } else if (recruitment.hasConfirmedReservation) {
+        showToast('확정된 예약이 있어 삭제가 불가합니다.');
+      }
+      return;
+    }
+    openModal(id);
   };
 
   // 삭제 핸들러
@@ -137,7 +165,7 @@ export default function MyRecruitmentPage() {
               <RecruitmentList
                 recruitments={activeRecruitments}
                 onEdit={handleEdit}
-                onDelete={openModal}
+                onDelete={handleDeleteClick}
                 onClick={handleCardClick}
                 onLoadMore={fetchActiveNextPage}
                 hasMore={hasActiveNextPage}

--- a/src/components/post/Actions/PostActions.tsx
+++ b/src/components/post/Actions/PostActions.tsx
@@ -8,9 +8,14 @@ import { FixedBottomContainer } from '@/src/components/common/FixedBottomContain
 interface PostActionsProps {
   recruitmentId: number;
   designerUserId: number;
+  hasPendingReservation?: boolean;
 }
 
-export default function PostActions({ recruitmentId, designerUserId }: PostActionsProps) {
+export default function PostActions({
+  recruitmentId,
+  designerUserId,
+  hasPendingReservation = false,
+}: PostActionsProps) {
   const router = useRouter();
   const createChatRoom = useCreateChatRoom();
   const { showToast } = useToast();
@@ -27,6 +32,10 @@ export default function PostActions({ recruitmentId, designerUserId }: PostActio
   };
 
   const handleReservation = () => {
+    if (hasPendingReservation) {
+      showToast('대기 중인 예약이 있습니다.');
+      return;
+    }
     router.push(`/reservation/${recruitmentId}`);
   };
 

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -370,16 +370,12 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
       {/* 하단 액션 버튼 */}
       {isOwner ? (
         // 본인 공고: 수정하기 버튼
+        // TODO: 디자이너 상세 페이지 수정 차단 - 현재 API(GET /recruitments/{id})의 hasPendingReservation은
+        // "현재 로그인한 모델 기준"이므로 디자이너가 조회하면 항상 false. 백엔드에 canModify 필드 추가 요청 필요.
         <FixedBottomContainer>
           <button
             type="button"
-            onClick={() => {
-              if (detail.hasPendingReservation) {
-                showToast('대기 중인 예약이 있어 수정이 불가합니다.');
-                return;
-              }
-              router.push(`/myRecruitment/${recruitmentId}/edit`);
-            }}
+            onClick={() => router.push(`/myRecruitment/${recruitmentId}/edit`)}
             className="text-body-1-semibold h-[56px] w-full cursor-pointer rounded-full bg-gray-900 text-white"
           >
             수정하기

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -29,6 +29,7 @@ import {
 import CheckIcon from '@/public/icons/post/check.svg';
 import CloseIcon from '@/public/icons/common/close.svg';
 import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
+import { useToast } from '@/src/hooks/common/useToast';
 
 interface PostDetailContentProps {
   recruitmentId: number;
@@ -37,6 +38,7 @@ interface PostDetailContentProps {
 
 export default function PostDetailContent({ recruitmentId, isOwner = false }: PostDetailContentProps) {
   const router = useRouter();
+  const { showToast } = useToast();
   const [activeTab, setActiveTab] = useState<'detail' | 'review'>('detail');
 
   // Optimistic update를 위한 토글 카운트 (홀수면 반전)
@@ -371,7 +373,13 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
         <FixedBottomContainer>
           <button
             type="button"
-            onClick={() => router.push(`/myRecruitment/${recruitmentId}/edit`)}
+            onClick={() => {
+              if (detail.hasPendingReservation) {
+                showToast('대기 중인 예약이 있어 수정이 불가합니다.');
+                return;
+              }
+              router.push(`/myRecruitment/${recruitmentId}/edit`);
+            }}
             className="text-body-1-semibold h-[56px] w-full cursor-pointer rounded-full bg-gray-900 text-white"
           >
             수정하기
@@ -379,7 +387,11 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
         </FixedBottomContainer>
       ) : (
         // 다른 사람 공고: 채팅하기 / 예약하기
-        <PostActions recruitmentId={detail.recruitmentId} designerUserId={detail.designerProfile.userId} />
+        <PostActions
+          recruitmentId={detail.recruitmentId}
+          designerUserId={detail.designerProfile.userId}
+          hasPendingReservation={detail.hasPendingReservation}
+        />
       )}
     </div>
   );

--- a/src/hooks/queries/designerHome/useDesignerReservations.ts
+++ b/src/hooks/queries/designerHome/useDesignerReservations.ts
@@ -8,6 +8,7 @@ import {
 } from '@/src/apis/designer';
 import { useToast } from '@/src/hooks/common/useToast';
 import { calendarKeys } from '@/src/hooks/queries/calendar';
+import { myRecruitmentKeys } from '@/src/hooks/queries/myRecruitment';
 import type { ApiResponse } from '@/src/types';
 import type {
   TodayReservationsResult,
@@ -83,6 +84,7 @@ export function useConfirmReservation() {
       queryClient.invalidateQueries({ queryKey: designerReservationKeys.all });
       queryClient.invalidateQueries({ queryKey: designerReservationKeys.detail(reservationId) });
       queryClient.invalidateQueries({ queryKey: calendarKeys.all });
+      queryClient.invalidateQueries({ queryKey: myRecruitmentKeys.lists() });
     },
     onError: () => {
       showToast('예약 확정에 실패했습니다.');
@@ -104,6 +106,7 @@ export function useRejectReservation() {
       queryClient.invalidateQueries({ queryKey: designerReservationKeys.all });
       queryClient.invalidateQueries({ queryKey: designerReservationKeys.detail(reservationId) });
       queryClient.invalidateQueries({ queryKey: calendarKeys.all });
+      queryClient.invalidateQueries({ queryKey: myRecruitmentKeys.lists() });
       showToast('예약이 거절되었습니다.');
     },
     onError: () => {

--- a/src/mocks/explore/recruitmentDetail.ts
+++ b/src/mocks/explore/recruitmentDetail.ts
@@ -48,6 +48,7 @@ export const mockRecruitmentDetail: RecruitmentDetail = {
   isLiked: false,
   reviewCount: 42,
   averageRating: 4.8,
+  hasPendingReservation: false,
 };
 
 // 두 번째 공고 상세 Mock 데이터
@@ -86,4 +87,5 @@ export const mockRecruitmentDetail2: RecruitmentDetail = {
   isLiked: true,
   reviewCount: 18,
   averageRating: 4.5,
+  hasPendingReservation: false,
 };

--- a/src/mocks/myRecruitment/recruitments.ts
+++ b/src/mocks/myRecruitment/recruitments.ts
@@ -17,6 +17,9 @@ export const mockMyRecruitmentItems: MockRecruitmentItem[] = [
     averageRating: 4.8,
     thumbnail: '/images/mocks/hair-1.png',
     subCategory: ['커트', '염색'],
+    hasPendingReservation: false,
+    hasConfirmedReservation: false,
+    canModify: true,
     _month: '2025-12',
   },
   {
@@ -27,6 +30,9 @@ export const mockMyRecruitmentItems: MockRecruitmentItem[] = [
     averageRating: 4.5,
     thumbnail: '/images/mocks/hair-2.png',
     subCategory: ['아트'],
+    hasPendingReservation: false,
+    hasConfirmedReservation: false,
+    canModify: true,
     _month: '2025-12',
   },
   {
@@ -37,6 +43,9 @@ export const mockMyRecruitmentItems: MockRecruitmentItem[] = [
     averageRating: 4.9,
     thumbnail: '/images/mocks/hair-3.png',
     subCategory: ['펌'],
+    hasPendingReservation: false,
+    hasConfirmedReservation: false,
+    canModify: true,
     _month: '2026-01',
   },
   {
@@ -47,6 +56,9 @@ export const mockMyRecruitmentItems: MockRecruitmentItem[] = [
     averageRating: 5.0,
     thumbnail: '/images/mocks/hair-4.png',
     subCategory: ['염색'],
+    hasPendingReservation: false,
+    hasConfirmedReservation: false,
+    canModify: true,
     _month: '2026-01',
   },
   {
@@ -57,6 +69,9 @@ export const mockMyRecruitmentItems: MockRecruitmentItem[] = [
     averageRating: 0,
     thumbnail: '/images/mocks/hair-5.png',
     subCategory: ['속눈썹 연장'],
+    hasPendingReservation: false,
+    hasConfirmedReservation: false,
+    canModify: true,
     _month: '2026-01',
   },
 ];

--- a/src/types/myRecruitment/recruitment.ts
+++ b/src/types/myRecruitment/recruitment.ts
@@ -47,6 +47,9 @@ export interface MyRecruitmentListItem {
   averageRating: number;
   thumbnail?: string;
   subCategory?: string[]; // 서브카테고리 배열 (예: ["커트"])
+  hasPendingReservation: boolean; // 대기 중인 예약 존재 여부
+  hasConfirmedReservation: boolean; // 진행 예정인 확정 예약 존재 여부
+  canModify: boolean; // 수정/삭제 가능 여부
 }
 
 /** 내 공고 리스트 응답 */

--- a/src/types/recruitment/recruitment.ts
+++ b/src/types/recruitment/recruitment.ts
@@ -96,5 +96,6 @@ export interface RecruitmentDetail {
   isLiked: boolean;
   reviewCount: number;
   averageRating: number;
+  hasPendingReservation: boolean; // 현재 모델의 대기 중인 예약 존재 여부
 }
 


### PR DESCRIPTION
### 💡 To Reviewers

- 새롭게 설치한 라이브러리 없음
- 백엔드에서 추가된 예약 상태 필드를 프론트엔드에 연동하여 수정/삭제 권한을 체크합니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

**타입 정의 추가**
- `MyRecruitmentListItem`에 `hasPendingReservation`, `hasConfirmedReservation`, `canModify` 필드 추가
- `RecruitmentDetail`에 `hasPendingReservation` 필드 추가

**디자이너 - 리스트 페이지 (`/myRecruitment`)**
- 수정/삭제 버튼 클릭 시 `canModify` 체크
- 대기 예약 시: "대기 중인 예약이 있어 수정/삭제가 불가합니다."
- 확정 예약 시: "확정된 예약이 있어 수정/삭제가 불가합니다."

**디자이너 - 상세 페이지 (`/myRecruitment/[id]`)**
- ⚠️ 수정 차단 미구현 - API 한계로 TODO 처리
- 현재 `GET /recruitments/{id}`의 `hasPendingReservation`은 "현재 로그인한 모델 기준"
- 디자이너가 조회하면 항상 `false`가 반환됨

**모델 - 공고 상세 (`/post/[id]`)**
- 예약 버튼 클릭 시 `hasPendingReservation` 체크
- 대기 예약 시: "대기 중인 예약이 있습니다." 토스트 표시

**쿼리 캐시 무효화**
- `useConfirmReservation`, `useRejectReservation` 성공 시 `myRecruitmentKeys.lists()` 캐시 무효화 추가
- 디자이너가 예약 확정/거절 후 내 공고 목록의 권한 상태가 즉시 갱신됨

### 🤔 추후 작업 예정

- 백엔드에 상세 API(`GET /recruitments/{recruitmentId}`)에 `hasConfirmedReservation`, `canModify` 필드 추가 요청
  - 추가 시 디자이너 상세 페이지에서도 수정 차단 가능

### 📸 작업 결과 (스크린샷)

- 테스트 필요

### 🔗 관련 이슈

- #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 펜딩 예약이 있는 채용공고의 수정/삭제 제한 기능 추가
  * 제한된 작업 시도 시 사용자 친화적인 토스트 알림으로 실시간 피드백 제공
  * 예약 상태에 따른 작업 사전 검증 로직 구현

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->