### PR TITLE
[FIX] 모델 홈 화면 - 내 주위 모집글 컴포넌트 잘리지 않도록 수정

### DIFF
--- a/src/components/explore/Cards/RecruitmentCard.tsx
+++ b/src/components/explore/Cards/RecruitmentCard.tsx
@@ -22,7 +22,7 @@ export default function RecruitmentCard({ recruitment, isLeftColumn = false, onL
   });
 
   return (
-    <Link href={`/post/${recruitment.recruitmentId}`} className="flex flex-col gap-2.5">
+    <Link href={`/post/${recruitment.recruitmentId}`} className="flex min-w-0 flex-col gap-2.5">
       {/* 이미지 */}
       <div className="relative h-[210px] w-full overflow-hidden rounded-none bg-gray-200">
         {recruitment.recruitmentThumbnail ? (
@@ -43,7 +43,7 @@ export default function RecruitmentCard({ recruitment, isLeftColumn = false, onL
       </div>
 
       {/* 정보 */}
-      <div className={`flex flex-col gap-2 ${isLeftColumn ? 'pr-[9px] pl-4' : 'pr-4 pl-2.5'}`}>
+      <div className={`flex min-w-0 flex-col gap-2 ${isLeftColumn ? 'pr-[9px] pl-4' : 'pr-4 pl-2.5'}`}>
         <div className="flex flex-col gap-1">
           {/* 제목 */}
           <h3 className="text-body-1-semibold truncate text-black">{recruitment.title}</h3>

--- a/src/components/modelHome/home/ModelHomeContent.tsx
+++ b/src/components/modelHome/home/ModelHomeContent.tsx
@@ -197,7 +197,7 @@ export function ModelHomeContent() {
               <div className="mt-2">
                 <div className="flex gap-2">
                   {[0, 1].map((index) => (
-                    <div key={`nearby-skeleton-${index}`} className="flex-1">
+                    <div key={`nearby-skeleton-${index}`} className="flex-1 min-w-0">
                       <RecruitmentCardSkeleton isLeftColumn={index % 2 === 0} />
                     </div>
                   ))}
@@ -219,7 +219,7 @@ export function ModelHomeContent() {
                     <SwiperSlide key={`nearby-slide-${slideIndex}`} className="w-full!">
                       <div className="flex gap-2">
                         {pair.map((item, index) => (
-                          <div key={item.recruitmentId} className="flex-1">
+                          <div key={item.recruitmentId} className="flex-1 min-w-0">
                             <RecruitmentCard
                               recruitment={item}
                               isLeftColumn={index === 0}
@@ -227,7 +227,7 @@ export function ModelHomeContent() {
                             />
                           </div>
                         ))}
-                        {pair.length === 1 && <div className="flex-1" aria-hidden />}
+                        {pair.length === 1 && <div className="flex-1 min-w-0" aria-hidden />}
                       </div>
                     </SwiperSlide>
                   ))}
@@ -239,7 +239,7 @@ export function ModelHomeContent() {
                   <SwiperSlide className="w-full!">
                     <div className="invisible flex w-full gap-2">
                       {[0, 1].map((index) => (
-                        <div key={`nearby-empty-${index}`} className="flex-1">
+                        <div key={`nearby-empty-${index}`} className="flex-1 min-w-0">
                           <RecruitmentCardSkeleton isLeftColumn={index % 2 === 0} />
                         </div>
                       ))}


### PR DESCRIPTION
### 💡 To Reviewers

- 모델 홈 화면에서 내 주위 모집글 부분 반응형에 따라 사이즈 깨지는 것 해결 했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 화면 컴포넌트 및 카드 컴포넌트 수정

### 🤔 추후 작업 예정


### 📸 작업 결과 (스크린샷)

<img width="376" height="732" alt="image" src="https://github.com/user-attachments/assets/e26377ce-fee0-41ce-846a-e21b6c66f0a9" />

### 🔗 관련 이슈

- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #172 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
* 컴포넌트 레이아웃 렌더링 안정성 개선으로 콘텐츠 자르기 및 크기 조정 동작이 더욱 견고해졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->