### PR TITLE
[FEAT] 공고 생성 시 다중 서브카테고리 선택 기능 및 CategoryBadge 공통 컴포넌트화

### DIFF
--- a/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
+++ b/src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx
@@ -28,8 +28,8 @@ export default function StepContent({ goNext, goPrev, isSubmitting = false, isEd
   const {
     content,
     setContent,
-    subCategory,
-    setSubCategory,
+    subCategories,
+    toggleSubCategory,
     restrictions,
     setRestrictions,
     notice,
@@ -89,7 +89,7 @@ export default function StepContent({ goNext, goPrev, isSubmitting = false, isEd
 
   // 등록 버튼 활성화 조건
   const isSubmitButtonEnabled = isStep2Valid(
-    { content, subCategory, restrictions, notice, imageFiles, imagePreviewUrls, purpose, purposeDetail },
+    { content, subCategories, restrictions, notice, imageFiles, imagePreviewUrls, purpose, purposeDetail },
     { isEditMode: isEdit },
   );
 
@@ -119,10 +119,11 @@ export default function StepContent({ goNext, goPrev, isSubmitting = false, isEd
         <Dropdown
           label="카테고리"
           required
+          multiple
           placeholder="시술 카테고리를 선택해주세요"
           options={subCategoryOptions}
-          value={subCategory}
-          onChange={setSubCategory}
+          value={subCategories}
+          onChange={toggleSubCategory}
         />
 
         {/* 제한 사항 */}

--- a/src/app/(designer)/reservations/[reservationId]/page.tsx
+++ b/src/app/(designer)/reservations/[reservationId]/page.tsx
@@ -125,7 +125,7 @@ export default function ReservationDetailPage() {
         {/* 카테고리 배지 + 공고 제목 */}
         <div className="mb-4 flex flex-col gap-2">
           <div className="flex flex-wrap items-center gap-2">
-            {[reservation.category, ...reservation.subCategories].map((cat) => (
+            {reservation.subCategories.map((cat) => (
               <span key={cat} className="text-caption-1-medium rounded-lg bg-purple-600 px-2 py-1 text-white">
                 {cat}
               </span>

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -54,6 +54,7 @@ export default function Dropdown<T = string>({
   scrollToSelected = false,
   maxHeight,
   align = 'right',
+  multiple = false,
   ariaLabel,
   buttonClassName,
 }: DropdownProps<T>) {
@@ -156,13 +157,38 @@ export default function Dropdown<T = string>({
   const handleSelect = useCallback(
     (optionValue: T) => {
       onChange(optionValue);
-      handleClose();
-      buttonRef.current?.focus();
+      if (!multiple) {
+        handleClose();
+        buttonRef.current?.focus();
+      }
     },
-    [onChange, handleClose],
+    [onChange, handleClose, multiple],
   );
 
   const selectedOption = options.find((opt) => opt.value === value);
+
+  // 다중 선택 모드 표시 텍스트
+  const getDisplayText = (): string => {
+    if (multiple && Array.isArray(value)) {
+      if (value.length === 0) return placeholder;
+      const labels = value
+        .map((v) => options.find((opt) => opt.value === v)?.label)
+        .filter(Boolean);
+      return labels.join(', ');
+    }
+    return selectedOption ? selectedOption.label : placeholder;
+  };
+
+  // 옵션 선택 여부 확인
+  const isOptionSelected = (optionValue: T): boolean => {
+    if (multiple && Array.isArray(value)) {
+      return value.includes(optionValue);
+    }
+    return value === optionValue;
+  };
+
+  // 값이 있는지 확인
+  const hasValue = multiple && Array.isArray(value) ? value.length > 0 : !!selectedOption;
 
   // Form variant
   if (variant === 'form') {
@@ -198,10 +224,10 @@ export default function Dropdown<T = string>({
               }`
             }
           >
-            <span className={`text-body-2-medium !text-[16px] ${selectedOption ? 'text-gray-900' : 'text-gray-600'}`}>
-              {selectedOption ? selectedOption.label : placeholder}
+            <span className={`truncate text-body-2-medium !text-[16px] ${hasValue ? 'text-gray-900' : 'text-gray-600'}`}>
+              {getDisplayText()}
             </span>
-            <ChevronDownIcon className={`h-5 w-5 text-gray-900 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+            <ChevronDownIcon className={`h-5 w-5 shrink-0 text-gray-900 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
           </button>
 
           {/* 드롭다운 옵션 목록 */}
@@ -223,7 +249,7 @@ export default function Dropdown<T = string>({
               >
                 <div className="flex flex-col gap-3">
                   {options.map((option, index) => {
-                    const isSelected = value === option.value;
+                    const isSelected = isOptionSelected(option.value);
                     const isFocused = focusedIndex === index;
                     return (
                       <button
@@ -237,7 +263,7 @@ export default function Dropdown<T = string>({
                         onMouseEnter={() => setFocusedIndex(index)}
                         className={getOptionClassName('form', isFocused)}
                       >
-                        <span className={getFormOptionTextClassName(isSelected, !!value)}>{option.label}</span>
+                        <span className={getFormOptionTextClassName(isSelected, hasValue)}>{option.label}</span>
                         {isSelected && <CheckIcon />}
                       </button>
                     );
@@ -273,8 +299,8 @@ export default function Dropdown<T = string>({
           }`
         }
       >
-        {selectedOption ? selectedOption.label : placeholder}
-        <ArrowDownIcon className={`size-5 text-gray-900 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+        <span className="truncate">{getDisplayText()}</span>
+        <ArrowDownIcon className={`size-5 shrink-0 text-gray-900 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
       </button>
 
       {isOpen && !disabled && (
@@ -293,7 +319,7 @@ export default function Dropdown<T = string>({
             style={maxHeight ? { maxHeight: `${maxHeight}px` } : undefined}
           >
             {options.map((option, index) => {
-              const isSelected = value === option.value;
+              const isSelected = isOptionSelected(option.value);
               const isFocused = focusedIndex === index;
               return (
                 <button

--- a/src/components/common/Dropdown/index.ts
+++ b/src/components/common/Dropdown/index.ts
@@ -1,1 +1,2 @@
 export { default as Dropdown } from './Dropdown';
+export type { DropdownOption, DropdownProps } from './types';

--- a/src/components/common/Dropdown/types.ts
+++ b/src/components/common/Dropdown/types.ts
@@ -6,7 +6,7 @@ export interface DropdownOption<T = string> {
 export interface DropdownProps<T = string> {
   // 필수 Props
   options: DropdownOption<T>[];
-  value: T | null;
+  value: T | null | T[]; // multiple일 때 T[]
   onChange: (value: T) => void;
   placeholder?: string;
 
@@ -21,6 +21,7 @@ export interface DropdownProps<T = string> {
   scrollToSelected?: boolean;
   maxHeight?: number;
   align?: 'left' | 'right';
+  multiple?: boolean; // 다중 선택 모드
 
   // 접근성
   ariaLabel?: string;

--- a/src/components/designerHome/pending/PendingReservationListItem.tsx
+++ b/src/components/designerHome/pending/PendingReservationListItem.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import CategoryBadge from '@/src/components/common/CategoryBadge';
 import type { PendingReservationItem } from '@/src/types/designerHome';
 
 // ===== 요일 배열 =====
@@ -29,7 +30,7 @@ interface PendingReservationListItemProps {
 }
 
 export function PendingReservationListItem({ item }: PendingReservationListItemProps) {
-  const category = item.subCategories?.[0] ?? '기타';
+  const categories = item.subCategories ?? [];
   const formattedDate = formatDateWithDay(item.date);
   const formattedTime = formatTimeWithAmPm(item.time);
 
@@ -40,10 +41,14 @@ export function PendingReservationListItem({ item }: PendingReservationListItemP
     >
       {/* 카테고리 뱃지 + 공고 제목 */}
       <div className="flex flex-col gap-1.5">
-        <div className="flex items-center">
-          <span className="rounded-lg bg-purple-600 px-2 py-1 text-caption-1-medium text-white">
-            {category}
-          </span>
+        <div className="flex flex-wrap gap-1">
+          {categories.length > 0 ? (
+            categories.map((cat) => (
+              <CategoryBadge key={cat} label={cat} variant="filled" />
+            ))
+          ) : (
+            <CategoryBadge label="기타" variant="filled" />
+          )}
         </div>
         <p className="text-head-4-semibold text-gray-900">{item.recruitmentTitle}</p>
       </div>

--- a/src/components/designerProfile/DesignerProfileRecruitments.tsx
+++ b/src/components/designerProfile/DesignerProfileRecruitments.tsx
@@ -49,15 +49,13 @@ export default function DesignerProfileRecruitments({
               </div>
               <div className="flex flex-1 flex-col gap-1 py-[3.5px]">
                 <div className="flex flex-wrap gap-1">
-                  {recruitment.subCategories
-                    .slice(0, 2)
-                    .map((subCategory) =>
-                      isCategoryCode(subCategory) ? (
-                        <CategoryBadge key={subCategory} category={subCategory} />
-                      ) : (
-                        <CategoryBadge key={subCategory} label={subCategory} />
-                      ),
-                    )}
+                  {recruitment.subCategories.map((subCategory) =>
+                    isCategoryCode(subCategory) ? (
+                      <CategoryBadge key={subCategory} category={subCategory} />
+                    ) : (
+                      <CategoryBadge key={subCategory} label={subCategory} />
+                    ),
+                  )}
                 </div>
                 <p className="text-body-2-medium line-clamp-2 text-gray-900">{recruitment.title}</p>
                 <div className="flex items-center gap-1 pt-1 text-gray-900">

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -83,7 +83,7 @@ export default function DesignerProfileView({
       date: item.createdDate.replace(/-/g, '.'),
       content: item.content,
       images: item.reviewImages ?? [],
-      category: item.summary,
+      summary: item.summary,
       isFixed: item.isFixed,
     }));
   }, [designerReviewsQuery.data?.pages, isOwnerProfile, reviewListQuery.data?.result?.items]);

--- a/src/components/designerProfile/edit/DesignerProfileEditRecruitments.tsx
+++ b/src/components/designerProfile/edit/DesignerProfileEditRecruitments.tsx
@@ -65,15 +65,13 @@ export default function DesignerProfileEditRecruitments({
                   </div>
                   <div className="flex flex-1 flex-col gap-1 pt-1">
                     <div className="flex flex-wrap gap-1">
-                      {recruitment.subCategories
-                        .slice(0, 2)
-                        .map((subCategory) =>
-                          isCategoryCode(subCategory) ? (
-                            <CategoryBadge key={subCategory} category={subCategory} />
-                          ) : (
-                            <CategoryBadge key={subCategory} label={subCategory} />
-                          ),
-                        )}
+                      {recruitment.subCategories.map((subCategory) =>
+                        isCategoryCode(subCategory) ? (
+                          <CategoryBadge key={subCategory} category={subCategory} />
+                        ) : (
+                          <CategoryBadge key={subCategory} label={subCategory} />
+                        ),
+                      )}
                     </div>
                     <p className="text-body-1-semibold line-clamp-2 text-gray-900">{recruitment.title}</p>
                     <div className="flex items-center gap-1 text-gray-700">

--- a/src/components/designerProfile/review/DesignerReviewAllView.tsx
+++ b/src/components/designerProfile/review/DesignerReviewAllView.tsx
@@ -49,7 +49,7 @@ export default function DesignerReviewAllView({ designerId, mode = 'public' }: D
       date: item.createdDate.replace(/-/g, '.'),
       content: item.content,
       images: item.reviewImages ?? [],
-      category: item.summary,
+      summary: item.summary,
       isFixed: item.isFixed,
     }));
   }, [reviewListQuery.data?.pages]);

--- a/src/components/designerProfile/review/DesignerReviewCard.tsx
+++ b/src/components/designerProfile/review/DesignerReviewCard.tsx
@@ -53,9 +53,12 @@ export default function DesignerReviewCard({ review }: DesignerReviewCardProps) 
       <p className="text-body-2-regular whitespace-pre-line text-gray-900">{review.content}</p>
       {review.summary && (
         <div className="flex flex-wrap gap-1">
-          {review.summary.split(', ').map((category) => (
-            <CategoryBadge key={category} label={category} />
-          ))}
+          {review.summary
+            .split(', ')
+            .filter((category) => category.trim())
+            .map((category, index) => (
+              <CategoryBadge key={`${category}-${index}`} label={category} />
+            ))}
         </div>
       )}
     </div>

--- a/src/components/designerProfile/review/DesignerReviewCard.tsx
+++ b/src/components/designerProfile/review/DesignerReviewCard.tsx
@@ -13,7 +13,7 @@ export interface DesignerReviewItem {
   date: string;
   content: string;
   images: string[];
-  category: string;
+  summary?: string;
   isFixed?: boolean;
 }
 
@@ -51,9 +51,13 @@ export default function DesignerReviewCard({ review }: DesignerReviewCardProps) 
       )}
 
       <p className="text-body-2-regular whitespace-pre-line text-gray-900">{review.content}</p>
-      <div className="flex">
-        <CategoryBadge label={review.category} />
-      </div>
+      {review.summary && (
+        <div className="flex flex-wrap gap-1">
+          {review.summary.split(', ').map((category) => (
+            <CategoryBadge key={category} label={category} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/designerProfile/review/DesignerReviewPhotoDetailView.tsx
+++ b/src/components/designerProfile/review/DesignerReviewPhotoDetailView.tsx
@@ -184,9 +184,13 @@ export default function DesignerReviewPhotoDetailView({
         </div>
 
         <p className="text-body-2-regular pt-2 whitespace-pre-line text-gray-700">{reviewItem.content}</p>
-        <div className="flex">
-          <CategoryBadge label={reviewItem.summary} />
-        </div>
+        {reviewItem.summary && (
+          <div className="flex flex-wrap gap-1">
+            {reviewItem.summary.split(', ').map((category) => (
+              <CategoryBadge key={category} label={category} />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/explore/Cards/RecruitmentCard.tsx
+++ b/src/components/explore/Cards/RecruitmentCard.tsx
@@ -78,7 +78,7 @@ export default function RecruitmentCard({ recruitment, isLeftColumn = false, onL
 
         {/* 서비스 태그 */}
         <div className="flex flex-wrap gap-1">
-          {recruitment.subCategories.slice(0, 2).map((subCategory) => (
+          {recruitment.subCategories.map((subCategory) => (
             <CategoryBadge key={subCategory} category={subCategory} />
           ))}
         </div>

--- a/src/components/map/MapRecruitmentCard.tsx
+++ b/src/components/map/MapRecruitmentCard.tsx
@@ -88,7 +88,7 @@ export default function MapRecruitmentCard({
 
           {/* 서비스 태그 */}
           <div className="flex flex-wrap gap-1">
-            {recruitment.subCategories.slice(0, 2).map((subCategory) => (
+            {recruitment.subCategories.map((subCategory) => (
               <CategoryBadge key={subCategory} category={subCategory} />
             ))}
           </div>

--- a/src/components/map/SelectedShopCard.tsx
+++ b/src/components/map/SelectedShopCard.tsx
@@ -276,9 +276,9 @@ export default function SelectedShopCard({
         <div className="flex flex-col gap-1">
           {/* 카테고리 배지 + 버튼 */}
           <div className="flex items-center justify-between px-4">
-            <div className="flex items-center gap-1">
+            <div className="flex flex-wrap items-center gap-1">
               <CategoryBadge category={shop.category} variant="filled" />
-              {firstRecruitment?.subCategories.slice(0, 1).map((subCategory) => (
+              {firstRecruitment?.subCategories.map((subCategory) => (
                 <CategoryBadge key={subCategory} category={subCategory} />
               ))}
               {recruitmentCount > 1 && (

--- a/src/components/modelHome/home/TopRecruitmentCard.tsx
+++ b/src/components/modelHome/home/TopRecruitmentCard.tsx
@@ -10,7 +10,7 @@ interface TopRecruitmentCardProps {
 }
 
 export function TopRecruitmentCard({ recruitment }: TopRecruitmentCardProps) {
-  const chipItems = [recruitment.category, ...recruitment.subCategories];
+  const chipItems = [recruitment.category, ...(recruitment.subCategories ?? [])];
 
   return (
     <Link href={`/post/${recruitment.recruitmentId}`} className="block">

--- a/src/components/modelHome/home/TopRecruitmentCard.tsx
+++ b/src/components/modelHome/home/TopRecruitmentCard.tsx
@@ -10,7 +10,7 @@ interface TopRecruitmentCardProps {
 }
 
 export function TopRecruitmentCard({ recruitment }: TopRecruitmentCardProps) {
-  const chipItems = [recruitment.category, ...recruitment.subCategories].slice(0, 2);
+  const chipItems = [recruitment.category, ...recruitment.subCategories];
 
   return (
     <Link href={`/post/${recruitment.recruitmentId}`} className="block">

--- a/src/components/mypage/designer-reviews/DesignerReviewCard.tsx
+++ b/src/components/mypage/designer-reviews/DesignerReviewCard.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import PinIcon from '@/public/icons/common/check-circle.svg';
 import StarDisplay from '@/src/components/common/StarDisplay';
 import KebabMenu from '@/src/components/common/KebabMenu/KebabMenu';
+import CategoryBadge from '@/src/components/common/CategoryBadge';
 import type { DesignerReviewItem } from '@/src/types';
 
 interface DesignerReviewCardProps {
@@ -124,10 +125,10 @@ export default function DesignerReviewCard({
 
         {/* 카테고리 배지 */}
         {review.summary && (
-          <div className="flex gap-1">
-            <span className="rounded-lg bg-purple-200 px-2 py-1 text-caption-1-medium text-purple-700">
-              {review.summary}
-            </span>
+          <div className="flex flex-wrap gap-1">
+            {review.summary.split(', ').map((category) => (
+              <CategoryBadge key={category} label={category} />
+            ))}
           </div>
         )}
       </div>

--- a/src/components/mypage/likes/Recruitment/LikedRecruitmentCard.tsx
+++ b/src/components/mypage/likes/Recruitment/LikedRecruitmentCard.tsx
@@ -98,7 +98,7 @@ export default function LikedRecruitmentCard({
         {/* 서비스 태그 */}
         {recruitment.subCategories && recruitment.subCategories.length > 0 && (
           <div className="flex flex-wrap gap-1">
-            {recruitment.subCategories.slice(0, 2).map((subCategory) => (
+            {recruitment.subCategories.map((subCategory) => (
               <CategoryBadge key={subCategory} category={subCategory} />
             ))}
           </div>

--- a/src/components/mypage/model-reviews/Card/UnreviewedCard.tsx
+++ b/src/components/mypage/model-reviews/Card/UnreviewedCard.tsx
@@ -50,8 +50,8 @@ export default function UnreviewedCard({
           {/* 메인 카테고리 뱃지 */}
           <CategoryBadge label={categoryLabel} variant="filled" />
           {/* 서브카테고리 뱃지 */}
-          {subCategoryLabels.map((label) => (
-            <CategoryBadge key={label} label={label} />
+          {subCategoryLabels.map((label, index) => (
+            <CategoryBadge key={`${label}-${index}`} label={label} />
           ))}
         </div>
 

--- a/src/components/mypage/model-reviews/Card/UnreviewedCard.tsx
+++ b/src/components/mypage/model-reviews/Card/UnreviewedCard.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
+import CategoryBadge from '@/src/components/common/CategoryBadge';
 import type { UnreviewedReservation } from '@/src/types';
 import { categoryCodeToName, subCategoryCodeToName } from '@/src/utils/myRecruitment';
 import { formatDateToKorean, formatTimeToKorean } from '@/src/utils/common';
@@ -45,19 +46,12 @@ export default function UnreviewedCard({
     <div className="flex w-full flex-col gap-5 rounded-[20px] bg-white px-5 py-4">
       {/* 카테고리 뱃지 */}
       <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-1">
+        <div className="flex flex-wrap items-center gap-1">
           {/* 메인 카테고리 뱃지 */}
-          <span className="text-caption-1-medium rounded-lg bg-purple-600 px-2 py-1 text-white">
-            {categoryLabel}
-          </span>
+          <CategoryBadge label={categoryLabel} variant="filled" />
           {/* 서브카테고리 뱃지 */}
           {subCategoryLabels.map((label) => (
-            <span
-              key={label}
-              className="text-caption-1-medium rounded-lg bg-purple-200 px-2 py-1 text-purple-700"
-            >
-              {label}
-            </span>
+            <CategoryBadge key={label} label={label} />
           ))}
         </div>
 

--- a/src/components/mypage/model-reviews/Card/WrittenReviewCard.tsx
+++ b/src/components/mypage/model-reviews/Card/WrittenReviewCard.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from 'react';
 import Image from 'next/image';
 import StarDisplay from '@/src/components/common/StarDisplay';
 import KebabMenu from '@/src/components/common/KebabMenu/KebabMenu';
+import CategoryBadge from '@/src/components/common/CategoryBadge';
 import type { WrittenReviewItem } from '@/src/types';
 
 interface WrittenReviewCardProps {
@@ -147,10 +148,10 @@ export default function WrittenReviewCard({
 
         {/* 카테고리 배지 */}
         {review.summary && (
-          <div className="flex gap-2">
-            <span className="rounded-lg bg-purple-200 px-2 py-1 text-caption-1-medium text-purple-700">
-              {review.summary}
-            </span>
+          <div className="flex flex-wrap gap-1">
+            {review.summary.split(', ').map((category) => (
+              <CategoryBadge key={category} label={category} />
+            ))}
           </div>
         )}
       </div>

--- a/src/components/mypage/reservations/Card/DesignerReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/DesignerReservationCard.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import CategoryBadge from '@/src/components/common/CategoryBadge';
 import type { DesignerReservationItem, ReservationListType, ReservationInfo } from '@/src/types';
 import { formatDateToKorean, formatTimeToKorean } from '@/src/utils/common';
 import {
@@ -78,14 +79,9 @@ export default function DesignerReservationCard({
       {/* 콘텐츠 */}
       <div className="flex flex-col gap-2">
         {/* 서브카테고리 뱃지 */}
-        <div className="flex items-center gap-1">
+        <div className="flex flex-wrap items-center gap-1">
           {reservation.subCategories.map((label) => (
-            <span
-              key={label}
-              className="text-caption-1-medium rounded-lg bg-purple-200 px-2 py-1 text-purple-700"
-            >
-              {label}
-            </span>
+            <CategoryBadge key={label} label={label} />
           ))}
         </div>
 

--- a/src/components/mypage/reservations/Card/common/CategoryBadges.tsx
+++ b/src/components/mypage/reservations/Card/common/CategoryBadges.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import CategoryBadge from '@/src/components/common/CategoryBadge';
 import { subCategoryCodeToName, categoryCodeToName } from '@/src/utils/myRecruitment';
 
 type StatusBadgeType = 'pending' | 'completed' | null;
@@ -28,20 +29,13 @@ export default function CategoryBadges({
   );
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex flex-wrap items-center gap-1">
       {/* 메인 카테고리 뱃지 */}
-      <span className="text-caption-1-medium rounded-lg bg-purple-600 px-2 py-1 text-white">
-        {categoryLabel}
-      </span>
+      <CategoryBadge label={categoryLabel} variant="filled" />
 
       {/* 서브카테고리 뱃지 */}
       {subCategoryLabels.map((label) => (
-        <span
-          key={label}
-          className="text-caption-1-medium rounded-lg bg-purple-200 px-2 py-1 text-purple-700"
-        >
-          {label}
-        </span>
+        <CategoryBadge key={label} label={label} />
       ))}
 
       {/* 상태 뱃지 */}

--- a/src/components/mypage/reservations/Card/common/CategoryBadges.tsx
+++ b/src/components/mypage/reservations/Card/common/CategoryBadges.tsx
@@ -24,9 +24,9 @@ export default function CategoryBadges({
   const categoryLabel =
     categoryCodeToName(category as 'HAIR' | 'NAIL' | 'TATTOO' | 'EYELASH') ?? category;
 
-  const subCategoryLabels = subCategories.map((code) =>
-    subCategoryCodeToName(category, code)
-  );
+  const subCategoryLabels = subCategories
+    .map((code) => subCategoryCodeToName(category, code))
+    .filter((label): label is string => label !== undefined);
 
   return (
     <div className="flex flex-wrap items-center gap-1">
@@ -34,8 +34,8 @@ export default function CategoryBadges({
       <CategoryBadge label={categoryLabel} variant="filled" />
 
       {/* 서브카테고리 뱃지 */}
-      {subCategoryLabels.map((label) => (
-        <CategoryBadge key={label} label={label} />
+      {subCategoryLabels.map((label, index) => (
+        <CategoryBadge key={`${label}-${index}`} label={label} />
       ))}
 
       {/* 상태 뱃지 */}

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -93,7 +93,7 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
       date: item.createdDate.replace(/-/g, '.'),
       content: item.content,
       images: item.reviewImages ?? [],
-      category: item.summary,
+      summary: item.summary,
       isFixed: item.isFixed,
     }));
   }, [isOwnerView, ownerReviewListQuery.data?.pages, reviewListQuery.data?.result?.items]);

--- a/src/stores/myRecruitment/useRecruitmentFormStore.ts
+++ b/src/stores/myRecruitment/useRecruitmentFormStore.ts
@@ -12,7 +12,7 @@ const INITIAL_STATE: RecruitmentFormState = {
   // Step 2: 시술 내용 + 카테고리 + 제한사항 + 전달사항 + 목적 + 동의
   content: '',
   category: null,
-  subCategory: null,
+  subCategories: [],
   restrictions: '',
   notice: '',
   purpose: null,
@@ -48,7 +48,8 @@ interface RecruitmentFormStore extends RecruitmentFormState {
   // Step 2 actions
   setContent: (content: string) => void;
   setCategory: (category: Category | null) => void;
-  setSubCategory: (subCategory: string | null) => void;
+  setSubCategories: (subCategories: string[]) => void;
+  toggleSubCategory: (subCategory: string) => void;
   setRestrictions: (restrictions: string) => void;
   setNotice: (notice: string) => void;
   setPurpose: (purpose: PurposeType | null) => void;
@@ -144,10 +145,17 @@ export const useRecruitmentFormStore = create<RecruitmentFormStore>((set) => ({
   setCategory: (category) =>
     set({
       category,
-      subCategory: null, // 카테고리 변경 시 서브카테고리 초기화
+      subCategories: [], // 카테고리 변경 시 서브카테고리 초기화
     }),
 
-  setSubCategory: (subCategory) => set({ subCategory }),
+  setSubCategories: (subCategories) => set({ subCategories }),
+
+  toggleSubCategory: (subCategory) =>
+    set((state) => ({
+      subCategories: state.subCategories.includes(subCategory)
+        ? state.subCategories.filter((s) => s !== subCategory)
+        : [...state.subCategories, subCategory],
+    })),
 
   setRestrictions: (restrictions) => set({ restrictions }),
 

--- a/src/types/myRecruitment/recruitment.ts
+++ b/src/types/myRecruitment/recruitment.ts
@@ -124,7 +124,7 @@ export interface RecruitmentFormState {
   // Step 2: 시술 내용 + 카테고리 + 제한사항 + 전달사항 + 목적 + 동의
   content: string; // 시술 내용
   category: Category | null; // 메인 카테고리 (HAIR, NAIL 등)
-  subCategory: string | null; // 서브 카테고리 (커트, 염색, 펌, 기타)
+  subCategories: string[]; // 서브 카테고리 배열 (커트, 염색, 펌, 기타)
   restrictions: string; // 제한 사항
   notice: string; // 전달 사항
   purpose: PurposeType | null; // 목적

--- a/src/types/review/model.ts
+++ b/src/types/review/model.ts
@@ -28,7 +28,7 @@ export interface WrittenReviewItem {
   designerName: string;
   shop?: string;
   shopAddress?: string;
-  summary?: string; // 카테고리 요약 (예: "파마", "염색", "커트")
+  summary?: string; // 카테고리 요약 (예: "파마, 염색, 커트")
   createdAt: string;
 }
 

--- a/src/utils/myRecruitment/form/convertDetailToFormState.ts
+++ b/src/utils/myRecruitment/form/convertDetailToFormState.ts
@@ -52,10 +52,12 @@ export function convertDetailToFormState(
   const categoryCode = categoryNameToCode(detail.category);
 
   // 서브카테고리 변환 (한글 -> 코드, 카테고리별로 다름)
-  const subCategoryName = detail.subCategories?.[0];
-  let subCategoryCode: string | null = null;
-  if (subCategoryName && categoryCode) {
-    subCategoryCode = subCategoryNameToCode(categoryCode, subCategoryName);
+  const subCategoryCodes: string[] = [];
+  if (categoryCode && detail.subCategories?.length) {
+    detail.subCategories.forEach((name) => {
+      const code = subCategoryNameToCode(categoryCode, name);
+      if (code) subCategoryCodes.push(code);
+    });
   }
 
   return {
@@ -65,7 +67,7 @@ export function convertDetailToFormState(
     applyTimesToAll: false,
     content: detail.content,
     category: categoryCode,
-    subCategory: subCategoryCode,
+    subCategories: subCategoryCodes,
     restrictions: detail.restriction, // 유의사항
     notice: detail.notice, // 전달 사항
     purpose,

--- a/src/utils/myRecruitment/form/transformFormToRequest.ts
+++ b/src/utils/myRecruitment/form/transformFormToRequest.ts
@@ -30,7 +30,7 @@ export function transformFormToRequest(
   return {
     title: formState.title,
     recruitmentSchedule,
-    subCategoryList: formState.subCategory ? [formState.subCategory as SubCategory] : [],
+    subCategoryList: formState.subCategories as SubCategory[],
     content: formState.content,
     restriction: formState.restrictions, // 유의사항
     notice: formState.notice, // 전달 사항

--- a/src/utils/myRecruitment/form/validation.ts
+++ b/src/utils/myRecruitment/form/validation.ts
@@ -44,7 +44,7 @@ export function isStep1Valid(state: {
 export function isStep2Valid(
   state: {
     content: string;
-    subCategory: string | null;
+    subCategories: string[];
     restrictions: string;
     notice: string;
     imageFiles: File[];
@@ -54,7 +54,7 @@ export function isStep2Valid(
   },
   options?: { isEditMode?: boolean },
 ): boolean {
-  const { content, subCategory, restrictions, notice, imageFiles, imagePreviewUrls, purpose, purposeDetail } =
+  const { content, subCategories, restrictions, notice, imageFiles, imagePreviewUrls, purpose, purposeDetail } =
     state;
   const isEditMode = options?.isEditMode ?? false;
 
@@ -63,7 +63,7 @@ export function isStep2Valid(
 
   return (
     content.trim().length > 0 &&
-    subCategory !== null &&
+    subCategories.length > 0 &&
     restrictions.trim().length > 0 &&
     notice.trim().length > 0 &&
     hasImages &&


### PR DESCRIPTION
### 💡 To Reviewers

- 공고글 등록, 수정시에 subCategory 2개 이상 등록 가능하도록 변경
- 위의 사항에 맞춰 CategoryBadge 공통 컴포넌트화
- 위의 사항에 맞춰 CategoryBadge 2개 이상 노출되는 곳 전수 조사 및 노출 갯수 1~2개 
 -> 전부로 변경
- Dropdown 컴포넌트에 `multiple` prop 추가하여 다중 선택 지원
- 리뷰 타입은 백엔드 API 응답(`summary: "커트, 파마"`)에 맞게 `split(', ')` 방식 사용

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

**1. 공고 생성 다중 서브카테고리 선택 기능**
- `RecruitmentFormState` 타입: `subCategory: string | null` → `subCategories: string[]`
- Zustand 스토어에 `toggleSubCategory`, `setSubCategories` 액션 추가
- Dropdown 컴포넌트에 `multiple` prop 추가하여 다중 선택 지원
- 폼 변환 함수 및 유효성 검사 수정

**2. 리뷰 타입 백엔드 API 응답에 맞게 수정**
- `WrittenReviewItem`, `DesignerReviewItem` 타입: `summary: string` 유지
- 리뷰 카드 컴포넌트에서 `summary.split(', ')` 방식으로 카테고리 표시

**3. 모집글 카드 서브카테고리 개수 제한 제거**
- 7개 컴포넌트에서 `.slice(0, 2)` 제거하여 모든 서브카테고리 표시

**4. CategoryBadge 컴포넌트 통일 및 UI 수정**
- 예약 상세 페이지에서 상위 카테고리 제거, 서브카테고리만 표시
- PendingReservationListItem에 `variant="filled"` 적용

### 📋 확인할 페이지

#### 공고 작성/수정
| 라우팅 경로 | 확인 내용 |
|------------|----------|
| `/myRecruitment/create` | 다중 서브카테고리 선택 가능 |
| `/myRecruitment/[id]/edit` | 기존 다중 카테고리 불러오기 |

#### 공고 카테고리 표시 (slice 제거)
| 라우팅 경로 | 확인 내용 |
|------------|----------|
| `/` | 모델 홈 TOP 공고 - 모든 카테고리 표시 |
| `/explore` | 탐색 페이지 - 모든 하위 카테고리 표시 |
| `/map` | 지도 카드/선택 샵 - 모든 하위 카테고리 표시 |
| `/mypage/likes` | 좋아요 공고 - 모든 하위 카테고리 표시 |
| `/designer/[id]` | 디자이너 프로필 공고 - 모든 하위 카테고리 표시 |
| `/myProfile/edit` | 디자이너 프로필 수정 - 모든 하위 카테고리 표시 |

#### 예약 카테고리 표시
| 라우팅 경로 | 확인 내용 |
|------------|----------|
| `/reservations/pending` | 진한 보라색 배지로 하위 카테고리 표시 |
| `/reservations/[id]` | 하위 카테고리만 표시 (상위 제거) |
| `/mypage/reservations` | CategoryBadge 통일 적용 |

#### 리뷰 카테고리 표시
| 라우팅 경로 | 확인 내용 |
|------------|----------|
| `/mypage/reviews` | 작성한 리뷰 - summary.split 표시 |
| `/mypage/reviews` (디자이너) | 받은 리뷰 - summary.split 표시 |
| `/designer/[id]` | 디자이너 프로필 리뷰 - summary.split 표시 |
| `/designer/[id]/reviews` | 리뷰 전체보기 - summary.split 표시 |
| `/post/[id]` (리뷰 탭) | 공고 상세 리뷰 - summary.split 표시 |

### 📁 영향받는 파일 (29개)

#### 타입/스토어/유틸 (6개)
- `src/types/myRecruitment/recruitment.ts`
- `src/types/review/model.ts`
- `src/stores/myRecruitment/useRecruitmentFormStore.ts`
- `src/utils/myRecruitment/form/*`

#### Dropdown 컴포넌트 (3개)
- `src/components/common/Dropdown/*`

#### 공고 폼 (1개)
- `src/app/(designer)/myRecruitment/create/_funnel/steps/StepContent.tsx`

#### 리뷰 카드 (7개)
- `src/components/mypage/model-reviews/Card/WrittenReviewCard.tsx`
- `src/components/mypage/designer-reviews/DesignerReviewCard.tsx`
- `src/components/designerProfile/review/DesignerReviewCard.tsx`
- `src/components/designerProfile/review/DesignerReviewPhotoDetailView.tsx`
- `src/components/designerProfile/review/DesignerReviewAllView.tsx`
- `src/components/designerProfile/DesignerProfileView.tsx`
- `src/components/post/PostDetailContent.tsx`

#### slice 제거 (7개)
- `src/components/explore/Cards/RecruitmentCard.tsx`
- `src/components/mypage/likes/Recruitment/LikedRecruitmentCard.tsx`
- `src/components/modelHome/home/TopRecruitmentCard.tsx`
- `src/components/map/MapRecruitmentCard.tsx`
- `src/components/map/SelectedShopCard.tsx`
- `src/components/designerProfile/DesignerProfileRecruitments.tsx`
- `src/components/designerProfile/edit/DesignerProfileEditRecruitments.tsx`

#### CategoryBadge 통일 및 UI 수정 (5개)
- `src/components/mypage/reservations/Card/common/CategoryBadges.tsx`
- `src/components/mypage/model-reviews/Card/UnreviewedCard.tsx`
- `src/components/mypage/reservations/Card/DesignerReservationCard.tsx`
- `src/components/designerHome/pending/PendingReservationListItem.tsx`
- `src/app/(designer)/reservations/[reservationId]/page.tsx`

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

- 공고 생성 시 서브카테고리 다중 선택 가능
- 모집글 카드에서 모든 서브카테고리 표시

### 🔗 관련 이슈

- #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-select capability to category/subcategory dropdowns in recruitment creation
  * Expanded category badge display to show all subcategories instead of limiting to first one or two

* **Bug Fixes**
  * Fixed category badge rendering to display complete list of selected categories in reviews and recruitment cards
  * Corrected category display format in designer reviews to properly show multiple categories

* **UI Updates**
  * Enhanced dropdown component to support multiple simultaneous selections
  * Improved category badge layout with wrapping support for better display of multiple categories

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->