### PR TITLE
[FEAT] 공고 상세 API 예약 상태 필드 업데이트 연동 (수정, 삭제 토스트 메시지 구체화)

### DIFF
--- a/src/components/post/Actions/PostActions.tsx
+++ b/src/components/post/Actions/PostActions.tsx
@@ -8,13 +8,13 @@ import { FixedBottomContainer } from '@/src/components/common/FixedBottomContain
 interface PostActionsProps {
   recruitmentId: number;
   designerUserId: number;
-  hasPendingReservation?: boolean;
+  modelHasPendingReservation?: boolean;
 }
 
 export default function PostActions({
   recruitmentId,
   designerUserId,
-  hasPendingReservation = false,
+  modelHasPendingReservation = false,
 }: PostActionsProps) {
   const router = useRouter();
   const createChatRoom = useCreateChatRoom();
@@ -32,7 +32,7 @@ export default function PostActions({
   };
 
   const handleReservation = () => {
-    if (hasPendingReservation) {
+    if (modelHasPendingReservation) {
       showToast('대기 중인 예약이 있습니다.');
       return;
     }

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -370,12 +370,20 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
       {/* 하단 액션 버튼 */}
       {isOwner ? (
         // 본인 공고: 수정하기 버튼
-        // TODO: 디자이너 상세 페이지 수정 차단 - 현재 API(GET /recruitments/{id})의 hasPendingReservation은
-        // "현재 로그인한 모델 기준"이므로 디자이너가 조회하면 항상 false. 백엔드에 canModify 필드 추가 요청 필요.
         <FixedBottomContainer>
           <button
             type="button"
-            onClick={() => router.push(`/myRecruitment/${recruitmentId}/edit`)}
+            onClick={() => {
+              if (!detail.canModify) {
+                if (detail.designerHasPendingReservation) {
+                  showToast('대기 중인 예약이 있어 수정이 불가합니다.');
+                } else if (detail.designerHasConfirmedReservation) {
+                  showToast('확정된 예약이 있어 수정이 불가합니다.');
+                }
+                return;
+              }
+              router.push(`/myRecruitment/${recruitmentId}/edit`);
+            }}
             className="text-body-1-semibold h-[56px] w-full cursor-pointer rounded-full bg-gray-900 text-white"
           >
             수정하기
@@ -386,7 +394,7 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
         <PostActions
           recruitmentId={detail.recruitmentId}
           designerUserId={detail.designerProfile.userId}
-          hasPendingReservation={detail.hasPendingReservation}
+          modelHasPendingReservation={detail.modelHasPendingReservation}
         />
       )}
     </div>

--- a/src/mocks/explore/recruitmentDetail.ts
+++ b/src/mocks/explore/recruitmentDetail.ts
@@ -48,7 +48,10 @@ export const mockRecruitmentDetail: RecruitmentDetail = {
   isLiked: false,
   reviewCount: 42,
   averageRating: 4.8,
-  hasPendingReservation: false,
+  modelHasPendingReservation: false,
+  designerHasPendingReservation: false,
+  designerHasConfirmedReservation: false,
+  canModify: true,
 };
 
 // 두 번째 공고 상세 Mock 데이터
@@ -87,5 +90,8 @@ export const mockRecruitmentDetail2: RecruitmentDetail = {
   isLiked: true,
   reviewCount: 18,
   averageRating: 4.5,
-  hasPendingReservation: false,
+  modelHasPendingReservation: false,
+  designerHasPendingReservation: false,
+  designerHasConfirmedReservation: false,
+  canModify: true,
 };

--- a/src/types/recruitment/recruitment.ts
+++ b/src/types/recruitment/recruitment.ts
@@ -96,6 +96,10 @@ export interface RecruitmentDetail {
   isLiked: boolean;
   reviewCount: number;
   averageRating: number;
-  hasPendingReservation: boolean; // 현재 모델의 대기 중인 예약 존재 여부
+  // 예약 상태 필드
+  modelHasPendingReservation: boolean; // 모델의 대기 중인 예약 존재 여부 (모델의 예약 신청 방지용)
+  designerHasPendingReservation: boolean; // 해당 공고의 대기 중인 예약 존재 여부
+  designerHasConfirmedReservation: boolean; // 해당 공고의 확정된 예약 중 아직 진행하지 않은 예약 존재 여부
+  canModify: boolean; // 디자이너의 해당 공고 수정/삭제 가능 여부
 }
 


### PR DESCRIPTION
### 💡 To Reviewers

- 디자이너 - 공고 상세(post/[id]) 페이지 하단 수정하기 버튼 클릭시 토스트 알림 추가 (대기중/확정된 예약 있을 시 수정 막음)
- 백엔드 API(GET /recruitments/{recruitmentId})에 새로운 예약 상태 필드가 추가되어 프론트엔드 연동

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

**타입 정의 업데이트**
- `RecruitmentDetail` 타입에 4개 필드 추가 (기존 `hasPendingReservation` 제거)
  - `modelHasPendingReservation`: 모델의 대기 중인 예약 존재 여부
  - `designerHasPendingReservation`: 해당 공고의 대기 중인 예약 존재 여부
  - `designerHasConfirmedReservation`: 해당 공고의 확정된 예약 존재 여부
  - `canModify`: 디자이너의 해당 공고 수정/삭제 가능 여부

**모델 - 공고 상세 (`/post/[id]`)**
- 예약 버튼: `modelHasPendingReservation` 사용
- 대기 예약 시: "대기 중인 예약이 있습니다." 토스트 표시

**디자이너 - 상세 페이지 (`/myRecruitment/[id]`)**
- 수정 버튼: `canModify` 체크 로직 구현
- 대기 예약 시: "대기 중인 예약이 있어 수정이 불가합니다."
- 확정 예약 시: "확정된 예약이 있어 수정이 불가합니다."

### 🤔 추후 작업 예정

없음

### 📸 작업 결과 (스크린샷)

- 테스트 필요

### 🔗 관련 이슈

- #177
- 관련: #170, #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 모집 공고 수정 버튼이 수정 권한 확인 기능을 추가했습니다. 진행 중인 예약이나 확정된 예약이 있을 경우 수정이 제한되며, 해당 상태에 따른 알림 메시지가 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->