### PR TITLE
[REFACTOR] 예약 시간 선택 시 오늘 지난 시간대 비활성화

### DIFF
--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx
@@ -106,6 +106,7 @@ export default function StepDateTime({
               <div>
                 <ReservationTimeSelector
                   timeSlots={selectedDateTimes}
+                  selectedDate={selectedDate}
                   selectedTime={selectedTime}
                   onTimeSelect={handleTimeSelect}
                 />

--- a/src/components/common/Calendar/calendarUtils.ts
+++ b/src/components/common/Calendar/calendarUtils.ts
@@ -24,3 +24,14 @@ export const getTodayString = (): string => {
   const now = new Date();
   return formatDateString(now.getFullYear(), now.getMonth() + 1, now.getDate());
 };
+
+/** 현재 시간 문자열 반환 (HH:mm) */
+export const getCurrentTimeString = (): string => {
+  const now = new Date();
+  return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+};
+
+/** 특정 날짜가 오늘인지 확인 */
+export const isToday = (date: string): boolean => {
+  return date === getTodayString();
+};

--- a/src/components/reservation/ReservationTimeSelector.tsx
+++ b/src/components/reservation/ReservationTimeSelector.tsx
@@ -2,21 +2,28 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import ChevronUpIcon from '@/public/icons/reservation/chevron-up.svg';
+import { isToday, getCurrentTimeString } from '@/src/components/common/Calendar/calendarUtils';
 import type { TimeSlot } from '@/src/types';
 
 interface ReservationTimeSelectorProps {
   timeSlots: TimeSlot[]; // API에서 받아온 시간대 목록
+  selectedDate: string; // 선택된 날짜 (YYYY-MM-DD)
   selectedTime: string | null;
   onTimeSelect: (time: string) => void;
 }
 
 export default function ReservationTimeSelector({
   timeSlots,
+  selectedDate,
   selectedTime,
   onTimeSelect,
 }: ReservationTimeSelectorProps) {
   const [isAmExpanded, setIsAmExpanded] = useState(true);
   const [isPmExpanded, setIsPmExpanded] = useState(true);
+
+  // 매 슬롯마다 Date 생성하지 않도록 컴포넌트 레벨에서 계산
+  const isTodaySelected = isToday(selectedDate);
+  const currentTime = isTodaySelected ? getCurrentTimeString() : '';
 
   // 오전/오후 시간대 분리
   const { amSlots, pmSlots } = useMemo(() => {
@@ -45,14 +52,16 @@ export default function ReservationTimeSelector({
 
   // 시간 클릭 핸들러
   const handleTimeClick = (slot: TimeSlot) => {
-    if (slot.isReserved) return;
+    const isPastTime = isTodaySelected && slot.startTime <= currentTime;
+    if (slot.isReserved || isPastTime) return;
     onTimeSelect(slot.startTime);
   };
 
   // 시간 버튼 렌더링
   const renderTimeButton = (slot: TimeSlot) => {
     const selected = isSelected(slot.startTime);
-    const disabled = slot.isReserved;
+    const isPastTime = isTodaySelected && slot.startTime <= currentTime;
+    const disabled = slot.isReserved || isPastTime;
 
     return (
       <button

--- a/src/components/reservation/ReservationTimeSelector.tsx
+++ b/src/components/reservation/ReservationTimeSelector.tsx
@@ -85,8 +85,12 @@ export default function ReservationTimeSelector({
   // 시간대가 없는 경우
   if (timeSlots.length === 0) {
     return (
-      <div className="flex h-20 items-center justify-center">
-        <p className="text-body-2-regular text-gray-500">해당 날짜에 예약 가능한 시간이 없습니다.</p>
+      <div className="flex min-h-20 items-center justify-center px-4">
+        <p className="text-center text-body-2-regular text-gray-500">
+          {isTodaySelected
+            ? '오늘은 예약 가능한 시간이 모두 지났습니다. 다른 날짜를 선택해 주세요.'
+            : '해당 날짜에 예약 가능한 시간이 없습니다.'}
+        </p>
       </div>
     );
   }

--- a/src/components/reservation/modal/ReservationChangeModal.tsx
+++ b/src/components/reservation/modal/ReservationChangeModal.tsx
@@ -9,6 +9,7 @@ import ReservationInfoCard from './ReservationInfoCard';
 import { formatDateToShort } from '@/src/utils/common';
 import { useIMEInput } from '@/src/hooks/custom/useIMEInput';
 import { useAvailableSchedules } from '@/src/hooks/queries/reservation';
+import { isToday, getCurrentTimeString } from '@/src/components/common/Calendar/calendarUtils';
 import type { ReservationInfo, ReservationChangeRequest, AvailableTimeSlot } from '@/src/types/reservation';
 
 interface ReservationChangeModalProps {
@@ -59,8 +60,16 @@ export default function ReservationChangeModal({
     if (!selectedDate) return [];
     const schedule = availableSchedules.find((item) => item.date === selectedDate);
     if (!schedule) return [];
+
+    const isTodaySelected = isToday(selectedDate);
+    const currentTime = isTodaySelected ? getCurrentTimeString() : '';
+
     return schedule.times
-      .filter((slot) => !slot.isReserved)
+      .filter((slot) => {
+        if (slot.isReserved) return false;
+        if (isTodaySelected && slot.startTime <= currentTime) return false;
+        return true;
+      })
       .map((slot) => ({ value: slot.startTime, label: slot.startTime }));
   }, [availableSchedules, selectedDate]);
 

--- a/src/components/reservation/modal/ReservationChangeModal.tsx
+++ b/src/components/reservation/modal/ReservationChangeModal.tsx
@@ -185,7 +185,11 @@ export default function ReservationChangeModal({
                     </button>
                   ))
                 ) : (
-                  <div className="text-body-2-medium px-4 py-3 text-gray-600">선택 가능한 시간이 없습니다.</div>
+                  <div className="text-body-2-medium px-4 py-3 text-gray-600">
+                    {isToday(selectedDate)
+                      ? '오늘은 예약 가능한 시간이 모두 지났습니다.'
+                      : '선택 가능한 시간이 없습니다.'}
+                  </div>
                 )}
               </div>
             )}


### PR DESCRIPTION
### 💡 To Reviewers

- 새롭게 설치한 라이브러리 없음
- `calendarUtils.ts`에 시간 비교용 유틸리티 함수 2개 추가 (`getCurrentTimeString`, `isToday`)

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 새 예약 신청 시 오늘 날짜 선택 → 현재 시간 이전 슬롯 비활성화 (회색 표시)
- 예약 변경 모달 (마이페이지/채팅) 시간 드롭다운에서 지난 시간 필터링
- 오늘 날짜 선택 시 시간이 없으면 구체적인 안내 메시지 표시
  - "오늘은 예약 가능한 시간이 모두 지났습니다. 다른 날짜를 선택해 주세요."

**수정 파일**
- `src/components/common/Calendar/calendarUtils.ts` - 유틸리티 함수 추가
- `src/components/reservation/ReservationTimeSelector.tsx` - 지난 시간 비활성화, 메시지 구체화
- `src/app/(model)/reservation/[recruitmentId]/_funnel/steps/1-StepDateTime.tsx` - selectedDate prop 전달
- `src/components/reservation/modal/ReservationChangeModal.tsx` - 드롭다운 필터링, 메시지 구체화

### 🤔 추후 작업 예정

**모집글 등록/수정 (디자이너) - 우선순위: 낮음**
- `TimeSelector.tsx`에서 오늘 날짜 선택 시 지난 시간 비활성화
- 현재 상태로도 기능상 문제없음 (디자이너가 지난 시간 설정해도 모델에게는 필터링되어 안 보임)
- 디자이너 UX 개선 목적의 선택적 작업

### 📸 작업 결과 (스크린샷)

- 오늘 날짜 선택 시 현재 시간 이전 슬롯이 회색으로 비활성화됨
- 시간이 모두 지난 경우 안내 메시지 표시

### ✅ 테스트 케이스

**1. 새 예약 신청 (`/reservation/[recruitmentId]`)**
| # | 시나리오 | 예상 결과 |
|---|---------|----------|
| 1-1 | 오늘 날짜 선택, 현재 시간 이전 슬롯 | 회색 비활성화, 클릭 불가 |
| 1-2 | 오늘 날짜 선택, 현재 시간 이후 슬롯 | 정상 활성화, 선택 가능 |
| 1-3 | 오늘 날짜 선택, 모든 시간 지남 | "오늘은 예약 가능한 시간이 모두 지났습니다. 다른 날짜를 선택해 주세요." |
| 1-4 | 내일 날짜 선택 | 모든 슬롯 정상 활성화 |
| 1-5 | 미래 날짜 선택, 시간 없음 | "해당 날짜에 예약 가능한 시간이 없습니다." |

**2. 예약 변경 모달 (마이페이지/채팅)**
| # | 시나리오 | 예상 결과 |
|---|---------|----------|
| 2-1 | 오늘 날짜 선택, 드롭다운 열기 | 현재 시간 이후만 목록에 표시 |
| 2-2 | 오늘 날짜 선택, 모든 시간 지남 | "오늘은 예약 가능한 시간이 모두 지났습니다." |
| 2-3 | 내일 날짜 선택, 드롭다운 열기 | 모든 예약 가능 시간 표시 |
| 2-4 | 미래 날짜 선택, 시간 없음 | "선택 가능한 시간이 없습니다." |

**3. 경계값 테스트**
| # | 시나리오 | 예상 결과 |
|---|---------|----------|
| 3-1 | 현재 시간이 정확히 슬롯 시간 (예: 14:00) | 해당 슬롯 비활성화 (`<=` 조건) |
| 3-2 | 날짜 변경 후 시간 선택 상태 | 시간 초기화됨 |

### 🔗 관련 이슈

- #181