### PR TITLE
[FEAT] 예약 신청 사진 첨부 카테고리별 필수/선택 구분

### DIFF
--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/2-StepPhoto.tsx
@@ -7,6 +7,8 @@ import { getReservationPresignedUrl } from '@/src/apis/reservation/model';
 import { uploadImageToS3 } from '@/src/apis/auth/profile';
 import { useToast } from '@/src/hooks/common/useToast';
 import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
+import { isPhotoRequired } from '@/src/utils/reservation/photoRequirement';
+import { Spinner } from '@/src/components/auth/common';
 
 interface StepPhotoProps {
   category: string;
@@ -29,6 +31,9 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
   const { showToast } = useToast();
   const [previewUrl, setPreviewUrl] = useState<string | null>(uploadedImageUrl);
   const [isUploading, setIsUploading] = useState(false);
+
+  // 사진 필수 여부 확인
+  const photoRequired = isPhotoRequired(category);
 
   // 스토어의 uploadedImageUrl 변경 시 previewUrl 동기화
   useEffect(() => {
@@ -82,7 +87,9 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
   }, [previewUrl, setUploadedImageUrl]);
 
   // 다음 버튼 활성화 조건
-  const canProceed = uploadedImageUrl !== null && !isUploading;
+  const canProceed = photoRequired
+    ? uploadedImageUrl !== null && !isUploading
+    : !isUploading;
 
   return (
     <div className="flex min-h-screen flex-col bg-white">
@@ -102,7 +109,14 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
             <h1 className="text-head-2-semibold text-gray-900">
               예약 신청을 위해
               <br />
-              필수 사진을 첨부해주세요.
+              {photoRequired ? (
+                '필수 사진을 첨부해주세요.'
+              ) : (
+                <>
+                  사진을 첨부해주세요.{' '}
+                  <span className="text-body-1-medium text-gray-500">(선택)</span>
+                </>
+              )}
             </h1>
 
             {/* 안내 문구 */}
@@ -125,7 +139,12 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
         />
 
         {/* 업로드 중 표시 */}
-        {isUploading && <p className="text-body-2-regular text-center text-gray-500">이미지 업로드 중...</p>}
+        {isUploading && (
+          <div className="flex items-center justify-center gap-2">
+            <Spinner color="gray" size="sm" />
+            <span className="text-body-2-regular text-gray-500">이미지 업로드 중…</span>
+          </div>
+        )}
       </div>
 
       {/* 하단 버튼 */}
@@ -134,7 +153,7 @@ export default function StepPhoto({ category, goNext, goPrev }: StepPhotoProps) 
           type="button"
           onClick={goNext}
           disabled={!canProceed}
-          className={`text-body-1-semibold h-14 w-full rounded-full transition-colors ${
+          className={`text-body-1-semibold h-14 w-full rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 ${
             canProceed ? 'cursor-pointer bg-gray-900 text-white' : 'cursor-not-allowed bg-gray-200 text-gray-500'
           }`}
         >

--- a/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
+++ b/src/app/(model)/reservation/[recruitmentId]/_funnel/steps/4-StepConfirm.tsx
@@ -10,6 +10,8 @@ import {
   subCategoryCodeToName,
 } from '@/src/utils/myRecruitment/category/categoryMapping';
 import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
+import { isPhotoRequired } from '@/src/utils/reservation/photoRequirement';
+import { Spinner } from '@/src/components/auth/common';
 
 interface StepConfirmProps {
   recruitmentId: number;
@@ -56,13 +58,17 @@ export default function StepConfirm({
   const { selectedDate, selectedTime, uploadedImageUrl, comment } = useReservationStore();
   const { mutate: createReservation, isPending } = useCreateReservation();
 
+  // 사진 필수 여부 확인 (컴포넌트 최상단에서 한 번만 계산)
+  const photoRequired = isPhotoRequired(category);
+
   // 카테고리 enum 변환 (한글/영문 모두 처리)
   const normalizedCategory = category.trim();
   const categoryEnum = categoryNameToCode(normalizedCategory);
 
   // 예약하기 버튼 클릭
   const handleReservation = () => {
-    if (!selectedDate || !selectedTime || !uploadedImageUrl || !categoryEnum) return;
+    if (!selectedDate || !selectedTime || !categoryEnum) return;
+    if (photoRequired && !uploadedImageUrl) return;
 
     // 서브카테고리 한글 → enum 변환
     const subCategoriesEnum = subCategories.map((sub) => subCategoryNameToCode(categoryEnum, sub));
@@ -77,7 +83,7 @@ export default function StepConfirm({
         comment,
         designerName,
         shop: shopName,
-        imageUrls: uploadedImageUrl,
+        ...(uploadedImageUrl && { imageUrls: uploadedImageUrl }),
       },
       {
         onSuccess: () => {
@@ -107,7 +113,7 @@ export default function StepConfirm({
   ];
 
   // 데이터 유효성 검사 (handleReservation과 동일한 조건)
-  const isValid = selectedDate && selectedTime && uploadedImageUrl && categoryEnum;
+  const isValid = selectedDate && selectedTime && categoryEnum && (photoRequired ? uploadedImageUrl : true);
 
   return (
     <div className="flex min-h-screen flex-col bg-white">
@@ -153,13 +159,20 @@ export default function StepConfirm({
           type="button"
           onClick={handleReservation}
           disabled={!isValid || isPending}
-          className={`text-body-1-semibold h-14 w-full rounded-full transition-colors ${
+          className={`text-body-1-semibold h-14 w-full rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 ${
             isValid && !isPending
               ? 'cursor-pointer bg-gray-900 text-white'
               : 'cursor-not-allowed bg-gray-200 text-gray-600'
           }`}
         >
-          {isPending ? '예약 중...' : '완료'}
+          {isPending ? (
+            <span className="flex items-center justify-center gap-2">
+              <Spinner color="white" size="sm" />
+              예약 중…
+            </span>
+          ) : (
+            '완료'
+          )}
         </button>
       </FixedBottomContainer>
     </div>

--- a/src/components/auth/common/Spinner.tsx
+++ b/src/components/auth/common/Spinner.tsx
@@ -1,6 +1,26 @@
+interface SpinnerProps {
+  /** 스피너 색상 (기본값: purple) */
+  color?: 'purple' | 'white' | 'gray';
+  /** 스피너 크기 (기본값: md) */
+  size?: 'sm' | 'md';
+}
+
+const colorStyles = {
+  purple: 'border-purple-700',
+  white: 'border-white',
+  gray: 'border-gray-500',
+};
+
+const sizeStyles = {
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+};
+
 /**
  * 로딩 스피너 컴포넌트
  */
-export const Spinner = () => (
-  <div className="h-5 w-5 animate-spin rounded-full border-2 border-purple-700 border-t-transparent" />
+export const Spinner = ({ color = 'purple', size = 'md' }: SpinnerProps) => (
+  <div
+    className={`animate-spin rounded-full border-2 border-t-transparent ${colorStyles[color]} ${sizeStyles[size]}`}
+  />
 );

--- a/src/components/designerHome/detail/AttachedPhotosCard.tsx
+++ b/src/components/designerHome/detail/AttachedPhotosCard.tsx
@@ -7,19 +7,21 @@ interface AttachedPhotosCardProps {
 }
 
 export function AttachedPhotosCard({ imageUrl }: AttachedPhotosCardProps) {
-  if (!imageUrl) {
-    return null;
-  }
-
   return (
     <div className="flex flex-col gap-2 rounded-[12px] bg-white p-5">
       {/* 라벨 */}
       <span className="text-body-2-medium text-gray-700">첨부 사진</span>
 
-      {/* 이미지 */}
-      <div className="relative aspect-square w-full overflow-hidden rounded-2xl">
-        <Image src={imageUrl} alt="첨부 사진" fill className="object-cover" />
-      </div>
+      {/* 이미지 또는 빈 상태 */}
+      {imageUrl ? (
+        <div className="relative aspect-square w-full overflow-hidden rounded-2xl">
+          <Image src={imageUrl} alt="첨부 사진" fill className="object-cover" />
+        </div>
+      ) : (
+        <div className="flex aspect-square w-full items-center justify-center rounded-2xl bg-gray-200">
+          <span className="text-body-2-regular text-gray-500">첨부된 사진이 없습니다</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/utils/reservation/photoRequirement.ts
+++ b/src/utils/reservation/photoRequirement.ts
@@ -1,0 +1,15 @@
+import type { Category } from '@/src/types/recruitment';
+import { categoryNameToCode } from '@/src/utils/myRecruitment/category/categoryMapping';
+
+// 사진 선택(옵션) 카테고리
+const OPTIONAL_PHOTO_CATEGORIES: Category[] = ['TATTOO', 'EYELASH'];
+
+/**
+ * 해당 카테고리에서 사진이 필수인지 확인
+ * @param category 카테고리 코드 또는 한글명 (예: 'HAIR', '헤어')
+ */
+export function isPhotoRequired(category: string): boolean {
+  const categoryCode = categoryNameToCode(category);
+  if (!categoryCode) return true; // 인식 불가 시 필수로 처리
+  return !OPTIONAL_PHOTO_CATEGORIES.includes(categoryCode);
+}


### PR DESCRIPTION
### 💡 To Reviewers

- Web Interface Guidelines 준수: `...` → `…` (ellipsis) 수정, `focus-visible` 스타일 추가
- Spinner 컴포넌트에 `color`, `size` prop 추가로 다양한 상황에서 재사용 가능

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

**카테고리별 사진 필수/선택 분기**
| 카테고리 | 사진 | 버튼 | 문구 |
|---------|------|------|------|
| 헤어/네일 | **필수** | 사진 업로드 후 활성화 | "필수 사진을 첨부해주세요." |
| 타투/속눈썹 | **선택** | 기본 활성화 | "사진을 첨부해주세요. (선택)" |

**주요 변경사항**
- `isPhotoRequired()` 헬퍼 함수 추가 - 카테고리별 사진 필수 여부 판단
- `Spinner` 컴포넌트 개선 - `color` (purple/white/gray), `size` (sm/md) prop 추가
- 예약 신청 Step 2 (사진 첨부) - 카테고리별 문구 분기, 버튼 활성화 조건 분기
- 예약 신청 Step 4 (확인) - 유효성 검사 및 API 요청 분기, 버튼 로딩 Spinner
- 디자이너 예약 상세 - 첨부 사진 없을 때 빈 상태 UI 표시

**UX 개선**
- 로딩 텍스트 `...` → `…` (ellipsis) 수정
- 버튼 `focus-visible:ring` 스타일 추가 (키보드 접근성)
- 버튼 로딩 시 텍스트 대신 Spinner 표시

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

<img width="440" height="906" alt="image" src="https://github.com/user-attachments/assets/069f32aa-e905-457e-836b-c5095d580236" />

<img width="476" height="907" alt="image" src="https://github.com/user-attachments/assets/2314ddd2-ac38-4c76-8c33-156278a418be" />

<img width="426" height="905" alt="image" src="https://github.com/user-attachments/assets/3b4cbca8-4934-4952-a830-635c67bd7bef" />


### 🔗 관련 이슈

- #182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 서비스 카테고리에 따른 동적 사진 요구사항 처리
  * 업로드 진행 상황을 시각적 인디케이터로 표시
  * 사진 없음 상태에 대한 플레이스홀더 표시

* **개선 사항**
  * 예약 제출 전 사진 필수 여부 검증 강화
  * 필수 사진 누락 시 진행 차단
  * 사진 필수/선택 여부 UI 텍스트 표시
  * 접근성 개선을 위한 스타일 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->