### PR TITLE
[FEAT] 디자이너 캘린더 예약 상태별 UI 구현

### DIFF
--- a/public/icons/calendar/chevron-right.svg
+++ b/public/icons/calendar/chevron-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M6.66797 12L9.96086 8.70711C10.3514 8.31658 10.3514 7.68342 9.96086 7.29289L6.66797 4" stroke="currentColor" stroke-linecap="round"/>
+</svg>

--- a/src/app/(designer)/calendar/page.tsx
+++ b/src/app/(designer)/calendar/page.tsx
@@ -6,8 +6,29 @@ import { DesignerCalendar, CalendarReservationCard } from '@/src/components/cale
 import { useMonthNavigation } from '@/src/hooks/custom/myRecruitment';
 import { useReservationDots, useCalendarReservations } from '@/src/hooks/queries/calendar';
 import { useToast } from '@/src/hooks/common';
+import { formatTimeWithPeriod } from '@/src/utils/common';
+import type { CalendarReservationItem } from '@/src/types/calendar';
 
 const WEEKDAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+/**
+ * 예약 목록을 시간별로 그룹핑
+ */
+function groupReservationsByTime(
+  reservations: CalendarReservationItem[],
+): Map<string, CalendarReservationItem[]> {
+  const grouped = new Map<string, CalendarReservationItem[]>();
+
+  reservations.forEach((reservation) => {
+    const time = reservation.startTime;
+    if (!grouped.has(time)) {
+      grouped.set(time, []);
+    }
+    grouped.get(time)!.push(reservation);
+  });
+
+  return grouped;
+}
 
 /**
  * 날짜를 "DD(요일)" 형식으로 포맷
@@ -69,6 +90,12 @@ export default function CalendarPage() {
   const reservations = reservationsData?.result?.items ?? [];
   const totalCount = reservationsData?.result?.totalCount ?? 0;
 
+  // 시간별로 그룹핑된 예약 목록
+  const groupedReservations = useMemo(
+    () => groupReservationsByTime(reservations),
+    [reservations],
+  );
+
   // 날짜 선택 핸들러
   const handleDateSelect = (date: string | null) => {
     setSelectedDate(date);
@@ -100,7 +127,7 @@ export default function CalendarPage() {
         </div>
 
         {/* 타이틀 영역 */}
-        <div className="mb-4 flex items-center gap-2">
+        <div className="mb-4 flex items-baseline gap-2">
           <h2 className="text-head-2-semibold text-gray-950">
             {selectedDate ? formatSelectedDateTitle(selectedDate) : '전체'}
           </h2>
@@ -108,7 +135,7 @@ export default function CalendarPage() {
         </div>
 
         {/* 예약 카드 리스트 */}
-        <div className="flex flex-1 flex-col gap-3 overflow-y-auto">
+        <div className="flex flex-1 flex-col gap-7 overflow-y-auto">
           {isReservationsLoading ? (
             <div className="flex flex-1 items-center justify-center py-10">
               <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-gray-900" />
@@ -118,8 +145,26 @@ export default function CalendarPage() {
               <p className="text-body-1-medium text-gray-500">예약 목록을 불러오지 못했습니다</p>
             </div>
           ) : reservations.length > 0 ? (
-            reservations.map((reservation) => (
-              <CalendarReservationCard key={reservation.reservationId} reservation={reservation} />
+            Array.from(groupedReservations.entries()).map(([time, items]) => (
+              <div key={time} className="flex flex-col gap-2">
+                {/* 시간 헤더 + 구분선 */}
+                <div className="flex items-center gap-2">
+                  <span className="text-body-2-semibold shrink-0 text-gray-900">
+                    {formatTimeWithPeriod(time)}
+                  </span>
+                  <div className="h-px flex-1 bg-gray-400" />
+                </div>
+
+                {/* 해당 시간대 예약 카드들 */}
+                <div className="flex flex-col gap-2">
+                  {items.map((reservation) => (
+                    <CalendarReservationCard
+                      key={reservation.reservationId}
+                      reservation={reservation}
+                    />
+                  ))}
+                </div>
+              </div>
             ))
           ) : (
             <div className="flex flex-1 flex-col items-center justify-center py-10">

--- a/src/components/calendar/CalendarReservationCard.tsx
+++ b/src/components/calendar/CalendarReservationCard.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import CalendarIcon from '@/public/icons/myRecruitment/calendar.svg';
 import TimeCircleIcon from '@/public/icons/calendar/time-circle.svg';
 import ChatIcon from '@/public/icons/calendar/chat.svg';
+import ChevronRightIcon from '@/public/icons/calendar/chevron-right.svg';
 import { subCategoryCodeToName } from '@/src/utils/myRecruitment/category';
 import { formatDateToShort, formatTimeWithPeriod } from '@/src/utils/common';
 import { ReservationChangeModal, ReservationCancelModal, ReservationSuccessModal } from '@/src/components/reservation';
@@ -56,6 +57,17 @@ export default function CalendarReservationCard({ reservation }: CalendarReserva
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
+
+  // 예약 상태 확인
+  const isUpcoming = reservation.reservationStatus === 'UPCOMING';
+  const isCompleted = reservation.reservationStatus === 'COMPLETED';
+
+  // 예약 공고 페이지로 이동
+  const handleRecruitmentClick = () => {
+    if (reservation.recruitmentId) {
+      router.push(`/myRecruitment/${reservation.recruitmentId}`);
+    }
+  };
 
   // 예약 정보를 모달에 전달할 형식으로 변환
   const reservationInfo: ReservationInfo = {
@@ -143,7 +155,29 @@ export default function CalendarReservationCard({ reservation }: CalendarReserva
     <div className="flex w-full flex-col gap-4 rounded-2xl border border-gray-200 bg-white p-4">
       {/* 고객 정보 */}
       <div className="flex flex-col gap-2">
-        <p className="text-head-4-semibold text-gray-900">{reservation.modelName}님</p>
+        {/* 이름 + 상태별 버튼/뱃지 */}
+        <div className="flex items-start gap-2">
+          <p className="text-head-4-semibold text-gray-900">{reservation.modelName}님</p>
+
+          {/* UPCOMING: 예약 공고 버튼 */}
+          {isUpcoming && reservation.recruitmentId && (
+            <button
+              type="button"
+              onClick={handleRecruitmentClick}
+              className="flex h-7 cursor-pointer items-center gap-0.5 rounded-xl bg-gray-200 py-[3px] pl-2.5 pr-1.5"
+            >
+              <span className="text-body-2-medium text-gray-800">예약 공고</span>
+              <ChevronRightIcon className="size-4 text-gray-800" />
+            </button>
+          )}
+
+          {/* COMPLETED: 완료된 일정 뱃지 */}
+          {isCompleted && (
+            <span className="text-caption-1-medium rounded-lg border border-gray-400 px-2 py-1 text-gray-800">
+              완료된 일정
+            </span>
+          )}
+        </div>
 
         {/* 예약 정보 */}
         <div className="flex items-center gap-2">
@@ -165,40 +199,42 @@ export default function CalendarReservationCard({ reservation }: CalendarReserva
         </div>
       </div>
 
-      {/* 액션 버튼 */}
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={handleChatClick}
-          disabled={createChatRoom.isPending}
-          className={`flex h-[42px] items-center gap-1 rounded-full px-3 py-2.5 whitespace-nowrap ${
-            createChatRoom.isPending ? 'cursor-not-allowed bg-gray-400' : 'cursor-pointer bg-gray-900'
-          }`}
-        >
-          {createChatRoom.isPending ? (
-            <div className="size-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
-          ) : (
-            <ChatIcon className="size-5 text-white" />
-          )}
-          <span className="text-body-2-medium text-white">채팅 보내기</span>
-        </button>
+      {/* 액션 버튼 - UPCOMING인 경우에만 표시 */}
+      {isUpcoming && (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleChatClick}
+            disabled={createChatRoom.isPending}
+            className={`flex h-[42px] items-center gap-1 rounded-full px-4 py-2.5 whitespace-nowrap ${
+              createChatRoom.isPending ? 'cursor-not-allowed bg-gray-400' : 'cursor-pointer bg-gray-900'
+            }`}
+          >
+            {createChatRoom.isPending ? (
+              <div className="size-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+            ) : (
+              <ChatIcon className="size-5 text-white" />
+            )}
+            <span className="text-body-2-medium text-white">채팅 보내기</span>
+          </button>
 
-        <button
-          type="button"
-          onClick={handleChangeClick}
-          className="flex h-[42px] cursor-pointer items-center justify-center rounded-full border border-gray-400 bg-white px-3 py-2.5 whitespace-nowrap"
-        >
-          <span className="text-body-2-medium text-gray-900">예약 변경</span>
-        </button>
+          <button
+            type="button"
+            onClick={handleChangeClick}
+            className="flex h-[42px] cursor-pointer items-center justify-center rounded-full border border-gray-400 bg-white px-4 py-2.5 whitespace-nowrap"
+          >
+            <span className="text-body-2-medium text-gray-900">예약 변경</span>
+          </button>
 
-        <button
-          type="button"
-          onClick={handleCancelClick}
-          className="flex h-[42px] cursor-pointer items-center justify-center rounded-full border border-gray-400 bg-white px-3 py-2.5 whitespace-nowrap"
-        >
-          <span className="text-body-2-medium text-gray-900">예약 취소</span>
-        </button>
-      </div>
+          <button
+            type="button"
+            onClick={handleCancelClick}
+            className="flex h-[42px] cursor-pointer items-center justify-center rounded-full border border-gray-400 bg-white px-4 py-2.5 whitespace-nowrap"
+          >
+            <span className="text-body-2-medium text-gray-900">예약 취소</span>
+          </button>
+        </div>
+      )}
 
       {/* 예약 변경 모달 */}
       {isChangeModalOpen && (

--- a/src/types/calendar/calendar.ts
+++ b/src/types/calendar/calendar.ts
@@ -12,6 +12,9 @@ export interface ReservationDotsResult {
   days: ReservationDot[];
 }
 
+// 예약 상태 타입
+export type ReservationStatus = 'UPCOMING' | 'COMPLETED';
+
 // 캘린더 예약 아이템
 export interface CalendarReservationItem {
   reservationId: number;
@@ -23,6 +26,7 @@ export interface CalendarReservationItem {
   date: string; // yyyy-MM-dd
   startTime: string; // HH:mm
   endTime: string; // HH:mm
+  reservationStatus: ReservationStatus; // 서버에서 현재 시간 기준으로 판단
 }
 
 // 캘린더 예약 목록 조회 응답

--- a/src/types/calendar/calendar.ts
+++ b/src/types/calendar/calendar.ts
@@ -13,7 +13,7 @@ export interface ReservationDotsResult {
 }
 
 // 예약 상태 타입
-export type ReservationStatus = 'UPCOMING' | 'COMPLETED';
+export type CalendarReservationStatus = 'UPCOMING' | 'COMPLETED';
 
 // 캘린더 예약 아이템
 export interface CalendarReservationItem {
@@ -26,7 +26,7 @@ export interface CalendarReservationItem {
   date: string; // yyyy-MM-dd
   startTime: string; // HH:mm
   endTime: string; // HH:mm
-  reservationStatus: ReservationStatus; // 서버에서 현재 시간 기준으로 판단
+  reservationStatus: CalendarReservationStatus; // 서버에서 현재 시간 기준으로 판단
 }
 
 // 캘린더 예약 목록 조회 응답


### PR DESCRIPTION
### 💡 To Reviewers

- 새롭게 설치한 라이브러리 없음
- API 응답에 `reservationStatus` 필드가 추가되어야 정상 동작합니다

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- `CalendarReservationItem` 타입에 `reservationStatus` 필드 추가 (`'UPCOMING' | 'COMPLETED'`)
- 예약 카드 상태별 UI 분기 구현
  - **UPCOMING**: 모델명 + "예약 공고" 버튼 + 액션 버튼 3개 (채팅, 변경, 취소)
  - **COMPLETED**: 모델명 + "완료된 일정" 뱃지 (액션 버튼 없음)
- 캘린더 페이지 시간별 그룹핑 UI 구현
  - 시간 헤더 (오후 12:00) + 구분선
  - 같은 시간대 예약을 그룹으로 묶어서 표시
- chevron-right 아이콘 추가

### 🤔 추후 작업 예정

- 백엔드 API `reservationStatus` 필드 연동 확인

### 📸 작업 결과 (스크린샷)

<img width="371" height="354" alt="image" src="https://github.com/user-attachments/assets/578800e0-6129-4bab-912b-0c132b958eb5" />


### 🔗 관련 이슈

- #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 예약이 시간별로 그룹화되어 캘린더에 표시됩니다.
  * 예약 상태(예정/완료)에 따라 다른 작업 옵션이 표시됩니다.
  * 예정된 예약에서는 채용공고 보기 버튼을 통해 관련 공고에 접근할 수 있습니다.
  * 완료된 예약에는 '완료된 일정' 배지가 표시됩니다.
  * 예정된 예약에서만 예약 변경, 취소, 채팅 기능을 사용할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->