### PR TITLE
[FEAT] 디자이너 리뷰 답글 입력 시 글자수 카운터 추가

### DIFF
--- a/src/components/mypage/designer-reviews/DesignerReviewCard.tsx
+++ b/src/components/mypage/designer-reviews/DesignerReviewCard.tsx
@@ -7,6 +7,8 @@ import KebabMenu from '@/src/components/common/KebabMenu/KebabMenu';
 import CategoryBadge from '@/src/components/common/CategoryBadge';
 import type { DesignerReviewItem } from '@/src/types';
 
+const REPLY_MAX_LENGTH = 200;
+
 interface DesignerReviewCardProps {
   review: DesignerReviewItem;
   onPin?: (reviewId: number, isFixed: boolean) => void;
@@ -136,13 +138,22 @@ export default function DesignerReviewCard({
       {/* 답글 입력 모드 */}
       {isReplying && (
         <>
-          <div className="flex h-[160px] items-start rounded-xl border border-gray-400 p-4">
+          <div className="flex h-[160px] flex-col justify-between rounded-xl border border-gray-400 p-4">
             <textarea
               value={replyContent}
-              onChange={(e) => onReplyContentChange?.(e.target.value)}
+              onChange={(e) => {
+                if (e.target.value.length <= REPLY_MAX_LENGTH) {
+                  onReplyContentChange?.(e.target.value);
+                }
+              }}
               placeholder="내용을 입력하세요"
-              className="size-full resize-none text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none"
+              className="h-full w-full resize-none text-body-2-medium text-gray-900 placeholder:text-gray-600 focus:outline-none"
             />
+            <div className="text-right">
+              <span className="text-body-2-regular text-gray-600">
+                {replyContent.length}/{REPLY_MAX_LENGTH}
+              </span>
+            </div>
           </div>
           <div className="flex gap-2">
             <button


### PR DESCRIPTION
### 💡 To Reviewers

- 새로 설치한 라이브러리 없음
- 모델 리뷰 작성 페이지와 동일한 글자수 카운터 패턴 적용

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 디자이너 리뷰 답글 작성 시 글자수 카운터 표시 (`0/200`)
- 200자 초과 입력 차단 기능 추가
- `REPLY_MAX_LENGTH` 상수 정의 (백엔드 검증 규칙과 일치)

### 🤔 추후 작업 예정

- 없음

### 📸 작업 결과 (스크린샷)

<img width="492" height="247" alt="image" src="https://github.com/user-attachments/assets/5fb8e866-70d0-4b0d-ac47-61150aa41c9f" />

### 🔗 관련 이슈

- #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 답변 입력 시 최대 문자 수 제한 기능 추가
  * 문자 수 카운트다운 표시 추가
  * 입력 영역 레이아웃 및 크기 개선으로 더 편한 입력 경험 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->