### PR TITLE
[FIX] 디자이너 프로필 이미지 깨짐 문제 해결 및 뒤로가기 경로

### DIFF
--- a/src/components/designerProfile/DesignerProfileActionBar.tsx
+++ b/src/components/designerProfile/DesignerProfileActionBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import LikeButton from '@/src/components/explore/Cards/shared/LikeButton';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 interface DesignerProfileActionBarProps {
   onChat?: () => void;
@@ -15,17 +16,17 @@ export default function DesignerProfileActionBar({ onChat, onLike, isLiked = fal
   };
 
   return (
-    <div className="fixed bottom-0 left-1/2 z-50 h-[76px] w-full -translate-x-1/2 bg-white px-4 py-3 sm:w-[375px]">
-      <div className="flex h-[52px] items-center gap-4">
+    <FixedBottomContainer>
+      <div className="flex h-[56px] items-center gap-4">
         <LikeButton isLiked={isLiked} onClick={handleLikeClick} className="h-6 w-6" />
         <button
           type="button"
           onClick={onChat}
-          className="text-body-1-semibold flex h-[52px] flex-1 cursor-pointer items-center justify-center rounded-full bg-gray-900 text-white"
+          className="text-body-1-semibold flex h-[56px] flex-1 cursor-pointer items-center justify-center rounded-full bg-gray-900 text-white"
         >
           채팅하기
         </button>
       </div>
-    </div>
+    </FixedBottomContainer>
   );
 }

--- a/src/components/designerProfile/DesignerProfileHero.tsx
+++ b/src/components/designerProfile/DesignerProfileHero.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import ProfileIcon from '@/public/icons/chat/profile.svg';
 import DesignerProfileHeader from '@/src/components/designerProfile/DesignerProfileHeader';
 
 interface DesignerProfileHeroProps {
@@ -24,14 +25,20 @@ export default function DesignerProfileHero({
 }: DesignerProfileHeroProps) {
   return (
     <section className="relative h-[374px] w-full overflow-hidden rounded-b-[20px]">
-      <Image
-        src={profileImageUrl}
-        alt={`${nickname} 디자이너 프로필`}
-        fill
-        sizes="100vw"
-        priority
-        className="object-cover"
-      />
+      {profileImageUrl ? (
+        <Image
+          src={profileImageUrl}
+          alt={`${nickname} 디자이너 프로필`}
+          fill
+          sizes="100vw"
+          priority
+          className="object-cover"
+        />
+      ) : (
+        <div className="absolute inset-0 flex items-center justify-center bg-gray-300">
+          <ProfileIcon className="size-60 text-gray-500" />
+        </div>
+      )}
       <div className="absolute inset-0 bg-[linear-gradient(180deg,transparent_32%,var(--color-black)_100%)]" />
 
       <DesignerProfileHeader actionType={actionType} onBack={onBack} onAction={onAction} />

--- a/src/components/designerProfile/DesignerProfileSkeleton.tsx
+++ b/src/components/designerProfile/DesignerProfileSkeleton.tsx
@@ -8,7 +8,9 @@ interface DesignerProfileSkeletonProps {
 
 export default function DesignerProfileSkeleton({ showActionBar = false }: DesignerProfileSkeletonProps) {
   return (
-    <div className={`flex min-h-screen flex-col bg-white ${showActionBar ? 'pb-[76px]' : ''}`}>
+    <div
+      className={`flex min-h-screen flex-col bg-white ${showActionBar ? 'pb-[calc(70px+env(safe-area-inset-bottom))]' : ''}`}
+    >
       {/* Hero */}
       <div className="relative h-[374px] w-full overflow-hidden rounded-b-[20px]">
         <Skeleton className="h-full w-full rounded-none" />

--- a/src/components/designerProfile/DesignerProfileSkeleton.tsx
+++ b/src/components/designerProfile/DesignerProfileSkeleton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Skeleton } from '@/src/components/common';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 
 interface DesignerProfileSkeletonProps {
   showActionBar?: boolean;
@@ -79,12 +80,12 @@ export default function DesignerProfileSkeleton({ showActionBar = false }: Desig
       </section>
 
       {showActionBar && (
-        <div className="fixed bottom-0 left-1/2 z-50 h-[76px] w-full -translate-x-1/2 bg-white px-4 py-3 sm:w-[375px]">
-          <div className="flex h-[52px] items-center gap-3">
-            <Skeleton variant="circular" className="h-[52px] w-[52px]" />
-            <Skeleton className="h-[52px] flex-1 rounded-full" />
+        <FixedBottomContainer>
+          <div className="flex h-[56px] items-center gap-3">
+            <Skeleton variant="circular" className="h-[56px] w-[56px]" />
+            <Skeleton className="h-[56px] flex-1 rounded-full" />
           </div>
-        </div>
+        </FixedBottomContainer>
       )}
     </div>
   );

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -29,7 +29,6 @@ interface DesignerProfileViewProps {
   portfolioTotalCount?: number;
   actionType?: 'edit' | 'share' | 'none';
   showActionBar?: boolean;
-  onBack?: () => void;
   onAction?: () => void;
 }
 

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -41,7 +41,6 @@ export default function DesignerProfileView({
   portfolioTotalCount,
   actionType = 'none',
   showActionBar = false,
-  onBack,
   onAction,
 }: DesignerProfileViewProps) {
   const router = useRouter();
@@ -240,7 +239,9 @@ export default function DesignerProfileView({
   };
 
   return (
-    <div className={`flex min-h-screen flex-col bg-white ${showActionBar ? 'pb-[76px]' : ''}`}>
+    <div
+      className={`flex min-h-screen flex-col bg-white ${showActionBar ? 'pb-[calc(70px+env(safe-area-inset-bottom))]' : ''}`}
+    >
       <DesignerProfileHero
         profileImageUrl={profile.profileImageUrl}
         nickname={profile.nickname}

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -155,11 +155,7 @@ export default function DesignerProfileView({
   };
 
   const handleBack = () => {
-    if (onBack) {
-      onBack();
-      return;
-    }
-    router.back();
+    router.replace('/explore');
   };
 
   const handleAction = () => {

--- a/src/components/explore/Cards/DesignerCard.tsx
+++ b/src/components/explore/Cards/DesignerCard.tsx
@@ -36,7 +36,7 @@ export default function DesignerCard({ designer, onLikeToggle }: DesignerCardPro
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center">
-              <ProfileIcon className="h-10 w-8 text-gray-600" />
+              <ProfileIcon className="w-8 text-gray-500" />
             </div>
           )}
         </div>

--- a/src/components/modelHome/home/ModelHomeContent.tsx
+++ b/src/components/modelHome/home/ModelHomeContent.tsx
@@ -20,7 +20,6 @@ import { useToggleDesignerLike, useToggleRecruitmentLike } from '@/src/hooks/que
 import BellIcon from '@/public/icons/designer-home/bell.svg';
 import MoandiLogo from '@/public/icons/model-home/moandiLogo.svg';
 import LocationIcon from '@/public/icons/common/location-current.svg';
-import ProfileIcon from '@/public/icons/chat/profile.svg';
 import { ReservationCard } from './ReservationCard';
 import { TopRecruitmentCard } from './TopRecruitmentCard';
 import type { HomeCategory } from '@/src/types/modelHome';
@@ -138,14 +137,10 @@ export function ModelHomeContent() {
                       )}
                     </p>
                   </div>
-                  <div className="relative size-16 shrink-0 overflow-hidden rounded-full bg-gray-300">
+                  <div className="relative size-16 shrink-0 overflow-hidden rounded-full" aria-hidden={!profileImageUrl}>
                     {profileImageUrl ? (
                       <Image src={profileImageUrl} alt="프로필" fill sizes="64px" className="object-cover" />
-                    ) : (
-                      <div className="flex size-full items-center justify-center bg-gray-100">
-                        <ProfileIcon className="size-10 text-gray-500" />
-                      </div>
-                    )}
+                    ) : null}
                   </div>
                 </div>
 

--- a/src/components/modelHome/home/ModelHomeContent.tsx
+++ b/src/components/modelHome/home/ModelHomeContent.tsx
@@ -20,7 +20,7 @@ import { useToggleDesignerLike, useToggleRecruitmentLike } from '@/src/hooks/que
 import BellIcon from '@/public/icons/designer-home/bell.svg';
 import MoandiLogo from '@/public/icons/model-home/moandiLogo.svg';
 import LocationIcon from '@/public/icons/common/location-current.svg';
-import ProfilePlaceholderIcon from '@/public/icons/designer-home/profile-placeholder.svg';
+import ProfileIcon from '@/public/icons/chat/profile.svg';
 import { ReservationCard } from './ReservationCard';
 import { TopRecruitmentCard } from './TopRecruitmentCard';
 import type { HomeCategory } from '@/src/types/modelHome';
@@ -142,8 +142,8 @@ export function ModelHomeContent() {
                     {profileImageUrl ? (
                       <Image src={profileImageUrl} alt="프로필" fill sizes="64px" className="object-cover" />
                     ) : (
-                      <div className="flex size-full items-center justify-center text-gray-500">
-                        <ProfilePlaceholderIcon className="size-6" />
+                      <div className="flex size-full items-center justify-center bg-gray-100">
+                        <ProfileIcon className="size-10 text-gray-500" />
                       </div>
                     )}
                   </div>
@@ -197,7 +197,7 @@ export function ModelHomeContent() {
               <div className="mt-2">
                 <div className="flex gap-2">
                   {[0, 1].map((index) => (
-                    <div key={`nearby-skeleton-${index}`} className="flex-1 min-w-0">
+                    <div key={`nearby-skeleton-${index}`} className="min-w-0 flex-1">
                       <RecruitmentCardSkeleton isLeftColumn={index % 2 === 0} />
                     </div>
                   ))}
@@ -219,7 +219,7 @@ export function ModelHomeContent() {
                     <SwiperSlide key={`nearby-slide-${slideIndex}`} className="w-full!">
                       <div className="flex gap-2">
                         {pair.map((item, index) => (
-                          <div key={item.recruitmentId} className="flex-1 min-w-0">
+                          <div key={item.recruitmentId} className="min-w-0 flex-1">
                             <RecruitmentCard
                               recruitment={item}
                               isLeftColumn={index === 0}
@@ -227,7 +227,7 @@ export function ModelHomeContent() {
                             />
                           </div>
                         ))}
-                        {pair.length === 1 && <div className="flex-1 min-w-0" aria-hidden />}
+                        {pair.length === 1 && <div className="min-w-0 flex-1" aria-hidden />}
                       </div>
                     </SwiperSlide>
                   ))}
@@ -239,7 +239,7 @@ export function ModelHomeContent() {
                   <SwiperSlide className="w-full!">
                     <div className="invisible flex w-full gap-2">
                       {[0, 1].map((index) => (
-                        <div key={`nearby-empty-${index}`} className="flex-1 min-w-0">
+                        <div key={`nearby-empty-${index}`} className="min-w-0 flex-1">
                           <RecruitmentCardSkeleton isLeftColumn={index % 2 === 0} />
                         </div>
                       ))}

--- a/src/components/mypage/ProfileCard.tsx
+++ b/src/components/mypage/ProfileCard.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { ReactNode } from 'react';
 import { Skeleton } from '@/src/components/common';
+import ProfileIcon from '@/public/icons/chat/profile.svg';
 
 type ProfileCardProps = {
   name: string;
@@ -56,7 +57,9 @@ export const ProfileCard = ({
             {isLoading ? (
               <Skeleton variant="circular" className="h-full w-full" />
             ) : !hasProfileImage ? (
-              <div className="h-full w-full bg-gray-300" />
+              <div className="flex h-full w-full items-center justify-center bg-gray-300">
+                <ProfileIcon className="size-11 text-gray-500" />
+              </div>
             ) : (
               <Image src={profileImageSrc} alt="프로필 이미지" fill className="object-cover" sizes="64px" priority />
             )}


### PR DESCRIPTION
### 💡 To Reviewers

- 디자이너 프로필 관련 QA 사항과 묶어서 처리할 수 있는 것들 처리했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 디자이너 프로필 이미지 없을 시 깨지는 문제 - 기본 아이콘 추가
- 뒤로가기: /explore 추가
- 하단 채팅하기 버튼 높이와 여백 수정
- 모델 홈 내 기본 아이콘 제거와 마이페이지 기본 아이콘 추가

### 🤔 추후 작업 예정


### 📸 작업 결과 (스크린샷)



### 🔗 관련 이슈

- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #185 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 이미지가 없을 때 여러 화면에서 아이콘 형태의 플레이스홀더 추가

* **버그 수정**
  * 노치·홈 인디케이터가 있는 기기에서 하단 여백 및 액션바 간격 개선
  * 프로필 화면 네비게이션 동작 안정화

* **스타일/시각 개선**
  * 플레이스홀더 아이콘의 크기·색조 및 액션바 높이 조정으로 일관된 레이아웃 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->