### PR TITLE
[FIX] 공고 및 디자이너 프로필 내 리뷰 관련 수정 및 UI QA 반영

### DIFF
--- a/src/apis/review/public.ts
+++ b/src/apis/review/public.ts
@@ -3,6 +3,7 @@ import type {
   ApiResponse,
   DesignerReviewsResponse,
   DesignerReviewThumbnailsResponse,
+  DesignerReviewImagesResponse,
   DesignerReviewDetailResponse,
   ReviewListParams,
 } from '@/src/types';
@@ -23,13 +24,28 @@ export async function getPublicDesignerReviews(
 
 /**
  * 디자이너 리뷰 썸네일 리스트 조회 (공개)
- * GET /{designerId}/reviews/images
+ * GET /{designerId}/reviews/thumbnails
  */
 export async function getPublicDesignerReviewThumbnails(
   designerId: number,
   params?: ReviewListParams
 ): Promise<ApiResponse<DesignerReviewThumbnailsResponse>> {
   const { data } = await axiosInstance.get<ApiResponse<DesignerReviewThumbnailsResponse>>(
+    `/${designerId}/reviews/thumbnails`,
+    { params }
+  );
+  return data;
+}
+
+/**
+ * 디자이너 리뷰 이미지 리스트 조회 (공개)
+ * GET /{designerId}/reviews/images
+ */
+export async function getPublicDesignerReviewImages(
+  designerId: number,
+  params?: ReviewListParams
+): Promise<ApiResponse<DesignerReviewImagesResponse>> {
+  const { data } = await axiosInstance.get<ApiResponse<DesignerReviewImagesResponse>>(
     `/${designerId}/reviews/images`,
     { params }
   );

--- a/src/components/designerProfile/DesignerPortfolioReviewSection.tsx
+++ b/src/components/designerProfile/DesignerPortfolioReviewSection.tsx
@@ -24,6 +24,7 @@ interface DesignerPortfolioReviewSectionProps {
   onReviewViewAll?: () => void;
   onReviewPreviewMore?: () => void;
   onReviewPreviewImageClick?: (reviewId: number, imageUrl: string) => void;
+  onReviewImageClick?: (reviewId: number, imageUrl: string) => void;
 }
 
 export default function DesignerPortfolioReviewSection({
@@ -41,6 +42,7 @@ export default function DesignerPortfolioReviewSection({
   onReviewViewAll,
   onReviewPreviewMore,
   onReviewPreviewImageClick,
+  onReviewImageClick,
 }: DesignerPortfolioReviewSectionProps) {
   const portfolioCount = portfolioTotalCount ?? portfolioImages.length;
   const hasPortfolios = portfolioImages.length > 0;
@@ -145,6 +147,7 @@ export default function DesignerPortfolioReviewSection({
               onPreviewMore={onReviewPreviewMore}
               showPreviewMoreLabel
               onPreviewImageClick={onReviewPreviewImageClick}
+              onReviewImageClick={onReviewImageClick}
             />
           )}
         </>

--- a/src/components/designerProfile/DesignerPortfolioReviewSection.tsx
+++ b/src/components/designerProfile/DesignerPortfolioReviewSection.tsx
@@ -23,6 +23,7 @@ interface DesignerPortfolioReviewSectionProps {
   onPortfolioSelect?: (portfolioId: number) => void;
   onReviewViewAll?: () => void;
   onReviewPreviewMore?: () => void;
+  onReviewPreviewImageClick?: (reviewId: number, imageUrl: string) => void;
 }
 
 export default function DesignerPortfolioReviewSection({
@@ -39,6 +40,7 @@ export default function DesignerPortfolioReviewSection({
   onPortfolioSelect,
   onReviewViewAll,
   onReviewPreviewMore,
+  onReviewPreviewImageClick,
 }: DesignerPortfolioReviewSectionProps) {
   const portfolioCount = portfolioTotalCount ?? portfolioImages.length;
   const hasPortfolios = portfolioImages.length > 0;
@@ -141,6 +143,8 @@ export default function DesignerPortfolioReviewSection({
               reviews={reviewItems}
               onViewAll={onReviewViewAll}
               onPreviewMore={onReviewPreviewMore}
+              showPreviewMoreLabel
+              onPreviewImageClick={onReviewPreviewImageClick}
             />
           )}
         </>

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -275,6 +275,7 @@ export default function DesignerProfileView({
         onReviewViewAll={handleReviewViewAll}
         onReviewPreviewMore={handleReviewPreviewMore}
         onReviewPreviewImageClick={handleReviewPreviewImageClick}
+        onReviewImageClick={handleReviewPreviewImageClick}
       />
 
       {showActionBar && <DesignerProfileActionBar isLiked={isLiked} onLike={handleLikeToggle} onChat={handleChat} />}

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -56,11 +56,11 @@ export default function DesignerProfileView({
   const reviewDesignerId = Number(profile.designerId ?? profile.designerUserId);
   const canFetchPublicReviews = Number.isFinite(reviewDesignerId) && reviewDesignerId > 0;
 
-  const designerReviewsQuery = useDesignerReviews({ size: 5 }, { enabled: reviewQueryEnabled && isOwnerProfile });
+  const designerReviewsQuery = useDesignerReviews({ size: 3 }, { enabled: reviewQueryEnabled && isOwnerProfile });
 
   const reviewListQuery = usePublicDesignerReviewList({
     designerId: reviewDesignerId,
-    params: { size: 5 },
+    params: { size: 3 },
     enabled: reviewQueryEnabled && !isOwnerProfile && canFetchPublicReviews,
   });
 

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -77,6 +77,7 @@ export default function DesignerProfileView({
     return items.map((item) => ({
       id: item.reviewId,
       name: item.modelName,
+      modelImage: item.modelImage ?? null,
       rating: item.rating,
       date: item.createdDate.replace(/-/g, '.'),
       content: item.content,

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -96,9 +96,11 @@ export default function DesignerProfileView({
     const listItems = isOwnerProfile ? ownerItems : (publicResult?.items ?? []);
     const totalCount = isOwnerProfile
       ? (ownerTotalCount ?? listItems.length)
-      : (publicResult?.totalCount ?? listItems.length);
+      : (publicResult?.totalCount ?? profile.reviewCount ?? listItems.length);
     const totalRating = listItems.reduce((sum, item) => sum + item.rating, 0);
-    const rating = listItems.length > 0 ? totalRating / listItems.length : 0;
+    const rating =
+      profile.averageRating ??
+      (listItems.length > 0 ? totalRating / listItems.length : 0);
     const previewItems =
       reviewImagesQuery.data?.result?.items
         ?.map((item) => ({ reviewId: item.reviewId, imageUrl: item.reviewImage }))
@@ -118,6 +120,8 @@ export default function DesignerProfileView({
     isOwnerProfile,
     reviewListQuery.data?.result,
     reviewImagesQuery.data?.result,
+    profile.reviewCount,
+    profile.averageRating,
   ]);
 
   const isReviewLoading = reviewQueryEnabled

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -9,8 +9,8 @@ import DesignerPortfolioReviewSection from '@/src/components/designerProfile/Des
 import DesignerProfileActionBar from '@/src/components/designerProfile/DesignerProfileActionBar';
 import {
   useDesignerReviews,
+  usePublicDesignerReviewImages,
   usePublicDesignerReviewList,
-  usePublicDesignerReviewThumbnails,
 } from '@/src/hooks/queries/review';
 import { useToggleDesignerLike } from '@/src/hooks/queries/likes';
 import { useCreateChatRoom } from '@/src/hooks/queries/chat';
@@ -64,9 +64,9 @@ export default function DesignerProfileView({
     enabled: reviewQueryEnabled && !isOwnerProfile && canFetchPublicReviews,
   });
 
-  const reviewThumbnailQuery = usePublicDesignerReviewThumbnails({
+  const reviewImagesQuery = usePublicDesignerReviewImages({
     designerId: reviewDesignerId,
-    params: { size: 10 },
+    params: { size: 3 },
     enabled: reviewQueryEnabled && canFetchPublicReviews,
   });
 
@@ -97,37 +97,25 @@ export default function DesignerProfileView({
       : (publicResult?.totalCount ?? listItems.length);
     const totalRating = listItems.reduce((sum, item) => sum + item.rating, 0);
     const rating = listItems.length > 0 ? totalRating / listItems.length : 0;
-    const thumbnailResult = reviewThumbnailQuery.data?.result;
-    const thumbnailItems = thumbnailResult?.items ?? [];
-    const fallbackPreviewItems = listItems
-      .map((item) => ({ reviewId: item.reviewId, imageUrl: item.reviewImages?.[0] }))
-      .filter((item): item is { reviewId: number; imageUrl: string } => Boolean(item.imageUrl));
-    const previewSourceItems =
-      thumbnailItems.length > 0
-        ? thumbnailItems
-            .map((item) => ({ reviewId: item.reviewId, imageUrl: item.reviewThumbnail }))
-            .filter((item): item is { reviewId: number; imageUrl: string } => Boolean(item.imageUrl))
-        : fallbackPreviewItems;
-    const previewImages = previewSourceItems.slice(0, 3).map((item) => item.imageUrl);
-    const totalPreviewCount =
-      thumbnailItems.length > 0
-        ? thumbnailResult?.hasNext
-          ? (thumbnailResult?.totalCount ?? previewSourceItems.length ?? totalCount)
-          : previewSourceItems.length
-        : (previewSourceItems.length ?? totalCount);
-    const moreCount = Math.max(totalPreviewCount - previewImages.length, 0);
+    const previewItems =
+      reviewImagesQuery.data?.result?.items
+        ?.map((item) => ({ reviewId: item.reviewId, imageUrl: item.reviewImage }))
+        .filter((item): item is { reviewId: number; imageUrl: string } => Boolean(item.imageUrl)) ?? [];
+    const previewItemsTrimmed = previewItems.slice(0, 3);
+    const totalPreviewCount = reviewImagesQuery.data?.result?.totalCount ?? previewItemsTrimmed.length;
+    const moreCount = Math.max(totalPreviewCount - previewItemsTrimmed.length, 0);
 
     return {
       rating,
       count: totalCount,
-      previewImages,
+      previewItems: previewItemsTrimmed,
       moreCount,
     };
   }, [
     designerReviewsQuery.data?.pages,
     isOwnerProfile,
     reviewListQuery.data?.result,
-    reviewThumbnailQuery.data?.result,
+    reviewImagesQuery.data?.result,
   ]);
 
   const isReviewLoading = reviewQueryEnabled
@@ -146,10 +134,26 @@ export default function DesignerProfileView({
     : canFetchPublicReviews
       ? `/designer/${reviewDesignerId}/reviews`
       : '';
+  const reviewPhotoPath = isOwnerProfile
+    ? '/myProfile/reviews/photos'
+    : canFetchPublicReviews
+      ? `/designer/${reviewDesignerId}/reviews/photos`
+      : '';
+  const reviewPhotoDetailBase = reviewPhotoPath;
 
   const handleReviewViewAll = () => {
     if (!reviewDetailPath) return;
     router.push(reviewDetailPath);
+  };
+
+  const handleReviewPreviewMore = () => {
+    if (!reviewPhotoPath) return;
+    router.push(reviewPhotoPath);
+  };
+
+  const handleReviewPreviewImageClick = (reviewId: number, imageUrl: string) => {
+    if (!reviewPhotoDetailBase) return;
+    router.push(`${reviewPhotoDetailBase}/${reviewId}?imageUrl=${encodeURIComponent(imageUrl)}`);
   };
 
   const handleBack = () => {
@@ -269,6 +273,8 @@ export default function DesignerProfileView({
         onPortfolioViewAll={handlePortfolioViewAll}
         onPortfolioSelect={handlePortfolioSelect}
         onReviewViewAll={handleReviewViewAll}
+        onReviewPreviewMore={handleReviewPreviewMore}
+        onReviewPreviewImageClick={handleReviewPreviewImageClick}
       />
 
       {showActionBar && <DesignerProfileActionBar isLiked={isLiked} onLike={handleLikeToggle} onChat={handleChat} />}

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -56,11 +56,11 @@ export default function DesignerProfileView({
   const reviewDesignerId = Number(profile.designerId ?? profile.designerUserId);
   const canFetchPublicReviews = Number.isFinite(reviewDesignerId) && reviewDesignerId > 0;
 
-  const designerReviewsQuery = useDesignerReviews({ size: 10 }, { enabled: reviewQueryEnabled && isOwnerProfile });
+  const designerReviewsQuery = useDesignerReviews({ size: 5 }, { enabled: reviewQueryEnabled && isOwnerProfile });
 
   const reviewListQuery = usePublicDesignerReviewList({
     designerId: reviewDesignerId,
-    params: { size: 10 },
+    params: { size: 5 },
     enabled: reviewQueryEnabled && !isOwnerProfile && canFetchPublicReviews,
   });
 

--- a/src/components/designerProfile/DesignerProfileView.tsx
+++ b/src/components/designerProfile/DesignerProfileView.tsx
@@ -83,6 +83,7 @@ export default function DesignerProfileView({
       images: item.reviewImages ?? [],
       summary: item.summary,
       isFixed: item.isFixed,
+      replyDto: item.replyDto ?? null,
     }));
   }, [designerReviewsQuery.data?.pages, isOwnerProfile, reviewListQuery.data?.result?.items]);
 

--- a/src/components/designerProfile/review/DesignerReviewAllView.tsx
+++ b/src/components/designerProfile/review/DesignerReviewAllView.tsx
@@ -134,7 +134,15 @@ export default function DesignerReviewAllView({ designerId, mode = 'public' }: D
                 <p className="text-body-2-medium text-gray-500">등록된 리뷰가 없습니다.</p>
               </div>
             ) : (
-              reviewItems.map((review) => <DesignerReviewCard key={review.id} review={review} />)
+              reviewItems.map((review) => (
+                <DesignerReviewCard
+                  key={review.id}
+                  review={review}
+                  onImageClick={(reviewId, imageUrl) =>
+                    router.push(`${photoDetailBase}/${reviewId}?imageUrl=${encodeURIComponent(imageUrl)}`)
+                  }
+                />
+              ))
             )}
 
             <div ref={loadMoreRef} className="h-4" />

--- a/src/components/designerProfile/review/DesignerReviewAllView.tsx
+++ b/src/components/designerProfile/review/DesignerReviewAllView.tsx
@@ -52,6 +52,7 @@ export default function DesignerReviewAllView({ designerId, mode = 'public' }: D
       images: item.reviewImages ?? [],
       summary: item.summary,
       isFixed: item.isFixed,
+      replyDto: item.replyDto ?? null,
     }));
   }, [reviewListQuery.data?.pages]);
 

--- a/src/components/designerProfile/review/DesignerReviewAllView.tsx
+++ b/src/components/designerProfile/review/DesignerReviewAllView.tsx
@@ -9,8 +9,8 @@ import DesignerReviewSummary from '@/src/components/designerProfile/review/Desig
 import { useInfiniteScroll } from '@/src/hooks/common/useInfiniteScroll';
 import {
   useDesignerReviews,
+  usePublicDesignerReviewImages,
   usePublicDesignerReviewListInfinite,
-  usePublicDesignerReviewThumbnails,
 } from '@/src/hooks/queries/review';
 
 interface DesignerReviewAllViewProps {
@@ -23,6 +23,7 @@ export default function DesignerReviewAllView({ designerId, mode = 'public' }: D
   const isOwnerMode = mode === 'owner';
   const canFetchReviews = Number.isFinite(designerId) && designerId > 0;
   const photoPath = isOwnerMode ? '/myProfile/reviews/photos' : `/designer/${designerId}/reviews/photos`;
+  const photoDetailBase = photoPath;
 
   const ownerReviewListQuery = useDesignerReviews({ size: 8 }, { enabled: isOwnerMode && canFetchReviews });
 
@@ -34,9 +35,9 @@ export default function DesignerReviewAllView({ designerId, mode = 'public' }: D
 
   const reviewListQuery = isOwnerMode ? ownerReviewListQuery : publicReviewListQuery;
 
-  const reviewThumbnailQuery = usePublicDesignerReviewThumbnails({
+  const reviewImagesQuery = usePublicDesignerReviewImages({
     designerId,
-    params: { size: 10 },
+    params: { size: 3 },
     enabled: canFetchReviews,
   });
 
@@ -59,25 +60,21 @@ export default function DesignerReviewAllView({ designerId, mode = 'public' }: D
     const totalCount = reviewListQuery.data?.pages[0]?.result?.totalCount ?? listItems.length;
     const totalRating = listItems.reduce((sum, item) => sum + item.rating, 0);
     const rating = listItems.length > 0 ? totalRating / listItems.length : 0;
-    const thumbnailItems = reviewThumbnailQuery.data?.result?.items ?? [];
-    const fallbackImages = listItems
-      .map((item) => item.reviewImages?.[0])
-      .filter((imageUrl): imageUrl is string => Boolean(imageUrl));
-    const thumbnailImages =
-      thumbnailItems.length > 0
-        ? thumbnailItems.map((item) => item.reviewThumbnail).filter(Boolean)
-        : fallbackImages;
-    const previewImages = thumbnailImages.slice(0, 3);
-    const totalPreviewCount = reviewThumbnailQuery.data?.result?.totalCount ?? thumbnailImages.length ?? totalCount;
-    const moreCount = Math.max(totalPreviewCount - previewImages.length, 0);
+    const previewItems =
+      reviewImagesQuery.data?.result?.items
+        ?.map((item) => ({ reviewId: item.reviewId, imageUrl: item.reviewImage }))
+        .filter((item): item is { reviewId: number; imageUrl: string } => Boolean(item.imageUrl)) ?? [];
+    const previewItemsTrimmed = previewItems.slice(0, 3);
+    const totalPreviewCount = reviewImagesQuery.data?.result?.totalCount ?? previewItemsTrimmed.length;
+    const moreCount = Math.max(totalPreviewCount - previewItemsTrimmed.length, 0);
 
     return {
       rating,
       count: totalCount,
-      previewImages,
+      previewItems: previewItemsTrimmed,
       moreCount,
     };
-  }, [reviewListQuery.data?.pages, reviewThumbnailQuery.data?.result]);
+  }, [reviewListQuery.data?.pages, reviewImagesQuery.data?.result]);
 
   const { loadMoreRef } = useInfiniteScroll({
     hasNextPage: reviewListQuery.hasNextPage ?? false,
@@ -119,12 +116,15 @@ export default function DesignerReviewAllView({ designerId, mode = 'public' }: D
       ) : (
         <div className="flex flex-1 flex-col pt-5 pb-[calc(24px+env(safe-area-inset-bottom))]">
           <DesignerReviewSummary rating={summary.rating} count={summary.count} />
-          {summary.previewImages.length > 0 && (
+          {summary.previewItems.length > 0 && (
             <DesignerReviewPreviewStrip
-              previewImages={summary.previewImages}
+              previewItems={summary.previewItems}
               moreCount={summary.moreCount}
               showMoreLabel
               onMoreClick={() => router.push(photoPath)}
+              onImageClick={(reviewId, imageUrl) =>
+                router.push(`${photoDetailBase}/${reviewId}?imageUrl=${encodeURIComponent(imageUrl)}`)
+              }
             />
           )}
 

--- a/src/components/designerProfile/review/DesignerReviewAllView.tsx
+++ b/src/components/designerProfile/review/DesignerReviewAllView.tsx
@@ -46,6 +46,7 @@ export default function DesignerReviewAllView({ designerId, mode = 'public' }: D
     return items.map((item) => ({
       id: item.reviewId,
       name: item.modelName,
+      modelImage: item.modelImage ?? null,
       rating: item.rating,
       date: item.createdDate.replace(/-/g, '.'),
       content: item.content,

--- a/src/components/designerProfile/review/DesignerReviewCard.tsx
+++ b/src/components/designerProfile/review/DesignerReviewCard.tsx
@@ -9,6 +9,7 @@ import DesignerReviewStars from '@/src/components/designerProfile/review/Designe
 export interface DesignerReviewItem {
   id: number;
   name: string;
+  modelImage?: string | null;
   rating: number;
   date: string;
   content: string;
@@ -33,7 +34,17 @@ export default function DesignerReviewCard({ review, onImageClick }: DesignerRev
     <div className="flex flex-col gap-3 rounded-2xl bg-white px-4 pt-4 pb-5 shadow-[0_0_4px_rgba(34,34,34,0.06)]">
       <div className="grid grid-cols-[44px_1fr_auto] grid-rows-[auto_auto] items-center gap-x-3 gap-y-1">
         <div className="row-span-2 flex h-11 w-11 items-center justify-center rounded-full bg-gray-300">
-          <ProfileIcon className="h-7 w-7 text-gray-500" />
+          {review.modelImage ? (
+            <Image
+              src={review.modelImage}
+              alt={review.name}
+              width={44}
+              height={44}
+              className="h-11 w-11 rounded-full object-cover"
+            />
+          ) : (
+            <ProfileIcon className="h-7 w-7 text-gray-500" />
+          )}
         </div>
         <span className="text-body-1-medium text-gray-900">{review.name}</span>
         <DesignerReviewStars rating={review.rating} className="col-start-2 row-start-2" />

--- a/src/components/designerProfile/review/DesignerReviewCard.tsx
+++ b/src/components/designerProfile/review/DesignerReviewCard.tsx
@@ -83,7 +83,7 @@ export default function DesignerReviewCard({ review, onImageClick }: DesignerRev
 
       {review.replyDto?.content && (
         <div className="flex flex-col gap-3 rounded-xl bg-gray-100 px-4 py-4">
-          <span className="text-caption-1-medium text-gray-500">디자이너가 남긴 답글</span>
+          <span className="text-caption-1-medium text-gray-600">디자이너가 남긴 답글</span>
           <p className="text-body-2-regular whitespace-pre-line text-gray-900">{review.replyDto.content}</p>
         </div>
       )}

--- a/src/components/designerProfile/review/DesignerReviewCard.tsx
+++ b/src/components/designerProfile/review/DesignerReviewCard.tsx
@@ -15,6 +15,12 @@ export interface DesignerReviewItem {
   images: string[];
   summary?: string;
   isFixed?: boolean;
+  replyDto?: {
+    replyId: number;
+    designerName?: string;
+    content: string;
+    createdAt?: string;
+  } | null;
 }
 
 interface DesignerReviewCardProps {
@@ -43,7 +49,7 @@ export default function DesignerReviewCard({ review, onImageClick }: DesignerRev
 
       {review.images.length > 0 && (
         <div className="flex gap-2">
-          {review.images.map((imageUrl, index) => (
+          {review.images.map((imageUrl, index) =>
             onImageClick ? (
               <button
                 key={`${imageUrl}-${index}`}
@@ -58,8 +64,8 @@ export default function DesignerReviewCard({ review, onImageClick }: DesignerRev
               <div key={`${imageUrl}-${index}`} className="relative h-[99px] w-[98px] overflow-hidden rounded-lg">
                 <Image src={imageUrl} alt="" fill sizes="92px" className="object-cover" />
               </div>
-            )
-          ))}
+            ),
+          )}
         </div>
       )}
 
@@ -72,6 +78,13 @@ export default function DesignerReviewCard({ review, onImageClick }: DesignerRev
             .map((category, index) => (
               <CategoryBadge key={`${category}-${index}`} label={category} />
             ))}
+        </div>
+      )}
+
+      {review.replyDto?.content && (
+        <div className="flex flex-col gap-3 rounded-xl bg-gray-100 px-4 py-4">
+          <span className="text-caption-1-medium text-gray-500">디자이너가 남긴 답글</span>
+          <p className="text-body-2-regular whitespace-pre-line text-gray-900">{review.replyDto.content}</p>
         </div>
       )}
     </div>

--- a/src/components/designerProfile/review/DesignerReviewCard.tsx
+++ b/src/components/designerProfile/review/DesignerReviewCard.tsx
@@ -19,9 +19,10 @@ export interface DesignerReviewItem {
 
 interface DesignerReviewCardProps {
   review: DesignerReviewItem;
+  onImageClick?: (reviewId: number, imageUrl: string) => void;
 }
 
-export default function DesignerReviewCard({ review }: DesignerReviewCardProps) {
+export default function DesignerReviewCard({ review, onImageClick }: DesignerReviewCardProps) {
   return (
     <div className="flex flex-col gap-3 rounded-2xl bg-white px-4 pt-4 pb-5 shadow-[0_0_4px_rgba(34,34,34,0.06)]">
       <div className="grid grid-cols-[44px_1fr_auto] grid-rows-[auto_auto] items-center gap-x-3 gap-y-1">
@@ -43,9 +44,21 @@ export default function DesignerReviewCard({ review }: DesignerReviewCardProps) 
       {review.images.length > 0 && (
         <div className="flex gap-2">
           {review.images.map((imageUrl, index) => (
-            <div key={`${imageUrl}-${index}`} className="relative h-[99px] w-[98px] overflow-hidden rounded-lg">
-              <Image src={imageUrl} alt="" fill sizes="92px" className="object-cover" />
-            </div>
+            onImageClick ? (
+              <button
+                key={`${imageUrl}-${index}`}
+                type="button"
+                onClick={() => onImageClick(review.id, imageUrl)}
+                className="relative h-[99px] w-[98px] cursor-pointer overflow-hidden rounded-lg"
+                aria-label={`리뷰 사진 ${index + 1} 보기`}
+              >
+                <Image src={imageUrl} alt="" fill sizes="92px" className="object-cover" />
+              </button>
+            ) : (
+              <div key={`${imageUrl}-${index}`} className="relative h-[99px] w-[98px] overflow-hidden rounded-lg">
+                <Image src={imageUrl} alt="" fill sizes="92px" className="object-cover" />
+              </div>
+            )
           ))}
         </div>
       )}

--- a/src/components/designerProfile/review/DesignerReviewPhotoDetailView.tsx
+++ b/src/components/designerProfile/review/DesignerReviewPhotoDetailView.tsx
@@ -59,11 +59,16 @@ export default function DesignerReviewPhotoDetailView({
   const reviewImages = reviewItem?.reviewImages ?? [];
   const displayDate = reviewItem?.createdDate ? reviewItem.createdDate.replace(/-/g, '.') : '';
   const initialIndex = useMemo(() => {
+    const imageUrlParam = searchParams.get('imageUrl');
+    if (imageUrlParam) {
+      const matchedIndex = reviewImages.findIndex((url) => url === imageUrlParam);
+      if (matchedIndex >= 0) return matchedIndex;
+    }
     const rawIndex = Number(searchParams.get('imageIndex'));
     if (!Number.isFinite(rawIndex)) return 0;
     const clamped = Math.max(0, Math.min(rawIndex, reviewImages.length - 1));
     return Number.isNaN(clamped) ? 0 : clamped;
-  }, [reviewImages.length, searchParams]);
+  }, [reviewImages, searchParams]);
 
   if (!canFetchReviews) {
     return (

--- a/src/components/designerProfile/review/DesignerReviewPhotoDetailView.tsx
+++ b/src/components/designerProfile/review/DesignerReviewPhotoDetailView.tsx
@@ -13,7 +13,12 @@ import PinIcon from '@/public/icons/common/pin.svg';
 import ProfilePlaceholderIcon from '@/public/icons/designer-home/profile-placeholder-sm.svg';
 import CategoryBadge from '@/src/components/common/CategoryBadge';
 import DesignerReviewStars from '@/src/components/designerProfile/review/DesignerReviewStars';
-import { useDesignerReviews, usePublicDesignerReviewListInfinite } from '@/src/hooks/queries/review';
+import {
+  useDesignerReviews,
+  usePublicDesignerReviewDetail,
+  usePublicDesignerReviewListInfinite,
+} from '@/src/hooks/queries/review';
+import type { ApiResponse, DesignerReviewDetailResponse } from '@/src/types';
 
 interface DesignerReviewPhotoDetailViewProps {
   designerId: number;
@@ -31,6 +36,12 @@ export default function DesignerReviewPhotoDetailView({
   const isOwnerMode = mode === 'owner';
   const paginationId = useId().replace(/:/g, '');
   const canFetchReviews = Number.isFinite(designerId) && designerId > 0 && reviewId > 0;
+
+  const reviewDetailQuery = usePublicDesignerReviewDetail({
+    reviewId,
+    enabled: canFetchReviews,
+  });
+  const reviewDetail = reviewDetailQuery.data as ApiResponse<DesignerReviewDetailResponse> | undefined;
 
   const ownerReviewQuery = useDesignerReviews({ size: 10 }, { enabled: isOwnerMode && canFetchReviews });
 
@@ -52,8 +63,14 @@ export default function DesignerReviewPhotoDetailView({
     reviewListQuery.fetchNextPage();
   }, [canFetchReviews, reviewItem, reviewListQuery]);
 
-  const reviewImages = reviewItem?.reviewImages ?? [];
+  const reviewImages = reviewDetail?.result?.imageUrls?.length
+    ? reviewDetail.result.imageUrls
+    : reviewItem?.reviewImages ?? [];
   const displayDate = reviewItem?.createdDate ? reviewItem.createdDate.replace(/-/g, '.') : '';
+  const displayName = reviewItem?.modelName ?? '고객';
+  const displayRating = reviewDetail?.result?.rating ?? reviewItem?.rating ?? 0;
+  const displayContent = reviewDetail?.result?.content ?? reviewItem?.content ?? '';
+  const displaySummary = reviewDetail?.result?.summary ?? reviewItem?.summary ?? '';
   const initialIndex = useMemo(() => {
     const imageUrlParam = searchParams.get('imageUrl');
     if (imageUrlParam) {
@@ -74,7 +91,7 @@ export default function DesignerReviewPhotoDetailView({
     );
   }
 
-  if (reviewListQuery.isLoading && !reviewItem) {
+  if (reviewDetailQuery.isLoading && !reviewDetail?.result && !reviewItem) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-white">
         <p className="text-body-2-medium text-gray-500">리뷰를 불러오는 중입니다.</p>
@@ -82,7 +99,7 @@ export default function DesignerReviewPhotoDetailView({
     );
   }
 
-  if (!reviewItem) {
+  if (!reviewDetail?.result && !reviewItem) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-white">
         <p className="text-body-2-medium text-gray-500">리뷰 정보를 찾을 수 없습니다.</p>
@@ -161,10 +178,10 @@ export default function DesignerReviewPhotoDetailView({
         <div className="flex items-start justify-between">
           <div className="flex items-start gap-3">
             <div className="flex h-11 w-11 items-center justify-center rounded-full bg-gray-100">
-              {reviewItem.modelImage ? (
+              {reviewItem?.modelImage ? (
                 <Image
                   src={reviewItem.modelImage}
-                  alt={reviewItem.modelName}
+                  alt={displayName}
                   width={44}
                   height={44}
                   className="h-11 w-11 rounded-full object-cover"
@@ -174,26 +191,26 @@ export default function DesignerReviewPhotoDetailView({
               )}
             </div>
             <div className="flex flex-col gap-1">
-              <span className="text-body-1-semibold text-gray-900">{reviewItem.modelName}</span>
-              <DesignerReviewStars rating={reviewItem.rating} />
+              <span className="text-body-1-semibold text-gray-900">{displayName}</span>
+              <DesignerReviewStars rating={displayRating} />
             </div>
           </div>
           <div className="flex flex-col items-end gap-2">
-            {reviewItem.isFixed && <PinIcon className="h-5 w-5 text-gray-700" />}
-            <span className="text-caption-1-medium text-gray-500">{displayDate}</span>
+            {reviewItem?.isFixed && <PinIcon className="h-5 w-5 text-gray-700" />}
+            {displayDate && <span className="text-caption-1-medium text-gray-500">{displayDate}</span>}
           </div>
         </div>
 
-        <p className="text-body-2-regular pt-2 whitespace-pre-line text-gray-700">{reviewItem.content}</p>
-        {reviewItem.summary && (
+        <p className="text-body-2-regular pt-2 whitespace-pre-line text-gray-700">{displayContent}</p>
+        {displaySummary && (
           <div className="flex flex-wrap gap-1">
-            {reviewItem.summary.split(', ').map((category) => (
+            {displaySummary.split(', ').map((category) => (
               <CategoryBadge key={category} label={category} />
             ))}
           </div>
         )}
 
-        {reviewItem.replyDto?.content && (
+        {reviewItem?.replyDto?.content && (
           <div className="mt-1 flex flex-col gap-3 rounded-xl bg-gray-100 px-4 py-4">
             <span className="text-caption-1-medium text-gray-600">디자이너가 남긴 답글</span>
             <p className="text-body-2-regular whitespace-pre-line text-gray-900">{reviewItem.replyDto.content}</p>

--- a/src/components/designerProfile/review/DesignerReviewPhotoDetailView.tsx
+++ b/src/components/designerProfile/review/DesignerReviewPhotoDetailView.tsx
@@ -10,7 +10,7 @@ import { Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import ArrowLeftIcon from '@/public/icons/common/arrow-left.svg';
 import PinIcon from '@/public/icons/common/pin.svg';
-import ProfilePlaceholderIcon from '@/public/icons/designer-home/profile-placeholder-sm.svg';
+import ProfileIcon from '@/public/icons/chat/profile.svg';
 import CategoryBadge from '@/src/components/common/CategoryBadge';
 import DesignerReviewStars from '@/src/components/designerProfile/review/DesignerReviewStars';
 import {
@@ -65,7 +65,7 @@ export default function DesignerReviewPhotoDetailView({
 
   const reviewImages = reviewDetail?.result?.imageUrls?.length
     ? reviewDetail.result.imageUrls
-    : reviewItem?.reviewImages ?? [];
+    : (reviewItem?.reviewImages ?? []);
   const displayDate = reviewItem?.createdDate ? reviewItem.createdDate.replace(/-/g, '.') : '';
   const displayName = reviewItem?.modelName ?? '고객';
   const displayRating = reviewDetail?.result?.rating ?? reviewItem?.rating ?? 0;
@@ -177,7 +177,7 @@ export default function DesignerReviewPhotoDetailView({
       <div className="mt-6 flex flex-col gap-2 px-4 pb-[calc(24px+env(safe-area-inset-bottom))]">
         <div className="flex items-start justify-between">
           <div className="flex items-start gap-3">
-            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-gray-100">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-gray-300">
               {reviewItem?.modelImage ? (
                 <Image
                   src={reviewItem.modelImage}
@@ -187,7 +187,7 @@ export default function DesignerReviewPhotoDetailView({
                   className="h-11 w-11 rounded-full object-cover"
                 />
               ) : (
-                <ProfilePlaceholderIcon className="h-5 w-5 text-gray-400" />
+                <ProfileIcon className="h-7 w-7 text-gray-500" />
               )}
             </div>
             <div className="flex flex-col gap-1">

--- a/src/components/designerProfile/review/DesignerReviewPhotoDetailView.tsx
+++ b/src/components/designerProfile/review/DesignerReviewPhotoDetailView.tsx
@@ -50,11 +50,7 @@ export default function DesignerReviewPhotoDetailView({
   useEffect(() => {
     if (!canFetchReviews || reviewItem || !reviewListQuery.hasNextPage || reviewListQuery.isFetchingNextPage) return;
     reviewListQuery.fetchNextPage();
-  }, [
-    canFetchReviews,
-    reviewItem,
-    reviewListQuery,
-  ]);
+  }, [canFetchReviews, reviewItem, reviewListQuery]);
 
   const reviewImages = reviewItem?.reviewImages ?? [];
   const displayDate = reviewItem?.createdDate ? reviewItem.createdDate.replace(/-/g, '.') : '';
@@ -194,6 +190,13 @@ export default function DesignerReviewPhotoDetailView({
             {reviewItem.summary.split(', ').map((category) => (
               <CategoryBadge key={category} label={category} />
             ))}
+          </div>
+        )}
+
+        {reviewItem.replyDto?.content && (
+          <div className="mt-1 flex flex-col gap-3 rounded-xl bg-gray-100 px-4 py-4">
+            <span className="text-caption-1-medium text-gray-600">디자이너가 남긴 답글</span>
+            <p className="text-body-2-regular whitespace-pre-line text-gray-900">{reviewItem.replyDto.content}</p>
           </div>
         )}
       </div>

--- a/src/components/designerProfile/review/DesignerReviewPhotoGalleryView.tsx
+++ b/src/components/designerProfile/review/DesignerReviewPhotoGalleryView.tsx
@@ -6,10 +6,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import ArrowLeftIcon from '@/public/icons/common/arrow-left.svg';
 import { useInfiniteScroll } from '@/src/hooks/common/useInfiniteScroll';
-import {
-  useDesignerReviews,
-  usePublicDesignerReviewListInfinite,
-} from '@/src/hooks/queries/review';
+import { usePublicDesignerReviewImagesInfinite } from '@/src/hooks/queries/review';
 
 interface DesignerReviewPhotoGalleryViewProps {
   designerId: number;
@@ -24,33 +21,23 @@ export default function DesignerReviewPhotoGalleryView({
   const isOwnerMode = mode === 'owner';
   const canFetchPhotos = Number.isFinite(designerId) && designerId > 0;
 
-  const ownerReviewQuery = useDesignerReviews(
-    { size: 12 },
-    { enabled: isOwnerMode && canFetchPhotos },
-  );
-
-  const publicReviewQuery = usePublicDesignerReviewListInfinite({
+  const activeQuery = usePublicDesignerReviewImagesInfinite({
     designerId,
     params: { size: 12 },
-    enabled: !isOwnerMode && canFetchPhotos,
+    enabled: canFetchPhotos,
   });
-
-  const activeQuery = isOwnerMode ? ownerReviewQuery : publicReviewQuery;
   const detailBasePath = isOwnerMode
     ? '/myProfile/reviews/photos'
     : `/designer/${designerId}/reviews/photos`;
 
   const photoItems = useMemo(() => {
     const items = activeQuery.data?.pages.flatMap((page) => page.result?.items ?? []) ?? [];
-    return items.flatMap((item) =>
-      (item.reviewImages ?? [])
-        .filter((imageUrl): imageUrl is string => Boolean(imageUrl))
-        .map((imageUrl, imageIndex) => ({
-          reviewId: item.reviewId,
-          imageUrl,
-          imageIndex,
-        })),
-    );
+    return items
+      .map((item) => ({
+        reviewId: item.reviewId,
+        imageUrl: item.reviewImage,
+      }))
+      .filter((item): item is { reviewId: number; imageUrl: string } => Boolean(item.imageUrl));
   }, [activeQuery.data?.pages]);
 
   const { loadMoreRef } = useInfiniteScroll({
@@ -96,7 +83,7 @@ export default function DesignerReviewPhotoGalleryView({
             photoItems.map((item, index) => (
               <Link
                 key={`${item.reviewId}-${index}`}
-                href={`${detailBasePath}/${item.reviewId}?imageIndex=${item.imageIndex}`}
+                href={`${detailBasePath}/${item.reviewId}?imageUrl=${encodeURIComponent(item.imageUrl)}`}
                 className="relative aspect-square overflow-hidden rounded-2xl bg-gray-100"
                 aria-label={`리뷰 사진 ${index + 1} 보기`}
               >

--- a/src/components/designerProfile/review/DesignerReviewPreviewStrip.tsx
+++ b/src/components/designerProfile/review/DesignerReviewPreviewStrip.tsx
@@ -2,32 +2,36 @@
 
 import Image from 'next/image';
 import CircleArrowIcon from '@/public/icons/review/circle_arrow.svg';
+import type { DesignerReviewPreviewItem } from '@/src/components/designerProfile/review/DesignerReviewTab';
 
 interface DesignerReviewPreviewStripProps {
-  previewImages: string[];
+  previewItems: DesignerReviewPreviewItem[];
   moreCount: number;
   totalSlots?: number;
   showMoreLabel?: boolean;
   onMoreClick?: () => void;
+  onImageClick?: (reviewId: number, imageUrl: string) => void;
 }
 
 export default function DesignerReviewPreviewStrip({
-  previewImages,
+  previewItems,
   moreCount,
   totalSlots = 3,
   showMoreLabel = false,
   onMoreClick,
+  onImageClick,
 }: DesignerReviewPreviewStripProps) {
   const slots = Array.from({ length: totalSlots });
-  const lastPreviewIndex = previewImages.length > 0 ? previewImages.length - 1 : -1;
+  const lastPreviewIndex =
+    previewItems.length > 0 ? Math.min(previewItems.length, totalSlots) - 1 : -1;
 
   return (
     <div className="flex gap-2.5 px-4 pt-4">
       {slots.map((_, index) => {
-        const imageUrl = previewImages[index];
+        const item = previewItems[index];
         const isLastPreview = index === lastPreviewIndex;
 
-        if (!imageUrl) {
+        if (!item?.imageUrl) {
           return (
             <div key={`preview-placeholder-${index}`} className="aspect-square flex-1 rounded-[10px] bg-transparent" />
           );
@@ -42,12 +46,13 @@ export default function DesignerReviewPreviewStrip({
         ) : (
           <span className="text-body-1-semibold text-white">+{moreCount}</span>
         );
+        const containerClass = "relative aspect-square flex-1 overflow-hidden rounded-[10px]";
 
-        return (
-          <div key={`${imageUrl}-${index}`} className="relative aspect-square flex-1 overflow-hidden rounded-[10px]">
-            <Image src={imageUrl} alt="" fill sizes="33vw" className="object-cover" />
-            {showOverlay &&
-              (onMoreClick ? (
+        if (showOverlay) {
+          return (
+            <div key={`${item.reviewId}-${index}`} className={containerClass}>
+              <Image src={item.imageUrl} alt="" fill sizes="33vw" className="object-cover" />
+              {onMoreClick ? (
                 <button
                   type="button"
                   onClick={onMoreClick}
@@ -57,7 +62,27 @@ export default function DesignerReviewPreviewStrip({
                 </button>
               ) : (
                 <div className="absolute inset-0 flex items-center justify-center bg-black/45">{overlayContent}</div>
-              ))}
+              )}
+            </div>
+          );
+        }
+
+        if (onImageClick) {
+          return (
+            <button
+              key={`${item.reviewId}-${index}`}
+              type="button"
+              onClick={() => onImageClick(item.reviewId, item.imageUrl)}
+              className={`${containerClass} cursor-pointer`}
+            >
+              <Image src={item.imageUrl} alt="" fill sizes="33vw" className="object-cover" />
+            </button>
+          );
+        }
+
+        return (
+          <div key={`${item.reviewId}-${index}`} className={containerClass}>
+            <Image src={item.imageUrl} alt="" fill sizes="33vw" className="object-cover" />
           </div>
         );
       })}

--- a/src/components/designerProfile/review/DesignerReviewTab.tsx
+++ b/src/components/designerProfile/review/DesignerReviewTab.tsx
@@ -5,10 +5,15 @@ import DesignerReviewPreviewStrip from '@/src/components/designerProfile/review/
 import DesignerReviewSummary from '@/src/components/designerProfile/review/DesignerReviewSummary';
 import RightArrowIcon from '@/public/icons/common/arrow-right.svg';
 
+export interface DesignerReviewPreviewItem {
+  reviewId: number;
+  imageUrl: string;
+}
+
 export interface DesignerReviewSummaryData {
   rating: number;
   count: number;
-  previewImages: string[];
+  previewItems: DesignerReviewPreviewItem[];
   moreCount: number;
 }
 
@@ -18,6 +23,7 @@ interface DesignerReviewTabProps {
   onViewAll?: () => void;
   onPreviewMore?: () => void;
   showPreviewMoreLabel?: boolean;
+  onPreviewImageClick?: (reviewId: number, imageUrl: string) => void;
 }
 
 export default function DesignerReviewTab({
@@ -26,16 +32,18 @@ export default function DesignerReviewTab({
   onViewAll,
   onPreviewMore,
   showPreviewMoreLabel = false,
+  onPreviewImageClick,
 }: DesignerReviewTabProps) {
   return (
     <div className="bg-gray-100 pt-4 pb-[calc(24px+env(safe-area-inset-bottom))]">
       <DesignerReviewSummary rating={summary.rating} count={summary.count} onViewAll={onViewAll} />
-      {summary.previewImages.length > 0 && (
+      {summary.previewItems.length > 0 && (
         <DesignerReviewPreviewStrip
-          previewImages={summary.previewImages}
+          previewItems={summary.previewItems}
           moreCount={summary.moreCount}
           showMoreLabel={showPreviewMoreLabel}
           onMoreClick={onPreviewMore}
+          onImageClick={onPreviewImageClick}
         />
       )}
 

--- a/src/components/designerProfile/review/DesignerReviewTab.tsx
+++ b/src/components/designerProfile/review/DesignerReviewTab.tsx
@@ -24,6 +24,7 @@ interface DesignerReviewTabProps {
   onPreviewMore?: () => void;
   showPreviewMoreLabel?: boolean;
   onPreviewImageClick?: (reviewId: number, imageUrl: string) => void;
+  onReviewImageClick?: (reviewId: number, imageUrl: string) => void;
 }
 
 export default function DesignerReviewTab({
@@ -33,6 +34,7 @@ export default function DesignerReviewTab({
   onPreviewMore,
   showPreviewMoreLabel = false,
   onPreviewImageClick,
+  onReviewImageClick,
 }: DesignerReviewTabProps) {
   return (
     <div className="bg-gray-100 pt-4 pb-[calc(24px+env(safe-area-inset-bottom))]">
@@ -50,7 +52,9 @@ export default function DesignerReviewTab({
       <div className="flex flex-col px-4 pt-5">
         <div className="flex flex-col gap-5">
           {reviews.length > 0 ? (
-            reviews.map((review) => <DesignerReviewCard key={review.id} review={review} />)
+            reviews.map((review) => (
+              <DesignerReviewCard key={review.id} review={review} onImageClick={onReviewImageClick} />
+            ))
           ) : (
             <div className="flex items-center justify-center rounded-2xl bg-white px-4 py-6">
               <p className="text-body-2-medium text-gray-500">등록된 리뷰가 없습니다.</p>

--- a/src/components/designerProfile/review/DesignerReviewTab.tsx
+++ b/src/components/designerProfile/review/DesignerReviewTab.tsx
@@ -3,6 +3,7 @@
 import DesignerReviewCard, { DesignerReviewItem } from '@/src/components/designerProfile/review/DesignerReviewCard';
 import DesignerReviewPreviewStrip from '@/src/components/designerProfile/review/DesignerReviewPreviewStrip';
 import DesignerReviewSummary from '@/src/components/designerProfile/review/DesignerReviewSummary';
+import RightArrowIcon from '@/public/icons/common/arrow-right.svg';
 
 export interface DesignerReviewSummaryData {
   rating: number;
@@ -27,7 +28,7 @@ export default function DesignerReviewTab({
   showPreviewMoreLabel = false,
 }: DesignerReviewTabProps) {
   return (
-    <div className="bg-gray-100 pt-4 pb-[calc(32px+env(safe-area-inset-bottom))]">
+    <div className="bg-gray-100 pt-4 pb-[calc(24px+env(safe-area-inset-bottom))]">
       <DesignerReviewSummary rating={summary.rating} count={summary.count} onViewAll={onViewAll} />
       {summary.previewImages.length > 0 && (
         <DesignerReviewPreviewStrip
@@ -38,12 +39,26 @@ export default function DesignerReviewTab({
         />
       )}
 
-      <div className="flex flex-col gap-5 px-4 pt-5">
-        {reviews.length > 0 ? (
-          reviews.map((review) => <DesignerReviewCard key={review.id} review={review} />)
-        ) : (
-          <div className="flex items-center justify-center rounded-2xl bg-white px-4 py-6">
-            <p className="text-body-2-medium text-gray-500">등록된 리뷰가 없습니다.</p>
+      <div className="flex flex-col px-4 pt-5">
+        <div className="flex flex-col gap-5">
+          {reviews.length > 0 ? (
+            reviews.map((review) => <DesignerReviewCard key={review.id} review={review} />)
+          ) : (
+            <div className="flex items-center justify-center rounded-2xl bg-white px-4 py-6">
+              <p className="text-body-2-medium text-gray-500">등록된 리뷰가 없습니다.</p>
+            </div>
+          )}
+        </div>
+        {onViewAll && reviews.length > 0 && (
+          <div className="mt-4 flex justify-center">
+            <button
+              type="button"
+              onClick={onViewAll}
+              className="text-body-2-medium flex cursor-pointer items-center rounded-[34px] border border-gray-400 bg-white py-2 pr-2 pl-3.5 text-gray-900"
+            >
+              리뷰 전체보기
+              <RightArrowIcon className="h-6 scale-[0.7] text-gray-900" />
+            </button>
           </div>
         )}
       </div>

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -66,13 +66,13 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
   const isOwnerView = isOwner || isOwnerFromAuth || isOwnerFromProfile;
 
   const ownerReviewListQuery = useDesignerReviews(
-    { size: 10 },
+    { size: 5 },
     { enabled: reviewQueryEnabled && isOwnerView },
   );
 
   const reviewListQuery = usePublicDesignerReviewList({
     designerId: reviewDesignerId,
-    params: { size: 10 },
+    params: { size: 5 },
     enabled: reviewQueryEnabled && !isOwnerView,
   });
 

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -95,6 +95,7 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
       images: item.reviewImages ?? [],
       summary: item.summary,
       isFixed: item.isFixed,
+      replyDto: item.replyDto ?? null,
     }));
   }, [isOwnerView, ownerReviewListQuery.data?.pages, reviewListQuery.data?.result?.items]);
 

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -89,6 +89,7 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
     return items.map((item) => ({
       id: item.reviewId,
       name: item.modelName,
+      modelImage: item.modelImage ?? null,
       rating: item.rating,
       date: item.createdDate.replace(/-/g, '.'),
       content: item.content,

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -364,6 +364,12 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
                         router.push(`${reviewPhotoDetailBase}/${reviewId}?imageUrl=${encodeURIComponent(imageUrl)}`)
                     : undefined
                 }
+                onReviewImageClick={
+                  reviewPhotoDetailBase
+                    ? (reviewId, imageUrl) =>
+                        router.push(`${reviewPhotoDetailBase}/${reviewId}?imageUrl=${encodeURIComponent(imageUrl)}`)
+                    : undefined
+                }
                 showPreviewMoreLabel
               />
             </div>

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -110,7 +110,9 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
       ? ownerTotalCount ?? listItems.length
       : publicResult?.totalCount ?? data?.result?.reviewCount ?? listItems.length;
     const totalRating = listItems.reduce((sum, item) => sum + item.rating, 0);
-    const rating = listItems.length > 0 ? totalRating / listItems.length : (data?.result?.averageRating ?? 0);
+    const rating =
+      data?.result?.averageRating ??
+      (listItems.length > 0 ? totalRating / listItems.length : 0);
     const previewItems =
       reviewImagesQuery.data?.result?.items
         ?.map((item) => ({ reviewId: item.reviewId, imageUrl: item.reviewImage }))

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -23,8 +23,8 @@ import { getAccessToken } from '@/src/stores';
 import { useMyDesignerProfile } from '@/src/hooks/queries/profile';
 import {
   useDesignerReviews,
+  usePublicDesignerReviewImages,
   usePublicDesignerReviewList,
-  usePublicDesignerReviewThumbnails,
 } from '@/src/hooks/queries/review';
 import CheckIcon from '@/public/icons/post/check.svg';
 import CloseIcon from '@/public/icons/common/close.svg';
@@ -76,9 +76,9 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
     enabled: reviewQueryEnabled && !isOwnerView,
   });
 
-  const reviewThumbnailQuery = usePublicDesignerReviewThumbnails({
+  const reviewImagesQuery = usePublicDesignerReviewImages({
     designerId: reviewDesignerId,
-    params: { size: 10 },
+    params: { size: 3 },
     enabled: reviewQueryEnabled && canFetchReviews,
   });
 
@@ -109,30 +109,18 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
       : publicResult?.totalCount ?? data?.result?.reviewCount ?? listItems.length;
     const totalRating = listItems.reduce((sum, item) => sum + item.rating, 0);
     const rating = listItems.length > 0 ? totalRating / listItems.length : (data?.result?.averageRating ?? 0);
-    const thumbnailResult = reviewThumbnailQuery.data?.result;
-    const thumbnailItems = thumbnailResult?.items ?? [];
-    const fallbackPreviewItems = listItems
-      .map((item) => ({ reviewId: item.reviewId, imageUrl: item.reviewImages?.[0] }))
-      .filter((item): item is { reviewId: number; imageUrl: string } => Boolean(item.imageUrl));
-    const previewSourceItems =
-      thumbnailItems.length > 0
-        ? thumbnailItems
-            .map((item) => ({ reviewId: item.reviewId, imageUrl: item.reviewThumbnail }))
-            .filter((item): item is { reviewId: number; imageUrl: string } => Boolean(item.imageUrl))
-        : fallbackPreviewItems;
-    const previewImages = previewSourceItems.slice(0, 3).map((item) => item.imageUrl);
-    const totalPreviewCount =
-      thumbnailItems.length > 0
-        ? thumbnailResult?.hasNext
-          ? thumbnailResult?.totalCount ?? previewSourceItems.length ?? totalCount
-          : previewSourceItems.length
-        : previewSourceItems.length ?? totalCount;
-    const moreCount = Math.max(totalPreviewCount - previewImages.length, 0);
+    const previewItems =
+      reviewImagesQuery.data?.result?.items
+        ?.map((item) => ({ reviewId: item.reviewId, imageUrl: item.reviewImage }))
+        .filter((item): item is { reviewId: number; imageUrl: string } => Boolean(item.imageUrl)) ?? [];
+    const previewItemsTrimmed = previewItems.slice(0, 3);
+    const totalPreviewCount = reviewImagesQuery.data?.result?.totalCount ?? previewItemsTrimmed.length;
+    const moreCount = Math.max(totalPreviewCount - previewItemsTrimmed.length, 0);
 
     return {
       rating,
       count: totalCount,
-      previewImages,
+      previewItems: previewItemsTrimmed,
       moreCount,
     };
   }, [
@@ -141,7 +129,7 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
     isOwnerView,
     ownerReviewListQuery.data?.pages,
     reviewListQuery.data?.result,
-    reviewThumbnailQuery.data?.result,
+    reviewImagesQuery.data?.result,
   ]);
 
   const isReviewLoading = reviewQueryEnabled
@@ -179,6 +167,12 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
   const reviewDetailPath = isOwnerView
     ? '/myProfile/reviews'
     : `/designer/${detail.designerProfile.designerId}/reviews`;
+  const reviewPhotoPath = isOwnerView
+    ? '/myProfile/reviews/photos'
+    : canFetchReviews
+      ? `/designer/${reviewDesignerId}/reviews/photos`
+      : '';
+  const reviewPhotoDetailBase = reviewPhotoPath;
 
   // 서버 상태 + 로컬 토글 카운트로 현재 상태 계산
   const isLiked = toggleCount % 2 === 0 ? detail.isLiked : !detail.isLiked;
@@ -363,6 +357,14 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
                 summary={reviewSummary}
                 reviews={reviewItems}
                 onViewAll={() => router.push(reviewDetailPath)}
+                onPreviewMore={reviewPhotoPath ? () => router.push(reviewPhotoPath) : undefined}
+                onPreviewImageClick={
+                  reviewPhotoDetailBase
+                    ? (reviewId, imageUrl) =>
+                        router.push(`${reviewPhotoDetailBase}/${reviewId}?imageUrl=${encodeURIComponent(imageUrl)}`)
+                    : undefined
+                }
+                showPreviewMoreLabel
               />
             </div>
           )}

--- a/src/components/post/PostDetailContent.tsx
+++ b/src/components/post/PostDetailContent.tsx
@@ -66,13 +66,13 @@ export default function PostDetailContent({ recruitmentId, isOwner = false }: Po
   const isOwnerView = isOwner || isOwnerFromAuth || isOwnerFromProfile;
 
   const ownerReviewListQuery = useDesignerReviews(
-    { size: 5 },
+    { size: 3 },
     { enabled: reviewQueryEnabled && isOwnerView },
   );
 
   const reviewListQuery = usePublicDesignerReviewList({
     designerId: reviewDesignerId,
-    params: { size: 5 },
+    params: { size: 3 },
     enabled: reviewQueryEnabled && !isOwnerView,
   });
 

--- a/src/hooks/queries/review/useDesignerReviews.ts
+++ b/src/hooks/queries/review/useDesignerReviews.ts
@@ -29,6 +29,7 @@ export const designerReviewKeys = {
 // 커서 타입
 interface ReviewCursor {
   cursorId?: number;
+  cursorIsFixed?: boolean;
 }
 
 interface UseDesignerReviewsOptions {
@@ -39,7 +40,7 @@ interface UseDesignerReviewsOptions {
  * 디자이너가 받은 리뷰 목록 조회 Hook (무한 스크롤)
  */
 export function useDesignerReviews(
-  params?: Omit<ReviewListParams, 'cursorId'>,
+  params?: Omit<ReviewListParams, 'cursorId' | 'cursorIsFixed'>,
   options: UseDesignerReviewsOptions = {}
 ) {
   const { enabled = true } = options;
@@ -56,6 +57,7 @@ export function useDesignerReviews(
       const apiParams = {
         ...params,
         cursorId: pageParam?.cursorId,
+        cursorIsFixed: pageParam?.cursorIsFixed,
       };
       return getDesignerReviews(apiParams);
     },
@@ -64,6 +66,7 @@ export function useDesignerReviews(
       if (!lastPage.result?.hasNext) return undefined;
       return {
         cursorId: lastPage.result.nextCursor ?? undefined,
+        cursorIsFixed: lastPage.result.nextCursorFixed ?? undefined,
       };
     },
     enabled,

--- a/src/hooks/queries/review/usePublicDesignerReviews.ts
+++ b/src/hooks/queries/review/usePublicDesignerReviews.ts
@@ -1,9 +1,14 @@
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
-import { getPublicDesignerReviews, getPublicDesignerReviewThumbnails } from '@/src/apis';
+import {
+  getPublicDesignerReviews,
+  getPublicDesignerReviewThumbnails,
+  getPublicDesignerReviewImages,
+} from '@/src/apis';
 import type {
   ApiResponse,
   DesignerReviewsResponse,
   DesignerReviewThumbnailsResponse,
+  DesignerReviewImagesResponse,
   ReviewListParams,
 } from '@/src/types';
 
@@ -17,6 +22,10 @@ export const publicDesignerReviewKeys = {
     [...publicDesignerReviewKeys.all, 'thumbnails', designerId, params] as const,
   thumbnailsInfinite: (designerId: number, params?: ReviewListParams) =>
     [...publicDesignerReviewKeys.all, 'thumbnailsInfinite', designerId, params] as const,
+  images: (designerId: number, params?: ReviewListParams) =>
+    [...publicDesignerReviewKeys.all, 'images', designerId, params] as const,
+  imagesInfinite: (designerId: number, params?: ReviewListParams) =>
+    [...publicDesignerReviewKeys.all, 'imagesInfinite', designerId, params] as const,
 };
 
 interface UsePublicDesignerReviewListParams {
@@ -29,9 +38,14 @@ interface ReviewCursor {
   cursorId?: number;
 }
 
+interface ReviewListCursor {
+  cursorId?: number;
+  cursorIsFixed?: boolean;
+}
+
 interface UsePublicDesignerReviewListInfiniteParams {
   designerId: number;
-  params?: Omit<ReviewListParams, 'cursorId'>;
+  params?: Omit<ReviewListParams, 'cursorId' | 'cursorIsFixed'>;
   enabled?: boolean;
 }
 
@@ -44,6 +58,18 @@ interface UsePublicDesignerReviewThumbnailsParams {
 interface UsePublicDesignerReviewThumbnailsInfiniteParams {
   designerId: number;
   params?: Omit<ReviewListParams, 'cursorId'>;
+  enabled?: boolean;
+}
+
+interface UsePublicDesignerReviewImagesParams {
+  designerId: number;
+  params?: ReviewListParams;
+  enabled?: boolean;
+}
+
+interface UsePublicDesignerReviewImagesInfiniteParams {
+  designerId: number;
+  params?: Omit<ReviewListParams, 'cursorId' | 'cursorIsFixed'>;
   enabled?: boolean;
 }
 
@@ -74,15 +100,16 @@ export function usePublicDesignerReviewListInfinite({
   return useInfiniteQuery<
     ApiResponse<DesignerReviewsResponse>,
     Error,
-    { pages: ApiResponse<DesignerReviewsResponse>[]; pageParams: ReviewCursor[] },
+    { pages: ApiResponse<DesignerReviewsResponse>[]; pageParams: ReviewListCursor[] },
     ReturnType<typeof publicDesignerReviewKeys.listInfinite>,
-    ReviewCursor
+    ReviewListCursor
   >({
     queryKey: publicDesignerReviewKeys.listInfinite(designerId, params),
     queryFn: async ({ pageParam }) => {
       const apiParams = {
         ...params,
         cursorId: pageParam?.cursorId,
+        cursorIsFixed: pageParam?.cursorIsFixed,
       };
       return getPublicDesignerReviews(designerId, apiParams);
     },
@@ -91,6 +118,7 @@ export function usePublicDesignerReviewListInfinite({
       if (!lastPage.result?.hasNext) return undefined;
       return {
         cursorId: lastPage.result.nextCursor ?? undefined,
+        cursorIsFixed: lastPage.result.nextCursorFixed ?? undefined,
       };
     },
     enabled,
@@ -142,6 +170,59 @@ export function usePublicDesignerReviewThumbnailsInfinite({
       if (!lastPage.result?.hasNext) return undefined;
       return {
         cursorId: lastPage.result.nextCursor ?? undefined,
+      };
+    },
+    enabled,
+    staleTime: 1000 * 60 * 2, // 2분
+  });
+}
+
+/**
+ * 디자이너 리뷰 이미지 리스트 조회 Hook (공개)
+ */
+export function usePublicDesignerReviewImages({
+  designerId,
+  params,
+  enabled = true,
+}: UsePublicDesignerReviewImagesParams) {
+  return useQuery<ApiResponse<DesignerReviewImagesResponse>, Error>({
+    queryKey: publicDesignerReviewKeys.images(designerId, params),
+    queryFn: () => getPublicDesignerReviewImages(designerId, params),
+    enabled,
+    staleTime: 1000 * 60 * 2, // 2분
+  });
+}
+
+/**
+ * 디자이너 리뷰 이미지 리스트 조회 Hook (공개, 무한 스크롤)
+ */
+export function usePublicDesignerReviewImagesInfinite({
+  designerId,
+  params,
+  enabled = true,
+}: UsePublicDesignerReviewImagesInfiniteParams) {
+  return useInfiniteQuery<
+    ApiResponse<DesignerReviewImagesResponse>,
+    Error,
+    { pages: ApiResponse<DesignerReviewImagesResponse>[]; pageParams: ReviewListCursor[] },
+    ReturnType<typeof publicDesignerReviewKeys.imagesInfinite>,
+    ReviewListCursor
+  >({
+    queryKey: publicDesignerReviewKeys.imagesInfinite(designerId, params),
+    queryFn: async ({ pageParam }) => {
+      const apiParams = {
+        ...params,
+        cursorId: pageParam?.cursorId,
+        cursorIsFixed: pageParam?.cursorIsFixed,
+      };
+      return getPublicDesignerReviewImages(designerId, apiParams);
+    },
+    initialPageParam: {},
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.result?.hasNext) return undefined;
+      return {
+        cursorId: lastPage.result.nextCursor ?? undefined,
+        cursorIsFixed: lastPage.result.nextCursorFixed ?? undefined,
       };
     },
     enabled,

--- a/src/hooks/queries/review/usePublicDesignerReviews.ts
+++ b/src/hooks/queries/review/usePublicDesignerReviews.ts
@@ -3,12 +3,14 @@ import {
   getPublicDesignerReviews,
   getPublicDesignerReviewThumbnails,
   getPublicDesignerReviewImages,
+  getReviewDetail,
 } from '@/src/apis';
 import type {
   ApiResponse,
   DesignerReviewsResponse,
   DesignerReviewThumbnailsResponse,
   DesignerReviewImagesResponse,
+  DesignerReviewDetailResponse,
   ReviewListParams,
 } from '@/src/types';
 
@@ -26,6 +28,8 @@ export const publicDesignerReviewKeys = {
     [...publicDesignerReviewKeys.all, 'images', designerId, params] as const,
   imagesInfinite: (designerId: number, params?: ReviewListParams) =>
     [...publicDesignerReviewKeys.all, 'imagesInfinite', designerId, params] as const,
+  detail: (reviewId: number) =>
+    [...publicDesignerReviewKeys.all, 'detail', reviewId] as const,
 };
 
 interface UsePublicDesignerReviewListParams {
@@ -70,6 +74,11 @@ interface UsePublicDesignerReviewImagesParams {
 interface UsePublicDesignerReviewImagesInfiniteParams {
   designerId: number;
   params?: Omit<ReviewListParams, 'cursorId' | 'cursorIsFixed'>;
+  enabled?: boolean;
+}
+
+interface UsePublicDesignerReviewDetailParams {
+  reviewId: number;
   enabled?: boolean;
 }
 
@@ -225,6 +234,21 @@ export function usePublicDesignerReviewImagesInfinite({
         cursorIsFixed: lastPage.result.nextCursorFixed ?? undefined,
       };
     },
+    enabled,
+    staleTime: 1000 * 60 * 2, // 2분
+  });
+}
+
+/**
+ * 리뷰 단건 조회 Hook
+ */
+export function usePublicDesignerReviewDetail({
+  reviewId,
+  enabled = true,
+}: UsePublicDesignerReviewDetailParams) {
+  return useQuery<ApiResponse<DesignerReviewDetailResponse>, Error>({
+    queryKey: publicDesignerReviewKeys.detail(reviewId),
+    queryFn: () => getReviewDetail(reviewId),
     enabled,
     staleTime: 1000 * 60 * 2, // 2분
   });

--- a/src/types/profile/designer.ts
+++ b/src/types/profile/designer.ts
@@ -13,6 +13,8 @@ export interface DesignerProfileInfo {
   };
   intro: string;
   isLiked: boolean;
+  reviewCount?: number;
+  averageRating?: number;
 }
 
 // ===== 디자이너 프로필 내 공고 카드 =====

--- a/src/types/review/common.ts
+++ b/src/types/review/common.ts
@@ -19,6 +19,7 @@ export interface ReviewReply {
 export interface ReviewListParams {
   category?: Category | string;
   cursorId?: number;
+  cursorIsFixed?: boolean;
   size?: number;
 }
 

--- a/src/types/review/designer.ts
+++ b/src/types/review/designer.ts
@@ -28,6 +28,7 @@ export interface DesignerReviewsResponse {
   items: DesignerReviewItem[];
   hasNext: boolean;
   nextCursor?: number | null;
+  nextCursorFixed?: boolean | null;
   totalCount?: number;
 }
 
@@ -38,12 +39,29 @@ export interface DesignerReviewThumbnailItem {
   isFixed: boolean;
 }
 
+// ===== 디자이너 리뷰 이미지 아이템 =====
+export interface DesignerReviewImageItem {
+  reviewImageId: number;
+  reviewId: number;
+  reviewImage: string;
+  isFixed: boolean;
+}
+
 // ===== 디자이너 리뷰 썸네일 목록 응답 =====
 export interface DesignerReviewThumbnailsResponse {
   items: DesignerReviewThumbnailItem[];
   hasNext: boolean;
   nextCursor?: number | null;
   totalCount: number;
+}
+
+// ===== 디자이너 리뷰 이미지 목록 응답 =====
+export interface DesignerReviewImagesResponse {
+  items: DesignerReviewImageItem[];
+  hasNext: boolean;
+  nextCursor?: number | null;
+  nextCursorFixed?: boolean | null;
+  totalCount?: number;
 }
 
 // ===== 디자이너 리뷰 상세 응답 =====


### PR DESCRIPTION
### 💡 To Reviewers

- 리뷰 이미지, 답글 관련 QA 작업들 해당 브랜치에서 했습니다.
- 리뷰 탭은 서버 averageRating/reviewCount 기준으로 표시
- 리뷰/이미지/상세는 리뷰 API 분리 사용

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 리뷰 리스트/탭 UI 개선 (더보기/사진 클릭 → 사진 상세 이동)
- 리뷰 이미지 API(/reviews/images) 연동 및 커서(cursorIsFixed) 반영
- 리뷰 답글 추가 (카드/사진 상세)
- 리뷰 탭 기본 노출 개수 3개로 조정
- 기본 프로필 이미지 처리

### 🤔 추후 작업 예정

- 리뷰 단건 API 필드 추가 요청하는 게 나을듯..? (추후 수정)

### 📸 작업 결과 (스크린샷)
<img width="421" height="735" alt="image" src="https://github.com/user-attachments/assets/4f9a7f19-88aa-407d-ad79-22b89db80f82" />



### 🔗 관련 이슈

- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #184


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 리뷰 사진을 클릭하여 상세 뷰로 이동할 수 있습니다.
  * 리뷰에 디자이너 답글이 표시됩니다.
  * 사용자 모델 이미지가 리뷰에 표시됩니다.

* **Improvements**
  * 리뷰 상세 페이지의 정보 표시가 향상되었습니다.
  * 사진 갤러리 미리보기 기능이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->