### PR TITLE
[FIX] placeholder 문구 수정 및 하단 버튼 여백 조정

### DIFF
--- a/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
+++ b/src/app/(auth)/signup/_funnel/steps/5-ProfileInfo.tsx
@@ -330,7 +330,7 @@ export const StepProfileInfo: React.FC<StepProfileInfoProps> = ({ goPrev, goNext
                 <textarea
                   value={intro}
                   onChange={(e) => setField('intro', e.target.value.slice(0, 100))}
-                  placeholder="디자이너 서비스를 소개해주세요"
+                  placeholder="본인의 강점을 소개해주세요"
                   maxLength={100}
                   className="text-body-2-medium h-[120px] w-full resize-none overflow-y-auto rounded-xl bg-gray-100 px-4 py-3.5 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent"
                 />

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -66,7 +66,7 @@ export default function MypagePage() {
 
   // 비로그인 상태 UI
   const showLoginPrompt = authReady && !isLoggedIn;
-  const nameIcon = showLoginPrompt ? <ArrowRightIcon className="h-4 text-gray-400 ml-2" /> : undefined;
+  const nameIcon = showLoginPrompt ? <ArrowRightIcon className="h-6 text-gray-800" /> : undefined;
 
   // 읽지 않은 알림 개수
   const { data: unreadData } = useUnreadNotificationCount(authReady && isLoggedIn);

--- a/src/app/(common)/mypage/portfolio/create/page.tsx
+++ b/src/app/(common)/mypage/portfolio/create/page.tsx
@@ -84,11 +84,7 @@ export default function PortfolioCreatePage() {
       </header>
 
       <div className="flex flex-1 flex-col px-4 pt-1 pb-[calc(180px+env(safe-area-inset-bottom))]">
-        <PortfolioForm
-          submitLabel="등록하기"
-          subCategoryOptions={subCategoryOptions}
-          onSubmit={handleSubmit}
-        />
+        <PortfolioForm submitLabel="등록하기" subCategoryOptions={subCategoryOptions} onSubmit={handleSubmit} />
       </div>
     </div>
   );

--- a/src/app/(common)/mypage/portfolio/page.tsx
+++ b/src/app/(common)/mypage/portfolio/page.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import LeftArrowIcon from '@/public/icons/common/arrow-left.svg';
 import DesignerProfileEditPortfolio from '@/src/components/designerProfile/edit/DesignerProfileEditPortfolio';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { useInfiniteScroll } from '@/src/hooks/common/useInfiniteScroll';
 import { useDeletePortfolio, useDesignerPortfolios } from '@/src/hooks/queries';
 
@@ -90,15 +91,15 @@ export default function PortfolioManagePage() {
         )}
       </div>
 
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 py-3 sm:w-[375px]">
+      <FixedBottomContainer>
         <button
           type="button"
           onClick={handleAddPortfolio}
-          className="text-body-1-semibold flex w-full cursor-pointer items-center justify-center rounded-full bg-gray-900 py-4 text-white"
+          className="text-body-1-semibold flex h-[56px] w-full cursor-pointer items-center justify-center rounded-full bg-gray-900 text-white"
         >
           신규 포트폴리오 작성하기
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(common)/mypage/profile/edit/page.tsx
+++ b/src/app/(common)/mypage/profile/edit/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import ArrowLeftIcon from '@/public/icons/common/arrow-left.svg';
 import { AddressInput, FixedBottomButton, GenderSelect, ProfileImageUpload } from '@/src/components/signup';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { TextInput } from '@/src/components/common';
 import { useProfileEditForm } from '@/src/hooks/custom/mypage';
 
@@ -60,7 +61,7 @@ export default function ProfileEditPage() {
 
       {/* 폼 */}
       <form
-        className="mx-4 mt-4 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-6 sm:w-[343px]"
+        className="mx-4 mt-4 flex w-[calc(100%-2rem)] flex-1 flex-col gap-6 pb-[calc(88px+env(safe-area-inset-bottom))] sm:w-[343px]"
         onSubmit={(e) => e.preventDefault()}
       >
         {/* 프로필 이미지 */}
@@ -137,20 +138,16 @@ export default function ProfileEditPage() {
           )}
         </div>
 
-        {/* 제출 버튼 */}
-        <div className="mt-auto mb-3">
-          <FixedBottomButton
-            disabled={!isFormValid || isLoading}
-            onClick={handleSubmit}
-          >
-            {isButtonLoading ? (
-              <div className="size-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
-            ) : (
-              '완료'
-            )}
-          </FixedBottomButton>
-        </div>
       </form>
+      <FixedBottomContainer>
+        <FixedBottomButton disabled={!isFormValid || isLoading} onClick={handleSubmit}>
+          {isButtonLoading ? (
+            <div className="size-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+          ) : (
+            '완료'
+          )}
+        </FixedBottomButton>
+      </FixedBottomContainer>
     </div>
   );
 }

--- a/src/app/(common)/mypage/profile/edit/page.tsx
+++ b/src/app/(common)/mypage/profile/edit/page.tsx
@@ -108,7 +108,7 @@ export default function ProfileEditPage() {
                 <textarea
                   value={form.intro}
                   onChange={(e) => updateField('intro', e.target.value.slice(0, 100))}
-                  placeholder="디자이너 서비스를 소개해주세요"
+                  placeholder="본인의 강점을 소개해주세요"
                   maxLength={100}
                   className="text-body-2-medium h-[120px] w-full resize-none overflow-y-auto rounded-xl bg-gray-100 px-4 py-3.5 text-gray-900 placeholder:text-gray-600 focus:outline-none focus:placeholder:text-transparent"
                 />

--- a/src/components/designerProfile/edit/DesignerProfileEditView.tsx
+++ b/src/components/designerProfile/edit/DesignerProfileEditView.tsx
@@ -195,6 +195,7 @@ export default function DesignerProfileEditView({
                 <textarea
                   value={form.intro}
                   onChange={handleChange('intro')}
+                  placeholder="본인의 강점을 소개해주세요"
                   className="text-body-2-medium min-h-[120px] resize-none rounded-xl bg-gray-100 px-4 py-3.5 text-gray-900 focus:outline-none"
                 />
               </div>

--- a/src/components/mypage/portfolio/PortfolioForm.tsx
+++ b/src/components/mypage/portfolio/PortfolioForm.tsx
@@ -128,7 +128,7 @@ export default function PortfolioForm({
             />
           </div>
 
-          <div className="focus-within:pb-24">
+          <div>
             <Dropdown
               label="세부 카테고리"
               options={subCategoryOptions}

--- a/src/components/mypage/portfolio/PortfolioForm.tsx
+++ b/src/components/mypage/portfolio/PortfolioForm.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import PortfolioImageUploader from '@/src/components/mypage/portfolio/PortfolioImageUploader';
 import Dropdown from '@/src/components/common/Dropdown/Dropdown';
+import { FixedBottomContainer } from '@/src/components/common/FixedBottomContainer';
 import { useIMEInput } from '@/src/hooks/custom/useIMEInput';
 
 const MAX_TITLE_LENGTH = 20;
@@ -140,18 +141,18 @@ export default function PortfolioForm({
         </div>
       </div>
 
-      <div className="fixed bottom-0 left-1/2 z-50 w-full -translate-x-1/2 bg-white px-4 py-3 sm:w-[375px]">
+      <FixedBottomContainer>
         <button
           type="button"
           onClick={handleSubmit}
           disabled={!isSubmitEnabled}
-          className={`text-body-1-semibold flex w-full items-center justify-center rounded-full py-4 ${
+          className={`text-body-1-semibold flex h-[56px] w-full items-center justify-center rounded-full ${
             isSubmitEnabled ? 'cursor-pointer bg-gray-900 text-white' : 'cursor-not-allowed bg-gray-200 text-gray-500'
           }`}
         >
           {submitLabel}
         </button>
-      </div>
+      </FixedBottomContainer>
     </div>
   );
 }


### PR DESCRIPTION
### 💡 To Reviewers

- 기존 프로필 수정 페이지에서는 버튼이 하단 고정이 아니었는데, 관련 컴포넌트를 사용하면서 하단 고정으로 수정했습니다

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 한줄 소개 문구 변경
- 프로필 수정 페이지 버튼 수정
- 포트폴리오 관리, 등록 페이지 하단 버튼 여백 수정

### 🤔 추후 작업 예정

### 📸 작업 결과 (스크린샷)

### 🔗 관련 이슈

- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #187 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 디자이너 프로필 소개 텍스트 가이드를 더 명확하게 업데이트했습니다.
  * 버튼 높이 및 하단 액션 영역의 레이아웃 안정성을 개선했습니다.
  * 로그인 상태 표시 UI의 시각적 스타일을 조정했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->