### PR TITLE
[FIX] 버튼들 라우팅 경로 수정 및 추가

### DIFF
--- a/src/components/designerHome/home/DesignerHomeContent.tsx
+++ b/src/components/designerHome/home/DesignerHomeContent.tsx
@@ -100,13 +100,15 @@ export function DesignerHomeContent() {
         </div>
 
         {/* 하단 영역 - BottomNav(87px)와 16px 간격 유지 */}
-        <div className="mt-auto pb-[calc(87px+env(safe-area-inset-bottom)+16px)]">
+        <div className="mt-auto pb-[calc(87px+env(safe-area-inset-bottom)+88px)]">
           {/* 새로운 예약 신청 섹션 */}
           <PendingReservationSection data={pendingReservations} isLoading={isPendingLoading} />
-
-          {/* 퀵 액션 버튼 */}
-          <QuickActionButtons />
         </div>
+      </div>
+
+      {/* 퀵 액션 버튼 - 하단 고정 */}
+      <div className="fixed bottom-[calc(87px+env(safe-area-inset-bottom)+16px)] left-1/2 z-40 w-full -translate-x-1/2 sm:w-[375px]">
+        <QuickActionButtons />
       </div>
 
       {/* 하단 네비게이션 */}

--- a/src/components/designerHome/home/QuickActionButtons.tsx
+++ b/src/components/designerHome/home/QuickActionButtons.tsx
@@ -6,7 +6,7 @@ export function QuickActionButtons() {
   return (
     <section className="mt-4 flex gap-2 px-4">
       <Link
-        href="/mypage"
+        href="/myProfile"
         className="flex flex-1 items-center justify-center rounded-[12px] bg-white py-3 shadow-[0px_0px_11px_0px_rgba(34,34,34,0.04)]"
       >
         <span className="text-body-2-semibold text-gray-900">프로필 보기</span>

--- a/src/components/designerHome/home/QuickActionButtons.tsx
+++ b/src/components/designerHome/home/QuickActionButtons.tsx
@@ -2,9 +2,13 @@
 
 import Link from 'next/link';
 
-export function QuickActionButtons() {
+interface QuickActionButtonsProps {
+  className?: string;
+}
+
+export function QuickActionButtons({ className = '' }: QuickActionButtonsProps) {
   return (
-    <section className="mt-4 flex gap-2 px-4">
+    <section className={`flex gap-2 px-4 ${className}`}>
       <Link
         href="/myProfile"
         className="flex flex-1 items-center justify-center rounded-[12px] bg-white py-3 shadow-[0px_0px_11px_0px_rgba(34,34,34,0.04)]"

--- a/src/components/mypage/reservations/Card/DesignerReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/DesignerReservationCard.tsx
@@ -58,7 +58,7 @@ export default function DesignerReservationCard({
 
   // 카드 클릭 시 공고 상세로 이동
   const handleCardClick = () => {
-    router.push(`/post/${reservation.recruitmentId}`);
+    router.push(`/myRecruitment/${reservation.recruitmentId}`);
   };
 
   // 채팅방 생성 및 이동

--- a/src/components/mypage/reservations/Card/ModelReservationCard.tsx
+++ b/src/components/mypage/reservations/Card/ModelReservationCard.tsx
@@ -54,6 +54,10 @@ export default function ModelReservationCard({
     router.push(`/post/${reservation.recruitmentId}`);
   };
 
+  const handleProfileClick = () => {
+    router.push(`/designer/${reservation.designerId}`);
+  };
+
   return (
     <div className="flex w-full flex-col gap-5 rounded-[20px] bg-white px-5 py-4">
       <div className="flex flex-col gap-2">
@@ -86,7 +90,7 @@ export default function ModelReservationCard({
         <div className="flex w-full items-center gap-2">
           <button
             type="button"
-            onClick={handleCardClick}
+            onClick={handleProfileClick}
             className="text-body-2-medium flex h-[41px] cursor-pointer items-center justify-center rounded-full bg-gray-900 px-5 py-2.5 text-white"
           >
             프로필 보기


### PR DESCRIPTION
### 💡 To Reviewers

- 현재 의도한 페이지와 다른 곳으로 가는 버튼 3가지를 수정했습니다.
- 디자이너 홈 - 하단 퀵 액션 버튼 하단 고정도 추가했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 디자이너 - 예약목록에서 모집글 보는 화살표 누르면 홈으로 이동됨 -> 각 공고로 가지도록 수정
- 프로필 보기 - 프로필로 안넘어가고 마이페이지로 넘어가는 것 수정
- 모델 - 마이페이지 - 예약 목록 - 다가오는 일정 - 프로필 보기 버튼 디자이너 프로필로 안가고 있음 -> 수정
- 디자이너 홈 - 하단 퀵 액션 버튼 고정


### 🤔 추후 작업 예정


### 📸 작업 결과 (스크린샷)


### 🔗 관련 이슈

- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #203 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 빠른 작업 버튼이 하단 네비게이션 위 고정 위치로 이동했습니다.

* **개선 사항**
  * 예약 카드에서 디자이너 프로필 접근 경로를 개선했습니다.
  * 예약 관련 네비게이션 흐름을 최적화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->