### PR TITLE
[HOTFIX] 디자이너 홈 레이아웃 개선 - 오늘의 예약 내부 스크롤/디자이너 캘린더 날짜 표시 수정

### DIFF
--- a/src/app/(designer)/calendar/page.tsx
+++ b/src/app/(designer)/calendar/page.tsx
@@ -31,6 +31,25 @@ function groupReservationsByTime(
 }
 
 /**
+ * 예약 목록을 날짜+시간별로 그룹핑 (전체 모드용)
+ */
+function groupReservationsByDateTime(
+  reservations: CalendarReservationItem[],
+): Map<string, CalendarReservationItem[]> {
+  const grouped = new Map<string, CalendarReservationItem[]>();
+
+  reservations.forEach((reservation) => {
+    const key = `${reservation.date}_${reservation.startTime}`;
+    if (!grouped.has(key)) {
+      grouped.set(key, []);
+    }
+    grouped.get(key)!.push(reservation);
+  });
+
+  return grouped;
+}
+
+/**
  * 날짜를 "DD(요일)" 형식으로 포맷
  */
 function formatSelectedDateTitle(dateStr: string): string {
@@ -38,6 +57,16 @@ function formatSelectedDateTitle(dateStr: string): string {
   const date = new Date(dateStr);
   const weekday = WEEKDAY_NAMES[date.getDay()];
   return `${parseInt(day, 10)}(${weekday})`;
+}
+
+/**
+ * 날짜를 "M.DD(요일)" 형식으로 포맷 (전체 모드 헤더용)
+ */
+function formatDateHeader(dateStr: string): string {
+  const [, month, day] = dateStr.split('-');
+  const date = new Date(dateStr);
+  const weekday = WEEKDAY_NAMES[date.getDay()];
+  return `${parseInt(month, 10)}.${parseInt(day, 10)}(${weekday})`;
 }
 
 export default function CalendarPage() {
@@ -90,10 +119,13 @@ export default function CalendarPage() {
   const reservations = reservationsData?.result?.items ?? [];
   const totalCount = reservationsData?.result?.totalCount ?? 0;
 
-  // 시간별로 그룹핑된 예약 목록
+  // 전체 모드: 날짜+시간별 그룹핑, 특정 날짜: 시간별 그룹핑
   const groupedReservations = useMemo(
-    () => groupReservationsByTime(reservations),
-    [reservations],
+    () =>
+      selectedDate === null
+        ? groupReservationsByDateTime(reservations)
+        : groupReservationsByTime(reservations),
+    [reservations, selectedDate],
   );
 
   // 날짜 선택 핸들러
@@ -144,10 +176,12 @@ export default function CalendarPage() {
           ) : reservations.length > 0 ? (
             Array.from(groupedReservations.entries()).map(([time, items]) => (
               <div key={time} className="flex flex-col gap-2">
-                {/* 시간 헤더 + 구분선 */}
+                {/* 시간 헤더 + 구분선 (전체: 날짜+시간, 특정 날짜: 시간만) */}
                 <div className="flex items-center gap-2">
                   <span className="text-body-2-semibold shrink-0 text-gray-900">
-                    {formatTimeWithPeriod(time)}
+                    {selectedDate === null
+                      ? formatDateHeader(items[0].date)
+                      : formatTimeWithPeriod(time)}
                   </span>
                   <div className="h-px flex-1 bg-gray-400" />
                 </div>

--- a/src/app/(designer)/calendar/page.tsx
+++ b/src/app/(designer)/calendar/page.tsx
@@ -120,11 +120,8 @@ export default function CalendarPage() {
       />
 
       {/* 하단 예약 리스트 영역 */}
-      <div className="mt-4 flex flex-1 flex-col rounded-t-[40px] bg-gray-100 px-5 pt-3 pb-16">
-        {/* 상단 화살표 */}
-        <div className="mb-4 flex justify-center">
-          <ArrowUpIcon className="size-6 text-gray-400" />
-        </div>
+      <div className="mt-4 flex flex-1 flex-col bg-gray-100 px-5 pt-5 pb-16">
+
 
         {/* 타이틀 영역 */}
         <div className="mb-4 flex items-baseline gap-2">

--- a/src/components/calendar/CalendarReservationCard.tsx
+++ b/src/components/calendar/CalendarReservationCard.tsx
@@ -180,7 +180,7 @@ export default function CalendarReservationCard({ reservation }: CalendarReserva
         </div>
 
         {/* 예약 정보 */}
-        <div className="flex items-center gap-2">
+        {/* <div className="flex items-center gap-2">
           <div className="flex items-center gap-1">
             <CalendarIcon className="size-4 text-gray-800" />
             <span className="text-body-2-medium text-gray-800">{formatDateToShort(reservation.date)}</span>
@@ -196,7 +196,7 @@ export default function CalendarReservationCard({ reservation }: CalendarReserva
           <span className="text-body-2-medium text-gray-800">·</span>
 
           <span className="text-body-2-medium text-gray-800">{formatSubCategories(reservation.subCategories)}</span>
-        </div>
+        </div> */}
       </div>
 
       {/* 액션 버튼 - UPCOMING인 경우에만 표시 */}

--- a/src/components/designerHome/home/DateSelectorBar.tsx
+++ b/src/components/designerHome/home/DateSelectorBar.tsx
@@ -44,7 +44,7 @@ function DateButton({ date, isSelected, onClick }: DateButtonProps) {
     <button
       type="button"
       onClick={onClick}
-      className={`cursor-pointer flex w-[63px] shrink-0 flex-col items-center justify-center rounded-[12px] px-4 py-3 shadow-[0px_0px_4px_0px_rgba(34,34,34,0.09)] ${
+      className={`flex flex-1 cursor-pointer flex-col items-center justify-center rounded-[12px] py-3 shadow-[0px_0px_4px_0px_rgba(34,34,34,0.09)] ${
         isSelected ? 'bg-gray-900' : 'bg-white'
       }`}
     >
@@ -77,7 +77,7 @@ export function DateSelectorBar({ selectedDate, onDateSelect }: DateSelectorBarP
   const dates = generateDateRange(today, 5); // 오늘 + 4일
 
   return (
-    <div className="flex justify-between gap-2 overflow-x-auto px-4 scrollbar-hide">
+    <div className="flex gap-2 px-4">
       {dates.map((date) => {
         const dateStr = formatDateString(date);
         return (

--- a/src/components/designerHome/home/DesignerHomeContent.tsx
+++ b/src/components/designerHome/home/DesignerHomeContent.tsx
@@ -124,7 +124,7 @@ export function DesignerHomeContent() {
       {/* 하단 고정 영역 */}
       <div className="shrink-0 pb-[calc(87px+env(safe-area-inset-bottom)+16px)]">
         <PendingReservationSection data={pendingReservations} isLoading={isPendingLoading} />
-        <QuickActionButtons className="mb-4" />
+        <QuickActionButtons />
       </div>
 
       {/* 하단 네비게이션 */}

--- a/src/components/designerHome/home/DesignerHomeContent.tsx
+++ b/src/components/designerHome/home/DesignerHomeContent.tsx
@@ -41,19 +41,45 @@ export function DesignerHomeContent() {
   const { data: unreadData } = useUnreadNotificationCount();
   const unreadCount = unreadData?.result?.unreadCount ?? 0;
 
-  const todayReservations = todayData?.result ?? { date: selectedDate, totalCount: 0, reservations: [] };
-  const pendingReservations = pendingData?.result ?? {
-    reservations: [],
-    totalCount: 0,
+  // TODO: 삭제 필요 - 디자이너 확인용 Mock 데이터 (API 연동 후 제거)
+  const mockTodayReservations = {
+    date: selectedDate,
+    totalCount: 7,
+    reservations: [
+      { reservationId: 101, modelName: '김서연', recruitmentId: 2, time: '09:00', imageUrl: null, subCategories: ['커트'] },
+      { reservationId: 102, modelName: '박민정', recruitmentId: 3, time: '10:30', imageUrl: null, subCategories: ['펌'] },
+      { reservationId: 103, modelName: '이하늘', recruitmentId: 4, time: '12:00', imageUrl: null, subCategories: ['염색'] },
+      { reservationId: 104, modelName: '최예진', recruitmentId: 5, time: '14:00', imageUrl: null, subCategories: ['커트', '펌'] },
+      { reservationId: 105, modelName: '정수아', recruitmentId: 6, time: '15:30', imageUrl: null, subCategories: ['염색'] },
+      { reservationId: 106, modelName: '한지민', recruitmentId: 7, time: '17:00', imageUrl: null, subCategories: ['커트'] },
+      { reservationId: 107, modelName: '송혜교', recruitmentId: 8, time: '18:30', imageUrl: null, subCategories: ['펌', '염색'] },
+    ],
+  };
+
+  const mockPendingReservations = {
+    reservations: [
+      { reservationId: 999, modelName: '김민지', recruitmentTitle: '테스트', date: '2025-02-01', time: '14:00', subCategories: ['커트'] },
+      { reservationId: 998, modelName: '이수진', recruitmentTitle: '테스트', date: '2025-02-02', time: '10:30', subCategories: ['펌'] },
+      { reservationId: 997, modelName: '박지연', recruitmentTitle: '테스트', date: '2025-02-03', time: '15:00', subCategories: ['염색'] },
+      { reservationId: 996, modelName: '최유나', recruitmentTitle: '테스트', date: '2025-02-04', time: '11:00', subCategories: ['커트'] },
+      { reservationId: 995, modelName: '정하은', recruitmentTitle: '테스트', date: '2025-02-05', time: '16:30', subCategories: ['펌'] },
+      { reservationId: 994, modelName: '한소희', recruitmentTitle: '테스트', date: '2025-02-06', time: '09:00', subCategories: ['염색'] },
+    ],
+    totalCount: 6,
     cursorId: null,
     cursorDate: null,
     cursorTime: null,
     hasNext: false,
   };
 
+  // TODO: 삭제 필요 - API 연동 후 아래 주석 해제
+  const todayReservations = mockTodayReservations; // todayData?.result ?? { date: selectedDate, totalCount: 0, reservations: [] };
+  const pendingReservations = mockPendingReservations; // pendingData?.result ?? {...};
+
   return (
-    <>
-      <div className="flex min-h-screen flex-col bg-gray-200 pb-[calc(87px+env(safe-area-inset-bottom)+16px+72px)]">
+    <div className="flex h-[100dvh] flex-col bg-gray-200">
+      {/* 상단 고정 영역 */}
+      <div className="shrink-0">
         {/* 헤더 */}
         <header className="flex h-14 items-center justify-between px-5">
           <MoandiLogo />
@@ -88,25 +114,21 @@ export function DesignerHomeContent() {
         <div className="mt-4">
           <DateSelectorBar selectedDate={selectedDate} onDateSelect={setSelectedDate} />
         </div>
-
-        {/* 오늘의 예약 섹션 */}
-        <div className="mt-5">
-          <TodayReservationSection data={todayReservations} isLoading={isTodayLoading} />
-        </div>
-
-        <div className="mt-auto h-[40px]" />
       </div>
 
-      {/* 하단 고정 영역 - BottomNav 위 고정 */}
-      <div className="fixed right-0 bottom-[calc(87px+env(safe-area-inset-bottom))] left-0 z-10 w-full min-w-[375px] sm:right-auto sm:left-1/2 sm:w-[375px] sm:-translate-x-1/2">
-        <div className="bg-gray-200 pb-[40px]">
-          <PendingReservationSection data={pendingReservations} isLoading={isPendingLoading} />
-          <QuickActionButtons />
-        </div>
+      {/* 오늘의 예약 섹션 - 내부 스크롤 */}
+      <div className="mt-5 min-h-0 flex-1">
+        <TodayReservationSection data={todayReservations} isLoading={isTodayLoading} />
+      </div>
+
+      {/* 하단 고정 영역 */}
+      <div className="shrink-0 pb-[calc(87px+env(safe-area-inset-bottom)+16px)]">
+        <PendingReservationSection data={pendingReservations} isLoading={isPendingLoading} />
+        <QuickActionButtons className="mb-4" />
       </div>
 
       {/* 하단 네비게이션 */}
       <BottomNav />
-    </>
+    </div>
   );
 }

--- a/src/components/designerHome/home/DesignerHomeContent.tsx
+++ b/src/components/designerHome/home/DesignerHomeContent.tsx
@@ -41,40 +41,16 @@ export function DesignerHomeContent() {
   const { data: unreadData } = useUnreadNotificationCount();
   const unreadCount = unreadData?.result?.unreadCount ?? 0;
 
-  // TODO: 삭제 필요 - 디자이너 확인용 Mock 데이터 (API 연동 후 제거)
-  const mockTodayReservations = {
-    date: selectedDate,
-    totalCount: 7,
-    reservations: [
-      { reservationId: 101, modelName: '김서연', recruitmentId: 2, time: '09:00', imageUrl: null, subCategories: ['커트'] },
-      { reservationId: 102, modelName: '박민정', recruitmentId: 3, time: '10:30', imageUrl: null, subCategories: ['펌'] },
-      { reservationId: 103, modelName: '이하늘', recruitmentId: 4, time: '12:00', imageUrl: null, subCategories: ['염색'] },
-      { reservationId: 104, modelName: '최예진', recruitmentId: 5, time: '14:00', imageUrl: null, subCategories: ['커트', '펌'] },
-      { reservationId: 105, modelName: '정수아', recruitmentId: 6, time: '15:30', imageUrl: null, subCategories: ['염색'] },
-      { reservationId: 106, modelName: '한지민', recruitmentId: 7, time: '17:00', imageUrl: null, subCategories: ['커트'] },
-      { reservationId: 107, modelName: '송혜교', recruitmentId: 8, time: '18:30', imageUrl: null, subCategories: ['펌', '염색'] },
-    ],
-  };
-
-  const mockPendingReservations = {
-    reservations: [
-      { reservationId: 999, modelName: '김민지', recruitmentTitle: '테스트', date: '2025-02-01', time: '14:00', subCategories: ['커트'] },
-      { reservationId: 998, modelName: '이수진', recruitmentTitle: '테스트', date: '2025-02-02', time: '10:30', subCategories: ['펌'] },
-      { reservationId: 997, modelName: '박지연', recruitmentTitle: '테스트', date: '2025-02-03', time: '15:00', subCategories: ['염색'] },
-      { reservationId: 996, modelName: '최유나', recruitmentTitle: '테스트', date: '2025-02-04', time: '11:00', subCategories: ['커트'] },
-      { reservationId: 995, modelName: '정하은', recruitmentTitle: '테스트', date: '2025-02-05', time: '16:30', subCategories: ['펌'] },
-      { reservationId: 994, modelName: '한소희', recruitmentTitle: '테스트', date: '2025-02-06', time: '09:00', subCategories: ['염색'] },
-    ],
-    totalCount: 6,
+  // API 데이터
+  const todayReservations = todayData?.result ?? { date: selectedDate, totalCount: 0, reservations: [] };
+  const pendingReservations = pendingData?.result ?? {
+    reservations: [],
+    totalCount: 0,
     cursorId: null,
     cursorDate: null,
     cursorTime: null,
     hasNext: false,
   };
-
-  // TODO: 삭제 필요 - API 연동 후 아래 주석 해제
-  const todayReservations = mockTodayReservations; // todayData?.result ?? { date: selectedDate, totalCount: 0, reservations: [] };
-  const pendingReservations = mockPendingReservations; // pendingData?.result ?? {...};
 
   return (
     <div className="flex h-[100dvh] flex-col bg-gray-200">

--- a/src/components/designerHome/home/TodayReservationSection.tsx
+++ b/src/components/designerHome/home/TodayReservationSection.tsx
@@ -10,7 +10,7 @@ interface TodayReservationSectionProps {
 
 export function TodayReservationSection({ data, isLoading }: TodayReservationSectionProps) {
   return (
-    <section className="flex flex-col gap-[10px] px-4">
+    <section className="scrollbar-hide flex h-full flex-col gap-[10px] overflow-y-auto px-4 pb-4">
       {isLoading ? (
         <>
           <div className="h-[66px] animate-skeleton rounded-[12px] bg-gray-300" />


### PR DESCRIPTION
### 💡 To Reviewers

- 디자이너 확인용 Mock 데이터가 포함되어 있습니다. (TODO 주석으로 표시)
- API 연동 후 Mock 데이터 삭제 필요

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)

- 디자이너 홈 오늘의 예약 섹션 내부 스크롤 적용
- 예약이 5개 이상일 때 전체 페이지 스크롤 대신 오늘의 예약 영역만 스크롤
- 스크롤바 숨김 처리 (scrollbar-hide)
- 하단 영역(새로운 예약 신청 + 액션 버튼) 고정 유지

### 🤔 추후 작업 예정

- Mock 데이터 삭제 및 실제 API 연동
- 하단 패딩 값 조정 필요 시 수정

### 📸 작업 결과 (스크린샷)

- 디자이너 확인 후 추가 예정

### 🔗 관련 이슈

- hotfix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI 및 레이아웃 개선**
  * 홈 레이아웃 재구성: 상단에 헤더·인사·프로필·날짜 선택기 고정, 메인 콘텐츠는 전체 높이 세로 플렉스와 내부 스크롤 적용
  * 오늘 섹션 세로 스크롤 적용 및 스타일 조정
  * 하단을 비고정 영역으로 변경해 보류 예약·빠른작업 버튼 배치 유지
  * 날짜 선택바 버튼 배치·크기 변경으로 가로 스크롤 제거

* **캘린더**
  * 전체 모드에서 날짜+시간 기준 그룹화 및 헤더 표시 방식 변경
  * 예약 카드에서 날짜/시간 정보 비표시 처리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->